### PR TITLE
wrap error messages

### DIFF
--- a/inst/htmlwidgets/DiagrammeR.yaml
+++ b/inst/htmlwidgets/DiagrammeR.yaml
@@ -11,3 +11,7 @@ dependencies:
   version: 0.3.0
   src: htmlwidgets/lib/mermaid
   script: dist/mermaid.slim.min.js
+- name: styles
+  version: 0.1
+  src: htmlwidgets/lib/styles
+  stylesheet: styles.css

--- a/inst/htmlwidgets/lib/styles/styles.css
+++ b/inst/htmlwidgets/lib/styles/styles.css
@@ -1,0 +1,8 @@
+.DiagrammeR pre {
+  white-space: pre-wrap;       /* CSS 3 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+}
+


### PR DESCRIPTION
This ensures that error messages which are wider than the width of the htmlwidget div are still legible without scrolling.