### PR TITLE
Add library(pipeR) to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@ devtools::install_github('rich-iannone/DiagrammeR')
 library("nycflights13")
 library("lubridate")
 library("DiagrammeR")
+library("pipeR")
  
 # Choose a day from 2013 for NYC flight data
 # (You can choose any Julian day, it's interesting to see results for different days)


### PR DESCRIPTION
The nycflights13 will fail at `%>>%` without a call to library(pipeR). See [SO post](http://stackoverflow.com/questions/30033856/diagrammer-example-leads-to-could-not-find-function-error).