### PR TITLE
fix mermaid shiny

### DIFF
--- a/inst/htmlwidgets/DiagrammeR.js
+++ b/inst/htmlwidgets/DiagrammeR.js
@@ -106,10 +106,31 @@ HTMLWidgets.widget({
         .attr("id", "mermaidChart-" + el.id);
       // now we have to change the styling assigned by mermaid
       //   to point to our new id that we have assigned
-      d3.select(el).select("svg").select("style")[0][0].innerHTML = d3.select(el).select("svg")
+      /*d3.select(el).select("svg").select("style")[0][0].innerHTML = d3.select(el).select("svg")
         .select("style")[0][0].innerHTML
-        .replace(/mermaidChart[0-9]*/gi, "mermaidChart-" + el.id);
-        
+        */
+        //.replace(/mermaidChart[0-9]*/gi, "mermaidChart-" + el.id);
+
+      // difficult way to change the stylesheet to work on most browsers
+      for( i = 0; i <  document.styleSheets.length; i++ ) {
+        var s = document.styleSheets[i];
+        // find the stylesheet for this widget
+        if(s.ownerNode.parentNode.parentNode.id === el.id){
+          // use http://davidwalsh.name/add-rules-stylesheets
+          //  to change the rules to use our new svg id in css
+          var howManyRules = s.rules.length;
+          for ( rule = 0; rule < howManyRules; rule++){
+            s.insertRule(
+              s.rules.item(rule).cssText.replace(/mermaidChart[0-9]*/gi, "mermaidChart-" + el.id),
+              howManyRules
+            );
+          }
+          // now delete the original rules          
+          for ( rule = 0; rule < howManyRules ; rule++){
+            s.deleteRule(rule);
+          }
+        }
+      }
     } catch(e) {
       // if error look for last processed DiagrammeR
       //  and send error to the container div
@@ -126,7 +147,7 @@ HTMLWidgets.widget({
         el.removeAttribute("data-processed")
       }
       
-      processedDg.append("pre").html( "parse error with " + x.diagram )
+      processedDg.append("pre").html( ["parse error with " + x.diagram, e.message].join("\n") )
     }
     
     // makeResponsive needs to be run again with shiny

--- a/inst/htmlwidgets/DiagrammeR.js
+++ b/inst/htmlwidgets/DiagrammeR.js
@@ -86,47 +86,69 @@ HTMLWidgets.widget({
     }
 
   
-    // wait for the last to render to avoid duplicated svg ids from mermaid
+    // get all DiagrammeR mermaids widgets
     dg = document.getElementsByClassName("DiagrammeR");
-    if( dg[dg.length-1].id === el.id ){
-      // run mermaid.init
-      //  but use try catch block
-      //  to send error to the htmlwidget for display
-      try{
-        mermaid.init();
-      } catch(e) {
-        // if error look for last processed DiagrammeR
-        //  and send error to the container div
-        //  with pre containing the errors
-        var processedDg = d3.selectAll(".DiagrammeR[data-processed=true]");
-        // select the last
-        processedDg = d3.select(processedDg[0][processedDg[0].length - 1])
-        // remove the svg
-        processedDg.select("svg").remove();
-        processedDg.append("pre").html(e.message)
-      }      
+    // run mermaid.init
+    //  but use try catch block
+    //  to send error to the htmlwidget for display
+    try{
+      mermaid.init();
       
-      // make each DiagrammeR responsive
-      //  ? should we make this responsive an option
-      //     and add to tasks if true
-      for( i = 0; i < dg.length; i++ ){
-        makeResponsive(dg[i]);
+      // sort of make our diagram responsive
+      //   should we make this an option?
+      //   if so, then could easily add to list of post process tasks
+      makeResponsive( el );
+      
+      // change the id of our SVG assigned by mermaid to prevent conflict
+      //   mermaid.init has a counter that will reset to 0
+      //   and cause duplication of SVG id if multiple
+      d3.select(el).select("svg")
+        .attr("id", "mermaidChart-" + el.id);
+      // now we have to change the styling assigned by mermaid
+      //   to point to our new id that we have assigned
+      d3.select(el).select("svg").select("style")[0][0].innerHTML = d3.select(el).select("svg")
+        .select("style")[0][0].innerHTML
+        .replace(/mermaidChart[0-9]*/gi, "mermaidChart-" + el.id);
+        
+    } catch(e) {
+      // if error look for last processed DiagrammeR
+      //  and send error to the container div
+      //  with pre containing the errors
+      var processedDg = d3.selectAll(".DiagrammeR[data-processed=true]");
+      // select the last
+      processedDg = d3.select(processedDg[0][processedDg[0].length - 1])
+      // remove the svg
+      processedDg.select("svg").remove();
+      
+      //if dynamic such as shiny remove data-processed
+      // so mermaid will reprocess and redraw
+      if (HTMLWidgets.shinyMode) {
+        el.removeAttribute("data-processed")
       }
       
+      processedDg.append("pre").html( "parse error with " + x.diagram )
+    }
+    
+    // makeResponsive needs to be run again with shiny
+    //  since asynchrony sometimes results in not run
+    if( HTMLWidgets.shinyMode ){
+      for ( i = 0 ; i < dg.length; i++ ){
+        makeResponsive( dg[i] )
+      }
+    }
 
-      // will this ensure synchronous order of execution
-      //  the first set of tests seem to indicate they will
-      //  but it should be more robustly tested
-      if(!(typeof mermaid.tasks.length === "undefined" ) ) {
-        mermaid.tasks.forEach(function(t) { 
-          //add some error checking here
-          if ( typeof t.task === "function" ){
-            t.task.call(null, t.el);
-          } else {
-            console.log("task not a function so skipped");
-          }
-        });
-      }
+    // will this ensure synchronous order of execution
+    //  the first set of tests seem to indicate they will
+    //  but it should be more robustly tested
+    if(!(typeof mermaid.tasks.length === "undefined" ) ) {
+      mermaid.tasks.forEach(function(t) { 
+        //add some error checking here
+        if ( typeof t.task === "function" ){
+          t.task.call(null, t.el);
+        } else {
+          console.log("task not a function so skipped");
+        }
+      });
     }
   },
 

--- a/inst/htmlwidgets/DiagrammeR.js
+++ b/inst/htmlwidgets/DiagrammeR.js
@@ -106,12 +106,14 @@ HTMLWidgets.widget({
         .attr("id", "mermaidChart-" + el.id);
       // now we have to change the styling assigned by mermaid
       //   to point to our new id that we have assigned
-      /*d3.select(el).select("svg").select("style")[0][0].innerHTML = d3.select(el).select("svg")
+      d3.select(el).select("svg").select("style")[0][0].innerHTML = d3.select(el).select("svg")
         .select("style")[0][0].innerHTML
-        */
-        //.replace(/mermaidChart[0-9]*/gi, "mermaidChart-" + el.id);
+        .replace(/mermaidChart[0-9]*/gi, "mermaidChart-" + el.id);
 
-      // difficult way to change the stylesheet to work on most browsers
+      /*
+      //difficult way to change the stylesheet
+      //     thought it would be more robust but the above
+      //     works better
       for( i = 0; i <  document.styleSheets.length; i++ ) {
         var s = document.styleSheets[i];
         // find the stylesheet for this widget
@@ -121,8 +123,9 @@ HTMLWidgets.widget({
           var howManyRules = s.rules.length;
           for ( rule = 0; rule < howManyRules; rule++){
             s.insertRule(
-              s.rules.item(rule).cssText.replace(/mermaidChart[0-9]*/gi, "mermaidChart-" + el.id),
-              howManyRules
+      */
+      //        s.rules.item(rule).cssText.replace(/mermaidChart[0-9]*/gi, "mermaidChart-" + el.id),
+      /*        howManyRules
             );
           }
           // now delete the original rules          
@@ -131,6 +134,7 @@ HTMLWidgets.widget({
           }
         }
       }
+      */
     } catch(e) {
       // if error look for last processed DiagrammeR
       //  and send error to the container div


### PR DESCRIPTION
This pull should allow `DiagrammeR` to work much better with Shiny #51.  I'll try to quickly explain what I changed.  `mermaid.init()` attempts to change all class `.mermaid` within a page and assigns an id with a simple counter to the SVG.  If we add or change a `mermaid` widget, and then rerun `mermaid.init()` the counter results in duplicated ids which is not allowable by CSS.  My original fix tried to wait until the final `mermaid` instance to run `mermaid.init()`.  However, asynchrony makes it difficult/impossible to know when we are ready to run.

The new solution changes the id assigned by `mermaid` to `mermaidChart-` + the id assigned to the `htmlwidget`.  Then, the problem becomes the CSS points to the old id, so we need to change this also.  Cross-browser differences cause this to be additionally challenging.  This method seems to work in Chrome, Firefox, and Safari.  IE doesn't support `mermaid` so we don't have to worry with it for now.  RStudio Viewer also does not seem to work with `mermaid` + Shiny.