### PR TITLE
Preserve existing graph attributes when deleting nodes or edges

### DIFF
--- a/R/delete_edge.R
+++ b/R/delete_edge.R
@@ -60,7 +60,8 @@ delete_edge <- function(graph,
       row.names(revised_edges_df) <- NULL
 
       dgr_graph <- create_graph(nodes_df = graph$nodes_df,
-                                 edges_df = revised_edges_df)
+                                 edges_df = revised_edges_df,
+                                graph_attrs = graph$graph_attrs)
     }
   }
 

--- a/R/delete_node.R
+++ b/R/delete_node.R
@@ -56,7 +56,8 @@ delete_node <- function(graph,
     # Create a revised graph and return that graph
     dgr_graph <-
       create_graph(nodes_df = revised_nodes_df,
-                     edges_df = revised_edges_df)
+                     edges_df = revised_edges_df,
+                   graph_attrs = graph$graph_attrs)
 
     return(dgr_graph)
   }


### PR DESCRIPTION
When using either the `delete_edge` or `delete_node` functions, the updated graph object does not retain any of the graph attributes that may have been set when the original graph was created, such as `"layout = neato"`. I simply added the `graph_attrs` parameter to the `create_graph` calls within these functions to keep the original graph attributes.