### PR TITLE
Fix namespaced UQ()

### DIFF
--- a/R/add_edge.R
+++ b/R/add_edge.R
@@ -284,7 +284,7 @@ add_edge <- function(graph,
         graph <-
           graph %>%
           set_edge_attrs_ws(
-            edge_attr = rlang::UQ(colnames(edge_aes_tbl)[i]),
+            edge_attr = UQ(colnames(edge_aes_tbl)[i]),
             value = edge_aes_tbl[1, i][[1]])
       }
 
@@ -312,7 +312,7 @@ add_edge <- function(graph,
         graph <-
           graph %>%
           set_edge_attrs_ws(
-            edge_attr = rlang::UQ(colnames(edge_data_tbl)[i]),
+            edge_attr = UQ(colnames(edge_data_tbl)[i]),
             value = edge_data_tbl[1, i][[1]])
       }
 

--- a/R/add_edges_from_table.R
+++ b/R/add_edges_from_table.R
@@ -204,9 +204,9 @@ add_edges_from_table <- function(graph,
   # Get the `from` col
   col_from <-
     dplyr::as_tibble(csv) %>%
-    dplyr::select(rlang::UQ(from_col)) %>%
+    dplyr::select(UQ(from_col)) %>%
     dplyr::left_join(
-      ndf %>% select(id, rlang::UQ(from_to_map)),
+      ndf %>% select(id, UQ(from_to_map)),
       by = stats::setNames(from_to_map, from_col)) %>%
     dplyr::select(id) %>%
     dplyr::rename(from = id) %>%
@@ -215,9 +215,9 @@ add_edges_from_table <- function(graph,
   # Get the `to` col
   col_to <-
     dplyr::as_tibble(csv) %>%
-    dplyr::select(rlang::UQ(to_col)) %>%
+    dplyr::select(UQ(to_col)) %>%
     dplyr::left_join(
-      ndf %>% select(id, rlang::UQ(from_to_map)),
+      ndf %>% select(id, UQ(from_to_map)),
       by = stats::setNames(from_to_map, to_col)) %>%
     dplyr::select(id) %>%
     dplyr::rename(to = id) %>%

--- a/R/colorize_edge_attrs.R
+++ b/R/colorize_edge_attrs.R
@@ -220,7 +220,7 @@ colorize_edge_attrs <- function(graph,
   graph <-
     set_edge_attrs(
       graph = graph,
-      edge_attr = rlang::UQ(edge_attr_to_2),
+      edge_attr = UQ(edge_attr_to_2),
       values = edges_attr_vector_colorized)
 
   # Remove last action from the `graph_log`

--- a/R/colorize_node_attrs.R
+++ b/R/colorize_node_attrs.R
@@ -266,7 +266,7 @@ colorize_node_attrs <- function(graph,
   graph <-
     set_node_attrs(
       graph = graph,
-      node_attr = rlang::UQ(node_attr_to_2),
+      node_attr = UQ(node_attr_to_2),
       values = nodes_attr_vector_colorized)
 
   # Remove last action from the `graph_log`

--- a/R/delete_global_graph_attrs.R
+++ b/R/delete_global_graph_attrs.R
@@ -89,7 +89,7 @@ delete_global_graph_attrs <- function(graph,
 
     graph$global_attrs <-
       graph$global_attrs %>%
-      dplyr::filter(!(attr %in% rlang::UQ(attr)))
+      dplyr::filter(!(attr %in% UQ(attr)))
   }
 
   if (!is.null(attr_type) & is.null(attr)) {
@@ -108,7 +108,7 @@ delete_global_graph_attrs <- function(graph,
 
     graph$global_attrs <-
       graph$global_attrs %>%
-      dplyr::filter(!(attr_type %in% rlang::UQ(attr_type)))
+      dplyr::filter(!(attr_type %in% UQ(attr_type)))
   }
 
   if (!is.null(attr_type) & !is.null(attr)) {

--- a/R/get_agg_degree_in.R
+++ b/R/get_agg_degree_in.R
@@ -86,7 +86,7 @@ get_agg_degree_in <- function(graph,
     ndf <-
       filter(
         .data = ndf,
-        rlang::UQ(conditions))
+        UQ(conditions))
 
     # Get a vector of node ID values
     node_ids <-

--- a/R/get_agg_degree_out.R
+++ b/R/get_agg_degree_out.R
@@ -85,7 +85,7 @@ get_agg_degree_out <- function(graph,
     ndf <-
       filter(
         .data = ndf,
-        rlang::UQ(conditions))
+        UQ(conditions))
 
     # Get a vector of node ID values
     node_ids <-

--- a/R/get_agg_degree_total.R
+++ b/R/get_agg_degree_total.R
@@ -89,7 +89,7 @@ get_agg_degree_total <- function(graph,
     ndf <-
       dplyr::filter(
         .data = ndf,
-        rlang::UQ(conditions))
+        UQ(conditions))
 
     # Get a vector of node ID values
     node_ids <-

--- a/R/get_edge_attrs.R
+++ b/R/get_edge_attrs.R
@@ -113,7 +113,7 @@ get_edge_attrs <- function(graph,
     # Extract the edge attribute values
     edge_attr_vals <-
       edf %>%
-      dplyr::pull(rlang::UQ(edge_attr))
+      dplyr::pull(UQ(edge_attr))
 
     # Extract the edge names
     edge_names <-
@@ -139,7 +139,7 @@ get_edge_attrs <- function(graph,
     # Extract the edge attribute values
     edge_attr_vals <-
       edf %>%
-      dplyr::pull(rlang::UQ(edge_attr))
+      dplyr::pull(UQ(edge_attr))
 
     # Extract the edge names
     edge_names <-

--- a/R/get_edge_attrs_ws.R
+++ b/R/get_edge_attrs_ws.R
@@ -130,7 +130,7 @@ get_edge_attrs_ws <- function(graph,
   # Extract the edge attribute values
   edge_attr_vals <-
     edf %>%
-    dplyr::pull(rlang::UQ(edge_attr))
+    dplyr::pull(UQ(edge_attr))
 
   # Extract the edge names
   edge_names <-

--- a/R/get_edge_ids.R
+++ b/R/get_edge_ids.R
@@ -87,7 +87,7 @@ get_edge_ids <- function(graph,
     edges_df <-
       filter(
         .data = edges_df,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If no edges remain then return NA

--- a/R/get_edges.R
+++ b/R/get_edges.R
@@ -133,7 +133,7 @@ get_edges <- function(graph,
     edges_df <-
       filter(
         .data = edges_df,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If no edges remain then return NA

--- a/R/get_node_attrs.R
+++ b/R/get_node_attrs.R
@@ -76,7 +76,7 @@ get_node_attrs <- function(graph,
     # Extract the node attribute values
     node_attr_vals <-
       ndf %>%
-      dplyr::pull(rlang::UQ(node_attr))
+      dplyr::pull(UQ(node_attr))
 
     # Extract the node names
     node_names <- ndf$id
@@ -98,7 +98,7 @@ get_node_attrs <- function(graph,
     # Extract the node attribute values
     node_attr_vals <-
       ndf %>%
-      dplyr::pull(rlang::UQ(node_attr))
+      dplyr::pull(UQ(node_attr))
 
     # Extract the node names
     node_names <- ndf$id

--- a/R/get_node_attrs_ws.R
+++ b/R/get_node_attrs_ws.R
@@ -108,7 +108,7 @@ get_node_attrs_ws <- function(graph,
   # Extract the node attribute values
   node_attr_vals <-
     ndf %>%
-    dplyr::pull(rlang::UQ(node_attr))
+    dplyr::pull(UQ(node_attr))
 
   # Add names to each of the values
   names(node_attr_vals) <- nodes

--- a/R/get_node_ids.R
+++ b/R/get_node_ids.R
@@ -81,7 +81,7 @@ get_node_ids <- function(graph,
     nodes_df <-
       filter(
         .data = nodes_df,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If no nodes remain then return NA

--- a/R/rescale_edge_attrs.R
+++ b/R/rescale_edge_attrs.R
@@ -206,7 +206,7 @@ rescale_edge_attrs <- function(graph,
   graph <-
     set_edge_attrs(
       graph = graph,
-      edge_attr = rlang::UQ(edge_attr_to_2),
+      edge_attr = UQ(edge_attr_to_2),
       values = edges_attr_vector_rescaled)
 
   # Remove last action from the `graph_log`

--- a/R/rescale_node_attrs.R
+++ b/R/rescale_node_attrs.R
@@ -203,7 +203,7 @@ rescale_node_attrs <- function(graph,
   graph <-
     set_node_attrs(
       graph = graph,
-      node_attr = rlang::UQ(node_attr_to_2),
+      node_attr = UQ(node_attr_to_2),
       values = nodes_attr_vector_rescaled)
 
   # Remove last action from the `graph_log`

--- a/R/select_edges.R
+++ b/R/select_edges.R
@@ -150,7 +150,7 @@ select_edges <- function(graph,
     edges_df <-
       dplyr::filter(
         .data = edges_df,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If a `from` vector provided, filter the edf

--- a/R/select_nodes.R
+++ b/R/select_nodes.R
@@ -133,7 +133,7 @@ select_nodes <- function(graph,
     nodes_df <-
       filter(
         .data = nodes_df,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # Get the nodes as a vector

--- a/R/set_node_attrs_ws.R
+++ b/R/set_node_attrs_ws.R
@@ -100,7 +100,7 @@ set_node_attrs_ws <- function(graph,
   graph <-
     set_node_attrs(
       graph = graph,
-      node_attr = rlang::UQ(node_attr_2),
+      node_attr = UQ(node_attr_2),
       values = value,
       nodes = nodes)
 

--- a/R/trav_both.R
+++ b/R/trav_both.R
@@ -304,7 +304,7 @@ trav_both <- function(graph,
     valid_nodes <-
       dplyr::filter(
         .data = valid_nodes,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If the option is taken to copy node attribute

--- a/R/trav_both_edge.R
+++ b/R/trav_both_edge.R
@@ -299,7 +299,7 @@ trav_both_edge <- function(graph,
     valid_edges <-
       dplyr::filter(
         .data = valid_edges,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If no rows returned, then there are no

--- a/R/trav_in.R
+++ b/R/trav_in.R
@@ -324,7 +324,7 @@ trav_in <- function(graph,
     valid_nodes <-
       dplyr::filter(
         .data = valid_nodes,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If the option is taken to copy node attribute

--- a/R/trav_in_edge.R
+++ b/R/trav_in_edge.R
@@ -304,7 +304,7 @@ trav_in_edge <- function(graph,
     valid_edges <-
       filter(
         .data = valid_edges,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If no rows returned, then there are no

--- a/R/trav_in_node.R
+++ b/R/trav_in_node.R
@@ -310,7 +310,7 @@ trav_in_node <- function(graph,
     valid_nodes <-
       dplyr::filter(
         .data = valid_nodes,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If no rows returned, then there are no

--- a/R/trav_in_until.R
+++ b/R/trav_in_until.R
@@ -171,7 +171,7 @@ trav_in_until <- function(graph,
   all_nodes_conditions_met <-
     graph %>%
     get_node_ids(
-      conditions = rlang::UQ(conditions))
+      conditions = UQ(conditions))
 
   if (exclude_unmatched & all(is.na(all_nodes_conditions_met))) {
 

--- a/R/trav_out.R
+++ b/R/trav_out.R
@@ -328,7 +328,7 @@ trav_out <- function(graph,
     valid_nodes <-
       dplyr::filter(
         .data = valid_nodes,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If the option is taken to copy node attribute

--- a/R/trav_out_edge.R
+++ b/R/trav_out_edge.R
@@ -286,7 +286,7 @@ trav_out_edge <- function(graph,
     valid_edges <-
       dplyr::filter(
         .data = valid_edges,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If no rows returned, then there are no

--- a/R/trav_out_node.R
+++ b/R/trav_out_node.R
@@ -310,7 +310,7 @@ trav_out_node <- function(graph,
     valid_nodes <-
       dplyr::filter(
         .data = valid_nodes,
-        rlang::UQ(conditions))
+        UQ(conditions))
   }
 
   # If no rows returned, then there are no

--- a/R/trav_out_until.R
+++ b/R/trav_out_until.R
@@ -171,7 +171,7 @@ trav_out_until <- function(graph,
   all_nodes_conditions_met <-
     graph %>%
     get_node_ids(
-      conditions = rlang::UQ(conditions))
+      conditions = UQ(conditions))
 
   if (exclude_unmatched & all(is.na(all_nodes_conditions_met))) {
 


### PR DESCRIPTION
Hi Rich. Calling `UQ()` with the rlang namespace is deprecated as of rlang 0.3.0.

Could you please issue a quick patch release to CRAN? I'm planning to release 0.3.0 on Friday 19th and the warnings caused by diagrammeR trigger a check failure in processanimateR.

cc @fmannhardt