### PR TITLE
add warning for grVix in RStudio viewer since get strange error

### DIFF
--- a/R/grViz.R
+++ b/R/grViz.R
@@ -29,6 +29,9 @@ grViz <- function(diagram = "", width = NULL, height = NULL) {
   # forward options using x
   x <- list(diagram = diagram)
   
+  if(!is.null("viewer")){
+    warning("grViz() might not work with RStudio Viewer but should work in another browser")
+  }
   
   # create widget
   htmlwidgets::createWidget(


### PR DESCRIPTION
warn that `grViz` might not work on non-Windows RStudio viewer and almost definitely will not work on Windows RStudio viewer