### PR TITLE
set height to auto in DiagrammeROuput

### DIFF
--- a/R/DiagrammeR.R
+++ b/R/DiagrammeR.R
@@ -141,7 +141,7 @@ DiagrammeR <- function(diagram = "", type = "mermaid", ...) {
 #' @export
 DiagrammeROutput <- function(outputId,
                              width = '100%',
-                             height = '400px') {
+                             height = 'auto') {
 
   htmlwidgets::shinyWidgetOutput(outputId,
                                  'DiagrammeR',


### PR DESCRIPTION
Allow height to adjust based on graph characteristics by setting `height = 'auto'`