### PR TITLE
take first step to force mermaid.js rendered svg to respect height / width of container div

### DIFF
--- a/inst/htmlwidgets/DiagrammeR.js
+++ b/inst/htmlwidgets/DiagrammeR.js
@@ -12,6 +12,16 @@ HTMLWidgets.widget({
         as soon as class of the div is set to "mermaid"
     */
     
+    /* to prevent auto init() by mermaid
+        not documented but
+        see lines https://github.com/knsv/mermaid/blob/master/src/main.js#L100-L109
+          mermaid_config in global with mermaid_config.startOnLoad = false
+        appears to turn off the auto init behavior
+        allowing us to callback after manually init and then callback
+        after complete
+    */
+    window.mermaid_config = {startOnLoad : false};
+    
     return {
       // TODO: add instance fields as required
     }
@@ -33,16 +43,34 @@ HTMLWidgets.widget({
       el.style.display = "";
       //again if dynamic such as shiny
       //  explicitly run mermaid.init()
-      mermaid.init();
     } else {
       // set display to none
+      // should we remove instead??
       el.style.display = "none";
     }
     
+    this.manualRender( function(){
+       var svg = el.getElementsByTagName("svg")[0]
+       if(svg.width) {svg.removeAttribute("width")};
+       if(svg.height) {svg.removeAttribute("height")};
+       svg.style.width = "100%";
+       svg.style.height = "100%";
+    } );
   },
 
   resize: function(el, width, height, instance) {
 
+  },
+  
+  manualRender: function( callback ){
+    /* not optimal way to manually run and wait for
+        mermaid.init() before other steps
+    */
+    mermaid.init();
+    // currently just using to make "responsive" svg
+    // but could apply to a list of callbacks / behaviors
+    callback();
   }
+  
 
 });


### PR DESCRIPTION
I'm struggling with how best to handle #9, which I consider critical to adhere to the standard that `htmlwidgets` should work in all contexts - console plots, R markdown, Shiny, and standalone HTML.  As of now, this is my best idea and I hope it will be considered an improvement:

1.  Turn off auto-render by setting mermaid.config.startOnLoad = false https://github.com/timelyportfolio/DiagrammeR/blob/e39239e32c8e21c355f856faf5ac5151a41e1bdf/inst/htmlwidgets/DiagrammeR.js#L15-L23
2.  Use a callback to run `mermaid.init()`.  Hopefully an agreed upon `callback` for `htmlwidgets` will be chosen (see )  https://github.com/timelyportfolio/DiagrammeR/blob/e39239e32c8e21c355f856faf5ac5151a41e1bdf/inst/htmlwidgets/DiagrammeR.js#L65-L73
3.  After `mermaid.init` complete, use `callback` to remove the `height` and `width` attributes of the `SVG` and then set `height` and `width` to be `100%` of the container div which will have been sized by `htmlwidgets` https://github.com/timelyportfolio/DiagrammeR/blob/e39239e32c8e21c355f856faf5ac5151a41e1bdf/inst/htmlwidgets/DiagrammeR.js#L52-L59

@rich-iannone, please test and let me know your thoughts.  As an additional reference to quasi-"responsive" `SVG` this is an excellent [resource](http://sarasoueidan.com/blog/svg-coordinate-systems/), and you want one [more](http://demosthenes.info/blog/744/Make-SVG-Responsive).

I am also considering filing an issue with `mermaid.js` to potentially handle it there, since I expect other non-`htmlwidgets` would benefit from this.
