### PR TITLE
add ability for a diagram to be a vector of character with length > 1

### DIFF
--- a/R/DiagrammeR.R
+++ b/R/DiagrammeR.R
@@ -91,6 +91,23 @@
 #' @export
 DiagrammeR <- function(diagram = "", width = NULL, height = NULL) {
 
+  # check for vector with length > 1 and concat
+  if( length(diagram) > 1 ){
+    # should we also check for ; or \n and if not append
+    #   would look something like this I think
+    nosep  = (grep( x=diagram, pattern="[;\n]" ))
+    if( length(nosep) < length(diagram) ){
+      diagram[-nosep] = sapply(
+        diagram[-nosep]
+        ,function(c){
+          paste0(c,";")
+        }
+      )
+    }
+
+    diagram = paste0( diagram, collapse = "" )
+  }
+  
   # forward options using x
   x = list(
     diagram = diagram


### PR DESCRIPTION
As I was doing examples, I thought it might be a helpful feature for a diagram spec to be something like this.

```
DiagrammeR(
    c("graph LR","A-->B;","C\n")
)
```

If we have `length > 1`, we could paste these together on the `R` side, so it will work correctly.