### PR TITLE
Use font-weight to address padding issues in Firefox and Safari

### DIFF
--- a/inst/htmlwidgets/lib/mermaid/dist/mermaid.css
+++ b/inst/htmlwidgets/lib/mermaid/dist/mermaid.css
@@ -3,12 +3,13 @@
 /* Gantt chart variables */
 .mermaid .label {
   color: #333333;
+  font-weight: 400;
 }
 
-.node rect,
+.mermaid .node rect,
 .node circle,
-.node ellipse,
-.node polygon {
+.mermaid .node ellipse,
+.mermaid .node polygon {
   fill: #ECECFF;
   stroke: #CCCCFF;
   stroke-width: 1px;
@@ -19,9 +20,6 @@
 
 .mermaid g .edgeLabel {
   background-color: white;
-  /* padding to avoid cutoff text in non-chrome browsers */
-  padding-left: 8px;
-  padding-right: 10px;
 }
 
 .mermaid .cluster rect {


### PR DESCRIPTION
The padding I added in the previous PR unfortunately also added spaces for mermaid graphs without labels. The issue I was seeing in Firefox and Safari was resolved by setting font-weight for labels explicitly.