### PR TITLE
add exportSVG to get SVG using V8 from @jeroenooms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Description: With the DiagrammeR package, you can create diagrams and flowcharts
     Markdown, and in shiny apps.
 License: MIT + file LICENSE
 Imports:
-    htmlwidgets (>= 0.3.2), rstudioapi (>= 0.2)
+    htmlwidgets (>= 0.3.2), rstudioapi (>= 0.2), V8 (>=0.5)
 Suggests:
     knitr
 VignetteBuilder: knitr

--- a/R/graphviz_export.R
+++ b/R/graphviz_export.R
@@ -1,0 +1,40 @@
+#' Export a grViz as SVG with V8
+#' 
+#' Use viz.js with \code{V8} to get the diagram rendered
+#' as SVG in R instead of the browser.
+#' 
+#' @param \code{grViz} htmlwidget to render as SVG.
+#' 
+#' @return \code{string} of SVG XML text.
+#' 
+#' @examples
+#' \dontrun{
+#'  library(DiagrammeR)
+#'  (svg <- exportSVG(grViz('digraph{a->b;c->a;c->b;c->d;}',engine='circo')))
+#'  
+#'  # this can then be used with htmltools
+#'  #   can save significantly on size of output
+#'  #   using svg rather than unrendered grViz
+#'  library(htmltools)
+#'  html_print(HTML(svg))
+#' }
+#' 
+#' @import V8
+#' 
+#' @export
+
+exportSVG <- function(gv){
+  # check to make sure that V8 is available
+  if(!requireNamespace("V8")) stop("V8 is required to export.",call.=F)
+  stopifnot(packageVersion("V8") >= "0.5")
+  
+  # check to make sure gv is grViz
+  if(!inherits(gv,"grViz")) "gv must be a grViz htmlwidget."
+  
+  ct <- V8::new_context("window")
+  invisible(ct$source(system.file("htmlwidgets/lib/viz/viz.js",package="DiagrammeR")))
+  
+  svg <- ct$call("Viz", gv$x$diagram, "svg", gv$x$config$engine, gv$x$config$options )
+  
+  return(svg)
+}


### PR DESCRIPTION
using the [gist](https://gist.github.com/jeroenooms/d0d03c7e58443f5a4438) from @jeroenooms as an example, add an `exportSVG` function to get the `SVG` for the rendered `grViz` diagram without the browser.  Since `viz.js` is such a large dependency, this can save significantly on the size of the HTML especially when converted by Pandoc into a single document.

Please re-roxygenize.  Feel free to change the name of the function if you don't like it.

Addresses #66 .