### PR TITLE
Change addition of the pos column to the nodes df

### DIFF
--- a/R/create_graph.R
+++ b/R/create_graph.R
@@ -282,7 +282,7 @@ create_graph <- function(nodes_df = NULL,
                                    nodes_df[,column_with_y],
                                    "!"))
 
-        nodes_df <- cbind(nodes_df, pos)
+        nodes_df$pos <- pos$pos
       }
 
       # Determine whether column 'alpha' exists


### PR DESCRIPTION
With this change if the pos column already exists it overwrites it. 
Previously it kept on adding columns named "pos".
This happened for example after using add_node.