### PR TITLE
fix for transform_to_subgraph_ws for problem when selecting by edge id

### DIFF
--- a/R/transform_to_subgraph_ws.R
+++ b/R/transform_to_subgraph_ws.R
@@ -48,8 +48,8 @@
 #' # Create an edge data frame (edf)
 #' edf <-
 #'   create_edge_df(
-#'     from = c(1, 2, 4, 5, 2, 6),
-#'       to = c(2, 4, 1, 3, 5, 5))
+#'     from = c(1, 2, 4, 5, 2, 6, 2),
+#'       to = c(2, 4, 1, 3, 5, 5, 4))
 #'
 #' # Create a graph
 #' graph <-
@@ -74,6 +74,24 @@
 #'
 #' # Display the graph's edge data frame
 #' subgraph %>% get_edge_df()
+#'
+#' # Create a selection of edges, this selects
+#' # edges `1`, `2`
+#' graph <- graph %>%
+#'   clear_selection() %>%
+#'   select_edges(
+#'   edges = c(1,2))
+#'
+#' # Create a subgraph based on the selection
+#'   subgraph <-
+#'   graph %>%
+#'   transform_to_subgraph_ws()
+#'
+#' # Display the graph's node data frame
+#'   subgraph %>% get_node_df()
+#'
+#' # Display the graph's edge data frame
+#'   subgraph %>% get_edge_df()
 #' @importFrom dplyr filter semi_join
 #' @importFrom stringr str_split
 #' @export
@@ -96,7 +114,7 @@ transform_to_subgraph_ws <- function(graph) {
   # Validation: Graph object has valid selection of
   # nodes or edges
   if (!(graph_contains_node_selection(graph) |
-      graph_contains_edge_selection(graph))) {
+        graph_contains_edge_selection(graph))) {
 
     emit_error(
       fcn_name = fcn_name,
@@ -133,15 +151,14 @@ transform_to_subgraph_ws <- function(graph) {
   # Filter the edges in the graph
   if (graph_contains_edge_selection(graph)) {
 
-    selection_from <- graph$edge_selection$from
-    selection_to <- graph$edge_selection$to
+    selection <- graph$edge_selection$edge
 
     selection_df <-
-      data.frame(from = selection_from, to = selection_to)
+      data.frame(id = selection)
 
     edf <-
       graph$edges_df %>%
-      dplyr::semi_join(selection_df, by = c("from", "to"))
+      dplyr::semi_join(selection_df, by = c("id"))
 
     ndf <-
       graph$nodes_df %>%


### PR DESCRIPTION
Been using the DiagrammeR package for some time. So great! 

I've run into what I think is a bug when `select_edges(edges = ...)` is used to select edges in a graph.

If there are multiple edges with the same from and to nodes specified yet they are not included in the `edges` vector they are still included in the subgraph.

This is my first git pull request *ever*. Way overdue. I'm open to suggestions in how to better suggest changes in these.

Thanks !!

Andrew Maffei

```
# test case for problem in transform_to_subgraph_ws
# problem occurs when two edges in graph have same from and to
#
# Create a node data frame (ndf)
ndf <-
  create_node_df(
    n = 3,
    value =
      c(3.5, 2.6, 9.4))

# Create an edge data frame (edf)
# Note that edges 2 and 3 have same from and to
edf <-
  create_edge_df(
    from = c(1, 2, 2),
      to = c(2, 3, 3))

# Create a graph
graph <-
  create_graph(
    nodes_df = ndf,
    edges_df = edf)

# Create a selection of edges, this selects
# only edges `1`, `2`
graph <- graph %>%
  clear_selection() %>%
  select_edges(
  edges = c(1,2))

# Create a subgraph based on the selection
  subgraph <-
  graph %>%
  transform_to_subgraph_ws()

# Display the graph's node data frame
  subgraph %>% get_node_df()

# Display the graph's edge data frame
# Note that all 3 edges are included in subgraph instead of just `1` and `2`
  subgraph %>% get_edge_df()
```