### PR TITLE
add try ... catch in Javascript to show error in the htmlwidget

### DIFF
--- a/inst/htmlwidgets/DiagrammeR.js
+++ b/inst/htmlwidgets/DiagrammeR.js
@@ -90,7 +90,21 @@ HTMLWidgets.widget({
     dg = document.getElementsByClassName("DiagrammeR");
     if( dg[dg.length-1].id === el.id ){
       // run mermaid.init
-      mermaid.init();
+      //  but use try catch block
+      //  to send error to the htmlwidget for display
+      try{
+        mermaid.init();
+      } catch(e) {
+        // if error look for last processed DiagrammeR
+        //  and send error to the container div
+        //  with pre containing the errors
+        var processedDg = d3.selectAll(".DiagrammeR[data-processed=true]");
+        // select the last
+        processedDg = d3.select(processedDg[0][processedDg[0].length - 1])
+        // remove the svg
+        processedDg.select("svg").remove();
+        processedDg.append("pre").html(e.message)
+      }      
       
       // make each DiagrammeR responsive
       //  ? should we make this responsive an option


### PR DESCRIPTION
This is an attempt to use `try ... catch` with `mermaid.init()` to incorporate @jjallaire very good suggestion in #26 to send any `mermaid.js` errors (likely parse errors) to the `DiagrammeR` `htmlwidget`.  Since `mermaid.js` parses and renders in bulk, find the last processed `DiagrammeR` `div` since it should be the culprit.  As a couple of examples:

```
library(DiagrammeR)
# one with error
dErr = DiagrammeR("graph LR; --;")
dErr

# one or two without error and another with error
library(htmltools)
dGood = DiagrammeR("graph LR; A;")
html_print(tagList(dGood,dErr))
html_print(tagList(dErr,dGood))
html_print(tagList(dGood,dGood,dErr))
```

Could recurse until all done or found erroneous, but I think for now this solution will suffice.