### PR TITLE
Fix cluster rendering

### DIFF
--- a/R/generate_dot.R
+++ b/R/generate_dot.R
@@ -452,6 +452,27 @@ generate_dot <- function(graph) {
                    }))
       }
 
+      else if ('cluster' %in% colnames(nodes_df)) {
+	clustered_node_block <- character(0)
+	clusters <- split(node_block, nodes_df$cluster)
+	for (i in seq_along(clusters)) {
+	  if (names(clusters)[[i]] == "") {
+	    # nodes not in clusters
+	    cluster_block <- clusters[[i]]
+	  } else {
+	    cluster_block <- paste0("subgraph cluster", i, "{\nlabel='",
+	                            names(clusters)[[i]], "'\n",
+	       			    paste0(clusters[[i]], collapse="\n"), "}\n")
+	  }
+	  clustered_node_block <- c(clustered_node_block, cluster_block)
+	}
+
+	node_block <- clustered_node_block
+
+	# cleanup variables
+	rm(clustered_node_block, clusters, cluster_block)
+      }
+
       # Construct the `node_block` character object
       node_block <- paste(node_block, collapse = "\n")
 
@@ -463,45 +484,6 @@ generate_dot <- function(graph) {
       # Remove the `attribute` object if it exists
       if (exists("attribute")) {
         rm(attribute)
-      }
-
-      if ('cluster' %in% colnames(nodes_df)) {
-
-        # Get column number for column with node
-        # attribute `cluster`
-        cluster_colnum <-
-          which(colnames(nodes_df) %in% "cluster")
-
-        # Get list of clusters defined for the nodes
-        cluster_ids <-
-          unique(nodes_df$cluster)[
-            which(
-              unique(nodes_df$cluster) != "")]
-
-        for (i in seq_along(cluster_ids)) {
-
-          regex <-
-            paste0("'",
-                   paste(nodes_df[which(nodes_df[, cluster_colnum] == i ), 1],
-                         collapse = "'.*?\n |'"), "'.*?\n")
-
-          node_block <-
-            stringr::str_replace_all(node_block, regex, "")
-
-          replacement <-
-            stringr::str_replace(
-              paste0("  cluster_", i, " [label = 'xN\n",
-                     cluster_ids[i],
-                     "'; shape = 'circle';",
-                     " fixedsize = 'true';",
-                     " fontsize = '8pt';",
-                     " peripheries = '2']  \n"), "x",
-              length(
-                nodes_df[which(nodes_df[, cluster_colnum] == i ), 1]))
-
-          node_block <-
-            stringr::str_replace(node_block, "^", replacement)
-        }
       }
     }
 

--- a/tests/testthat/test-generate_dot.R
+++ b/tests/testthat/test-generate_dot.R
@@ -1,5 +1,16 @@
 context("Generate dot syntax from graph objects")
 
+# helper functions
+node <- function(id) paste0("'", id, "'")
+edge <- function(from, to) paste0("'", from, "'->'", to, "'")
+attrib_block <- "\\[[[:alnum:]'=.,[:space:]]*\\]"
+
+expect_dot <- function(graph, pattern) {
+  expect_match(
+    object = generate_dot(graph),
+    regexp = paste0(pattern, collapse="[[:space:]]*"))
+}
+
 test_that("Simple graph translates into specific form", {
 
   # Create simple graph
@@ -15,28 +26,49 @@ test_that("Simple graph translates into specific form", {
       nodes_df = nodes,
       edges_df = edges)
 
-  expect_match(
-    object = generate_dot(graph),
-    regexp = paste0(
-      # digraph {
-      "^digraph[[:space:]]*\\{",
-      # graph
-      "[[:space:]]*graph[[:space:]]*",
-      # [attrib block]
-      "\\[[[:alnum:]'=.,[:space:]]*\\]",
-      # node
-      "[[:space:]]*node[[:space:]]*",
-      # [attrib block]
-      "\\[[[:alnum:]'=.,[:space:]]*\\]",
-      # edge
-      "[[:space:]]*edge[[:space:]]*",
-      # [attrib block]
-      "\\[[[:alnum:]'=.,[:space:]]*\\]",
-      # node block  
-      paste0("[[:space:]]*'", 1:10, "'", collapse=""),
-      # edge block
-      paste0("[[:space:]]*'", 1:9, "'->'", 2:10, "'", collapse=""),
-      # }
-      "[[:space:]]*\\}$")
+  expect_dot(
+    graph,
+    c("^digraph", "\\{",
+      "graph", attrib_block,
+      "node", attrib_block,
+      "edge", attrib_block,
+      node(1:10),
+      edge(1:9, 2:10),
+      "\\}$")
+    )
+})
+
+test_that("Graph with clustered nodes create subgraph", {
+
+  # Create node clusters
+
+  nodes <-
+    create_node_df(
+      n = 6, 
+      cluster = c(NA, 'foo', 'foo', 'bar', NA, 'bar'))
+
+  edges <-
+    create_edge_df(
+      from = 1:5,
+      to = 2:6)
+
+  graph <-
+    create_graph(
+      nodes_df = nodes,
+      edges_df = edges)
+
+  expect_dot(
+    graph,
+    c("^digraph", "\\{",
+      "graph", attrib_block,
+      "node", attrib_block,
+      "edge", attrib_block,
+      node(c(1,5)),
+      "subgraph cluster2\\{\nlabel='bar'",
+      node(c(4,6)), "\\}",
+      "subgraph cluster3\\{\nlabel='foo'",
+      node(c(2,3)), "\\}",
+      edge(1:5, 2:6),
+      "\\}$")
     )
 })

--- a/tests/testthat/test-generate_dot.R
+++ b/tests/testthat/test-generate_dot.R
@@ -1,0 +1,42 @@
+context("Generate dot syntax from graph objects")
+
+test_that("Simple graph translates into specific form", {
+
+  # Create simple graph
+  nodes <- create_node_df(n = 10)
+
+  edges <-
+    create_edge_df(
+      from = 1:9,
+      to = 2:10)
+
+  graph <-
+    create_graph(
+      nodes_df = nodes,
+      edges_df = edges)
+
+  expect_match(
+    object = generate_dot(graph),
+    regexp = paste0(
+      # digraph {
+      "^digraph[[:space:]]*\\{",
+      # graph
+      "[[:space:]]*graph[[:space:]]*",
+      # [attrib block]
+      "\\[[[:alnum:]'=.,[:space:]]*\\]",
+      # node
+      "[[:space:]]*node[[:space:]]*",
+      # [attrib block]
+      "\\[[[:alnum:]'=.,[:space:]]*\\]",
+      # edge
+      "[[:space:]]*edge[[:space:]]*",
+      # [attrib block]
+      "\\[[[:alnum:]'=.,[:space:]]*\\]",
+      # node block  
+      paste0("[[:space:]]*'", 1:10, "'", collapse=""),
+      # edge block
+      paste0("[[:space:]]*'", 1:9, "'->'", 2:10, "'", collapse=""),
+      # }
+      "[[:space:]]*\\}$")
+    )
+})


### PR DESCRIPTION
The `render_graph` throws an error, whenever 'cluster' is present as a node attribute. It is discussed in #257. 