### PR TITLE
fix makeResponsive

### DIFF
--- a/inst/htmlwidgets/DiagrammeR.js
+++ b/inst/htmlwidgets/DiagrammeR.js
@@ -54,11 +54,13 @@ HTMLWidgets.widget({
     //  or at a minimum fit within the bounds set by htmlwidgets
     //  for the parent container
     function makeResponsive(el){
-       var svg = el.getElementsByTagName("svg")[0]
-       if(svg.width) {svg.removeAttribute("width")};
-       if(svg.height) {svg.removeAttribute("height")};
-       svg.style.width = "100%";
-       svg.style.height = "100%";
+       var svg = el.getElementsByTagName("svg")[0];
+       if(svg){
+        if(svg.width) {svg.removeAttribute("width")};
+        if(svg.height) {svg.removeAttribute("height")};
+        svg.style.width = "100%";
+        svg.style.height = "100%";
+       }
     };
 
     // set up a container for tasks to perform after completion


### PR DESCRIPTION
Likely an edge  case but currently `DiagrammeR` supports `tags$div(...,class="mermaid")` from `htmltools`  as another way to specify a diagram.  In this case `DiagrammeR()` simply injects dependencies, so the `htmlwidget` container will not have a `SVG`.  Check for this in `makeResponsive()`.