### PR TITLE
Converting code that produces warnings when using data.table or dplyr tables

### DIFF
--- a/R/create_graph.R
+++ b/R/create_graph.R
@@ -169,7 +169,7 @@ create_graph <- function(nodes_df = NULL,
     }
   }
 
-  if (class(edges_df) == "data.frame"){
+  if (inherits(edges_df,"data.frame")){
     if (ncol(edges_df) > 2){
 
       # Force all columns to be of the character class

--- a/R/get_edges.R
+++ b/R/get_edges.R
@@ -93,7 +93,7 @@ get_edges <- function(x,
     }
   }
 
-  if (class(x) == "data.frame"){
+  if (inherits(x,"data.frame")){
 
     if (colnames(x)[1] == "from" &
         colnames(x)[2] == "to"){

--- a/R/get_nodes.R
+++ b/R/get_nodes.R
@@ -67,7 +67,7 @@ get_nodes <- function(x,
     }
   }
 
-  if (class(x) == "data.frame"){
+  if (inherits(x,"data.frame")){
 
     if (colnames(x)[1] == "nodes"){
 

--- a/R/set_edge_attr.R
+++ b/R/set_edge_attr.R
@@ -90,7 +90,7 @@ set_edge_attr <- function(x,
     edges_df <- x$edges_df
   }
 
-  if (class(x) == "data.frame"){
+  if(inherits(x,"data.frame")){
 
     if (all(c("from", "to") %in% colnames(x))){
 

--- a/R/set_node_attr.R
+++ b/R/set_node_attr.R
@@ -65,7 +65,7 @@ set_node_attr <- function(x,
     nodes_df <- x$nodes_df
   }
 
-  if (class(x) == "data.frame"){
+  if(inherits(x,"data.frame")){
 
     if ("nodes" %in% colnames(x)){
 

--- a/tests/testthat/test-add_node_edge.R
+++ b/tests/testthat/test-add_node_edge.R
@@ -28,7 +28,7 @@ test_that("adding a node to a graph is possible", {
   expect_null(graph$edge_attrs)
 
   # Expect that the 'nodes_df' component is a data frame
-  expect_true(class(graph$nodes_df) == "data.frame")
+  expect_true(inherits(graph$nodes_df,"data.frame"))
 
   # Expect that the graph is a directed graph
   expect_true(graph$directed == TRUE)
@@ -205,10 +205,10 @@ test_that("adding an edge to a graph is possible", {
   expect_null(graph$edge_attrs)
 
   # Expect that the 'nodes_df' component is a data frame
-  expect_true(class(graph$nodes_df) == "data.frame")
+  expect_true(inherits(graph$nodes_df,"data.frame"))
 
   # Expect that the 'edges_df' component is a data frame
-  expect_true(class(graph$edges_df) == "data.frame")
+  expect_true(inherits(graph$edges_df,"data.frame"))
 
   # Expect that the graph is a directed graph
   expect_true(graph$directed == TRUE)

--- a/tests/testthat/test-add_node_edge_df.R
+++ b/tests/testthat/test-add_node_edge_df.R
@@ -43,8 +43,8 @@ test_that("adding a node df to a graph is possible", {
   expect_true(class(graph_3) == "dgr_graph")
 
   # Expect that the 'nodes_df' component is a data frame
-  expect_true(class(graph_2$nodes_df) == "data.frame")
-  expect_true(class(graph_3$nodes_df) == "data.frame")
+  expect_true(inherits(graph_2$nodes_df,"data.frame"))
+  expect_true(inherits(graph_3$nodes_df,"data.frame"))
 
   # Expect that the 'nodes_df' data frame has 4 and 8 rows
   expect_true(nrow(graph_2$nodes_df) == 4)
@@ -113,7 +113,7 @@ test_that("adding an edge df to a graph is possible", {
   expect_true(class(graph_3) == "dgr_graph")
 
   # Expect that the 'edges_df' component is a data frame
-  expect_true(class(graph_3$edges_df) == "data.frame")
+  expect_true(inherits(graph_3$edges_df,"data.frame"))
 
   # Expect that the 'edges_df' data frame has 6 rows
   expect_true(nrow(graph_3$edges_df) == 3)

--- a/tests/testthat/test-create_combine_edges.R
+++ b/tests/testthat/test-create_combine_edges.R
@@ -19,8 +19,8 @@ test_that("a correct edge data frame is generated", {
                  color = "red")
 
   # Expect that data frames are generated
-  expect_true(class(edges_1) == "data.frame")
-  expect_true(class(edges_2) == "data.frame")
+  expect_true(inherits(edges_1,"data.frame"))
+  expect_true(inherits(edges_2,"data.frame"))
 
   # Expect that each of the edge data frames has 4 rows
   expect_equal(nrow(edges_1), 4L)
@@ -93,7 +93,7 @@ test_that("two edge data frames can be successfully combined", {
   all_edges <- combine_edges(edges_1, edges_2)
 
   # Expect that a data frame is generated
-  expect_true(class(all_edges) == "data.frame")
+  expect_true(inherits(all_edges,"data.frame"))
 
   # Expect that the combined edge data frame has 8 rows
   expect_equal(nrow(all_edges), 8L)
@@ -132,7 +132,7 @@ test_that("three edge data frames can be successfully combined", {
   all_edges <- combine_edges(edges_1, edges_2, edges_3)
 
   # Expect that a data frame is generated
-  expect_true(class(all_edges) == "data.frame")
+  expect_true(inherits(all_edges,"data.frame"))
 
   # Expect that the combined edge data frame has 8 rows
   expect_equal(nrow(all_edges), 8L)

--- a/tests/testthat/test-create_graph.R
+++ b/tests/testthat/test-create_graph.R
@@ -73,7 +73,7 @@ test_that("a graph object with nodes can be created correctly", {
   expect_null(graph$edge_attrs)
 
   # Expect that the 'nodes_df' component is a data frame
-  expect_true(class(graph$nodes_df) == "data.frame")
+  expect_true(inherits(graph$nodes_df,"data.frame"))
 
   # Expect that the graph is a directed graph
   expect_true(graph$directed == TRUE)
@@ -108,13 +108,13 @@ test_that("a graph object can be created with a just an edge data frame", {
   expect_null(graph$edge_attrs)
 
   # Expect that the 'edges_df' component is a data frame
-  expect_true(class(graph$edges_df) == "data.frame")
+  expect_true(inherits(graph$edges_df,"data.frame"))
 
   # Expect that the 'nodes_df' component is not NULL
   expect_true(!is.null(graph$nodes_df))
 
   # Expect that the 'nodes_df' component is a data frame
-  expect_true(class(graph$edges_df) == "data.frame")
+  expect_true(inherits(graph$edges_df,"data.frame"))
 
   # Expect that the 'nodes_df' data frame has 3 columns
   expect_true(ncol(graph$nodes_df) == 3)
@@ -164,10 +164,10 @@ test_that("a graph object with nodes and edges can be created correctly", {
   expect_null(graph$graph_attrs)
 
   # Expect that the 'nodes_df' component is a data frame
-  expect_true(class(graph$nodes_df) == "data.frame")
+  expect_true(inherits(graph$nodes_df,"data.frame"))
 
   # Expect that the 'edges_df' component is a data frame
-  expect_true(class(graph$edges_df) == "data.frame")
+  expect_true(inherits(graph$edges_df,"data.frame"))
 
   # Expect that the 'node_attrs' component is a character vector of length 1
   expect_true(class(graph$node_attrs) == "character")

--- a/tests/testthat/test-datatablecompatability.R
+++ b/tests/testthat/test-datatablecompatability.R
@@ -1,0 +1,58 @@
+context("data.table and dplyr integration. Issue #159")
+
+test_that("combine_edges",{
+  edges_1 <-
+    create_edges(from = c("a", "a", "b", "c"),
+                 to = c("b", "d", "d", "a"),
+                 rel = "requires",
+                 color = "green",
+                 data = c(2.7, 8.9, 2.6, 0.6))
+
+  # Create 'edges_2' edge data frame
+  edges_2 <-
+    create_edges(from = c("e", "g", "h", "h"),
+                 to = c("g", "h", "f", "e"),
+                 rel = "receives",
+                 arrowhead = "dot",
+                 color = "red")
+
+  class(edges_1)<-c("data.table","tbl_df",class(edges_1))
+  class(edges_2)<-c("data.table","tbl_df",class(edges_2))
+  # Combine the 2 edge data frames
+  expect_warning(combine_edges(edges_1, edges_2), regexp = NA)
+  all_edges <- combine_edges(edges_1, edges_2)
+  # Expect that a data frame is generated
+  expect_true(inherits(all_edges,"data.frame"))
+
+  # Expect that the combined edge data frame has 8 rows
+  expect_equal(nrow(all_edges), 8L)
+
+  # Expect that the combined edge data frame has 6 columns
+  expect_equal(ncol(all_edges), 6L)
+})
+
+test_that("create_graph",{
+  # Create a node data frame
+  nodes <-
+    create_nodes(nodes = c("a", "b", "c", "d"),
+                 label = FALSE,
+                 type = "lower",
+                 style = "filled",
+                 color = "aqua",
+                 shape = c("circle", "circle",
+                           "rectangle", "rectangle"),
+                 data = c(3.5, 2.6, 9.4, 2.7))
+
+  class(nodes)<-c("data.table","tbl_df",class(nodes))
+
+  # Create the graph object using the node data frame
+  expect_warning( create_graph(nodes_df = nodes)  , regexp = NA)
+  graph <- create_graph(nodes_df = nodes)
+
+  # Expect that names in this graph object match a prescribed set of names
+  expect_true(all(names(graph) == c("graph_name", "graph_time", "graph_tz",
+                                    "nodes_df", "edges_df", "graph_attrs",
+                                    "node_attrs", "edge_attrs", "directed",
+                                    "dot_code")))
+
+})

--- a/tests/testthat/test-import_graph.R
+++ b/tests/testthat/test-import_graph.R
@@ -15,10 +15,10 @@ test_that("importing a .graphml file is possible", {
   expect_null(graphml_graph$graph_tz)
 
   # Expect that the 'nodes_df' component is a data frame
-  expect_true(class(graphml_graph$nodes_df) == "data.frame")
+  expect_true(inherits(graphml_graph$nodes_df,"data.frame"))
 
   # Expect that the 'edges_df' component is a data frame
-  expect_true(class(graphml_graph$edges_df) == "data.frame")
+  expect_true(inherits(graphml_graph$edges_df,"data.frame"))
 
   # Expect that the 'node_attrs' component is a character vector of length 1
   expect_true(class(graphml_graph$node_attrs) == "character")
@@ -56,10 +56,10 @@ test_that("importing a .sif file is possible", {
   expect_null(sif_graph$graph_tz)
 
   # Expect that the 'nodes_df' component is a data frame
-  expect_true(class(sif_graph$nodes_df) == "data.frame")
+  expect_true(inherits(sif_graph$nodes_df,"data.frame"))
 
   # Expect that the 'edges_df' component is a data frame
-  expect_true(class(sif_graph$edges_df) == "data.frame")
+  expect_true(inherits(sif_graph$edges_df,"data.frame"))
 
   # Expect that the 'node_attrs' is a vector of length 0
   expect_equal(length(sif_graph$node_attrs), 0)
@@ -95,10 +95,10 @@ test_that("importing a .gml file is possible", {
   expect_null(gml_graph$graph_tz)
 
   # Expect that the 'nodes_df' component is a data frame
-  expect_true(class(gml_graph$nodes_df) == "data.frame")
+  expect_true(inherits(gml_graph$nodes_df,"data.frame"))
 
   # Expect that the 'edges_df' component is a data frame
-  expect_true(class(gml_graph$edges_df) == "data.frame")
+  expect_true(inherits(gml_graph$edges_df,"data.frame"))
 
   # Expect that the 'node_attrs' is a vector of length 0
   expect_equal(length(gml_graph$node_attrs), 0)

--- a/tests/testthat/test-node_edge_info.R
+++ b/tests/testthat/test-node_edge_info.R
@@ -31,7 +31,7 @@ test_that("getting info about a graph's nodes is possible", {
   info_nodes <- node_info(graph)
 
   # Expect a data frame object
-  expect_true(class(info_nodes) == "data.frame")
+  expect_true(inherits(info_nodes,"data.frame"))
 
   # Expect that the data frame has 7 columns
   expect_true(ncol(info_nodes) == 7)
@@ -61,7 +61,7 @@ test_that("getting info about a graph's nodes is possible", {
   info_nodes_no_edges <- node_info(graph)
 
   # Expect a data frame object
-  expect_true(class(info_nodes_no_edges) == "data.frame")
+  expect_true(inherits(info_nodes_no_edges,"data.frame"))
 
   # Expect that the data frame has 7 columns
   expect_true(ncol(info_nodes_no_edges) == 7)
@@ -76,7 +76,7 @@ test_that("getting info about a graph's nodes is possible", {
   info_nodes_empty_graph <- node_info(graph)
 
   # Expect a data frame object
-  expect_true(class(info_nodes_empty_graph) == "data.frame")
+  expect_true(inherits(info_nodes_empty_graph,"data.frame"))
 
   # Expect that the data frame has 7 columns
   expect_true(ncol(info_nodes_empty_graph) == 7)
@@ -116,7 +116,7 @@ test_that("getting info about a graph's edges is possible", {
   info_edges <- edge_info(graph)
 
   # Expect a data frame object
-  expect_true(class(info_edges) == "data.frame")
+  expect_true(inherits(info_edges,"data.frame"))
 
   # Expect that the data frame has 3 columns
   expect_true(ncol(info_edges) == 3)
@@ -139,7 +139,7 @@ test_that("getting info about a graph's edges is possible", {
   info_graph_no_edges <- edge_info(graph)
 
   # Expect a data frame object
-  expect_true(class(info_graph_no_edges) == "data.frame")
+  expect_true(inherits(info_graph_no_edges,"data.frame"))
 
   # Expect that the data frame has 3 columns
   expect_true(ncol(info_graph_no_edges) == 3)


### PR DESCRIPTION
Changed the `class(x)=="data.frame"` constructs to `inherit(x,"data.frame")` instead. There's still a few other `class(x)=="something"` else constructs in there though. May take a look and submit another PR if I get the time but I don't think they're as problematic.