### PR TITLE
add Shiny click events

### DIFF
--- a/inst/htmlwidgets/grViz.js
+++ b/inst/htmlwidgets/grViz.js
@@ -39,6 +39,29 @@ HTMLWidgets.widget({
 
         makeResponsive(el);
 
+        if (HTMLWidgets.shinyMode) {
+          // Get widget id
+          var id = el.id;
+
+          $("#" + id + " .node").click(function(e) {
+            // Get node id
+            var nodeid = e.currentTarget.id;
+            // Get node text object and make an array
+            var node_texts = $("#" + nodeid + " text");
+            //var node_path = $("#" + nodeid + " path")[0];
+            var text_array = node_texts.map(function() {return $(this).text(); }).toArray();
+            // Build return object *obj* with node-id, node text values and node fill
+            var obj = {
+              id: nodeid,
+              //fill: node_path.attributes.fill.nodeValue,
+              //outerHMTL: node_path.outerHTML,
+              nodeValues: text_array
+            };
+            // Send *obj* to Shiny's inputs (input$[id]+_click  e.g.: input$vtree_click))
+            Shiny.setInputValue(id + "_click", obj, {priority: "event"});
+          });
+        }
+
         // set up a container for tasks to perform after completion
         //  one example would be add callbacks for event handling
         //  styling


### PR DESCRIPTION
This addresses #290 

For now a click on a node, creates a Shiny input object with node id and the text content. It would be nice to have some highlighting options too. But I hope this will do as a start.

Here's a test shiny-app:
```
library(DiagrammeR)
library(shiny)

# Load in a the small repository graph
graph <-
  open_graph(
    system.file(
      "extdata/example_graphs_dgr/repository.dgr",
      package = "DiagrammeR"))

ui <- fluidPage(
  grVizOutput("dg")
  , verbatimTextOutput("print")
  , DiagrammeROutput("dg1")
  , verbatimTextOutput("print1")
)

server <- function(input, output, session) {
  output$dg <- renderGrViz({
    render_graph(graph, layout = "kk")
  })
  output$print <- renderPrint({
    req(input$dg_click)
    print(unlist(input$dg_click))
  })
  
  output$dg1 <- renderDiagrammeR({
    DiagrammeR("graph LR;A(Rounded)-->B[Squared];B-->C{A Decision};
 C-->D[Square One];C-->E[Square Two];
 style A fill:#E5E25F;  style B fill:#87AB51; style C fill:#3C8937;
 style D fill:#23772C;  style E fill:#B6E6E6;"
    )
  })
  output$print1 <- renderPrint({
    req(input$dg1_click)
    print(unlist(input$dg1_click))
  })
}

shinyApp(ui, server)
```