### PR TITLE
document ... in DiagrammeR and mermaid and add NEWS.md to .Rbuildignore for CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 .bowerrc
+NEWS.md

--- a/R/DiagrammeR.R
+++ b/R/DiagrammeR.R
@@ -13,8 +13,7 @@
 #' \code{DiagrammeR} is just being used for dependency injection.
 #' @param type string - either "mermaid" (default) or "grViz" indicating
 #' the type of diagram spec and the desired parser/renderer
-#' @param width the width of the resulting graphic in pixels.
-#' @param height the height of the resulting graphic in pixels.
+#' @param ... any other parameters to pass to \code{grViz} or \code{mermaid}
 #' @return An object of class \code{htmlwidget} that will
 #' intelligently print itself into HTML in a variety of contexts
 #' including the R console, within R Markdown documents,

--- a/R/mermaid.R
+++ b/R/mermaid.R
@@ -8,6 +8,7 @@
 #' If no diagram is provided \code{diagram = ""} then the function will assume that
 #' a diagram will be provided by \code{\link[htmltools]{tags}} and
 #' \code{DiagrammeR} is just being used for dependency injection.
+#' @param ... other arguments and parameters you would like to send to Javascript
 #' @param width the width of the resulting graphic in pixels.
 #' @param height the height of the resulting graphic in pixels.
 #' @return An object of class \code{htmlwidget} that will
@@ -118,7 +119,7 @@
 #'
 #' @export
 
-mermaid <- function(diagram = "", ..., type = "mermaid", width = NULL, height = NULL) {
+mermaid <- function(diagram = "", ..., width = NULL, height = NULL) {
   
   # check for a connection or file
   if (inherits(diagram, "connection") || file.exists(diagram)) {


### PR DESCRIPTION
addressing warnings from CRAN submission:

1.  documented `...` for `mermaid` and `DiagrammeR`
2.  removed `type` from `mermaid` docs since not used
3.  added NEWS.md to .Rbuildignore

When `devtools::check()` no more warnings except those related to PDF vignette which are not applicable.

Please re-roxygenize.