### PR TITLE
fixes rich-iannone/DiagrammeR#357

### DIFF
--- a/R/spectools.R
+++ b/R/spectools.R
@@ -104,8 +104,8 @@ replace_in_spec <- function(spec) {
 
       while (grepl(paste0("@@", i, "([^-0-9])"), spec_body)) {
 
-        spec_body <- gsub(paste0("'@@", i, "'"),
-                          paste0("'", eval_expressions[[i]][1], "'"), spec_body)
+        spec_body <- gsub(paste0("@@", i),
+                          eval_expressions[[i]][1], spec_body)
       }
     }
 

--- a/tests/testthat/test-spectools.R
+++ b/tests/testthat/test-spectools.R
@@ -45,3 +45,12 @@ test_that("the specification tools are functional", {
   expect_is(
     replaced_spec, c("grViz", "htmlwidget"))
 })
+
+test_that("specification substitution works without quotes", {
+
+  spec <- "digraph { @@1 }
+   [1]: LETTERS[1]"
+  replaced_spec <- replace_in_spec(spec)
+  expect_equal(replaced_spec, "digraph { A }")
+
+})


### PR DESCRIPTION
This simple fix to rich-iannone/DiagrammeR#357 removes the single quotes when doing @@1 style substitution. It also adds a test for the behaviour.