### PR TITLE
provide distinct name for styles; ensure labels are black in bootstrap pages

### DIFF
--- a/inst/htmlwidgets/DiagrammeR.yaml
+++ b/inst/htmlwidgets/DiagrammeR.yaml
@@ -11,7 +11,7 @@ dependencies:
   version: 0.3.0
   src: htmlwidgets/lib/mermaid
   script: dist/mermaid.slim.min.js
-- name: styles
-  version: 0.1
+- name: DiagrammeR-styles
+  version: 0.2
   src: htmlwidgets/lib/styles
   stylesheet: styles.css

--- a/inst/htmlwidgets/grViz.yaml
+++ b/inst/htmlwidgets/grViz.yaml
@@ -3,7 +3,7 @@ dependencies:
   version: 0.3
   src: htmlwidgets/lib/viz
   script: viz.js
-- name: styles
-  version: 0.1
+- name: DiagrammeR-styles
+  version: 0.2
   src: htmlwidgets/lib/styles
   stylesheet: styles.css

--- a/inst/htmlwidgets/lib/styles/styles.css
+++ b/inst/htmlwidgets/lib/styles/styles.css
@@ -6,3 +6,7 @@
   word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 
+.DiagrammeR g .label {
+  color: black;
+}
+


### PR DESCRIPTION
This namespaces the styles dependency to DiagrammeR and also takes care of an issue in Bootstrap pages where labels used a white color in Bootstrap pages.