### PR TITLE
Fix delete_node for nodes without any edges

### DIFF
--- a/R/delete_node.R
+++ b/R/delete_node.R
@@ -48,8 +48,13 @@ delete_node <- function(graph,
     revised_nodes_df <- graph$nodes_df[-which(graph$nodes_df$nodes == node),]
 
     # Create a revised edge data frame
-    revised_edges_df <- graph$edges_df[-which((graph$edges_df$from == node) |
-                                                (graph$edges_df$to == node)),]
+    if (nrow(graph$edges_df[-which((graph$edges_df$from == node) |
+                                    (graph$edges_df$to == node)),]) == 0) {
+      revised_edges_df <- graph$edges_df
+    } else {
+      revised_edges_df <- graph$edges_df[-which((graph$edges_df$from == node) |
+                                                  (graph$edges_df$to == node)),]
+    }
 
     # Create a revised graph and return that graph
     dgr_graph <-


### PR DESCRIPTION
Before, it produced an empty nodes_df which made the create_graph
function to crash when trying to delete a node without edges.