### PR TITLE
missing closing bracket in graphviz_single_df

### DIFF
--- a/R/graphviz_single_df.R
+++ b/R/graphviz_single_df.R
@@ -666,4 +666,6 @@ graphviz_single_df <- function(df,
                             directed = directed)
 
   return(combined_block)
+  }
+  
 }


### PR DESCRIPTION
Not sure if I just caught your `master` in a state of flux, but I discovered this missing `}`.