### PR TITLE
grViz: only exclude old RStudio viewer, allow others

### DIFF
--- a/R/grViz.R
+++ b/R/grViz.R
@@ -54,8 +54,10 @@ grViz <- function(diagram = "",
     )
   )
 
-  # Only use the viewer for newer versions of RStudio
-  viewer.suppress <- !rstudioapi::isAvailable("0.99.120")
+  # Only use the viewer for newer versions of RStudio,
+  # but allow other, non-RStudio viewers
+  viewer.suppress <- rstudioapi::isAvailable() &&
+    !rstudioapi::isAvailable("0.99.120")
 
   # Create widget
   htmlwidgets::createWidget(


### PR DESCRIPTION
This fixes #183. 

I tried in a terminal, a browser windows opens.
I tried in Rcloud, it works fine.
I tried in new RStudio, it works fine.
I didn't try in old RStudio, to be honest, but that should work, too.

Thanks!