### PR TITLE
Fix incorrect arguments being passed into vis.js

### DIFF
--- a/inst/htmlwidgets/grViz.js
+++ b/inst/htmlwidgets/grViz.js
@@ -35,7 +35,7 @@ HTMLWidgets.widget({
 
       try {
 
-        el.innerHTML = Viz(x.diagram, format="svg", engine=x.config.engine, options=x.config.options);
+        el.innerHTML = Viz(x.diagram, {format: "svg", engine: x.config.engine, ...x.config.options});
 
         makeResponsive(el);
 


### PR DESCRIPTION
The arguments being passed into vis.js are in the wrong format:
https://github.com/mdaines/viz.js/blob/v1.8.2/src/api.js#L2

vis.js expects a single options object containing all the desired settings.

Perhaps this was missed when upgrading vis.js versions?

This caused weird errors for me as I had extended the string prototype to contain a 'format' function