### PR TITLE
turn off call and fix "viewer" for warning; also sweep spec and replace ' with \]"

### DIFF
--- a/R/grViz.R
+++ b/R/grViz.R
@@ -26,11 +26,18 @@ grViz <- function(diagram = "", width = NULL, height = NULL) {
     }
   }
   
+  # single quotes within a diagram spec are problematic
+  #  try to replace with \"
+  diagram = gsub(x=diagram,"'","\"")
+  
   # forward options using x
   x <- list(diagram = diagram)
   
-  if(!is.null("viewer")){
-    warning("grViz() might not work with RStudio Viewer but should work in another browser")
+  if(!is.null(options("viewer"))){
+    warning(
+      "grViz() might not work with RStudio Viewer but should work in another browser"
+      , call. = F
+    )
   }
   
   # create widget

--- a/inst/examples/graphviz_examples.R
+++ b/inst/examples/graphviz_examples.R
@@ -47,3 +47,24 @@ readLines("http://www.graphviz.org/Gallery/directed/Genetic_Programming.gv.txt")
 
 readLines("http://www.graphviz.org/Gallery/directed/unix.gv.txt") %>>%
   grViz
+
+
+
+
+# test single quote  in spec
+grViz("
+  digraph G {
+    node [shape='plaintext']
+    a [label=<<TABLE BORDER='0' CELLBORDER='1' CELLSPACING='0'>
+         <TR><TD PORT='1'>one<TD PORT='2' ROWSPAN='2'>two
+       <TR><TD PORT='3'>three
+       >];
+    b [label=<<TABLE BORDER='0' CELLBORDER='1' CELLSPACING='0'>
+         <TR><TD PORT='1'>one<TD PORT='2'>two
+       <TR><TD PORT='3' COLSPAN='2'>three
+       >];
+    a:1 -> b:2;
+    b:1 -> a:2;
+    b:3 -> a:3;
+  }
+")


### PR DESCRIPTION
@rich-iannone could you test on your machine?  I added one example in examples.R with `'` if that helps