### PR TITLE
correction in if condition for logical expression

### DIFF
--- a/R/select_nodes_by_degree.R
+++ b/R/select_nodes_by_degree.R
@@ -186,7 +186,7 @@ select_nodes_by_degree <- function(graph,
       }
     }
 
-    if (grepl("^!=.*", degree_values)){
+    if (grepl("^==.*", degree_values)){
 
       if (degree_type == "both" | degree_type == "degree"){
         nodes_selected <-


### PR DESCRIPTION
Hi, 

reading the code to understand `select_nodes_by_degree`, I encounter a typo mistake in the if condition for logical expression.

To filter node ID values by degree type and degree values, condition `"^==.*"` was not present and `"^!=.*"` was here twice. So, I corrected in the if condition related to `"=="`.
