### PR TITLE
suppress RStudio Viewer with `grViz`

### DIFF
--- a/R/grViz.R
+++ b/R/grViz.R
@@ -46,7 +46,9 @@ grViz <- function(diagram = "", width = NULL, height = NULL) {
     x = x,
     width = width,
     height = height,
-    package = "DiagrammeR"
+    package = "DiagrammeR",
+    # since grViz does not work in RStudio viewer
+    htmlwidgets::sizingPolicy(viewer.suppress = TRUE)
   )
 
 }


### PR DESCRIPTION
Since `grViz` is very unreliable in RStudio Viewer, use `sizingPolicy` (thanks @jjallaire ) to suppress RStudio Viewer.