### PR TITLE
Remove references to deprecated dplyr functions

### DIFF
--- a/R/add_nodes_from_df_cols.R
+++ b/R/add_nodes_from_df_cols.R
@@ -136,7 +136,7 @@ add_nodes_from_df_cols <- function(graph,
           trimws() %>%
           stringr::str_split(" ") %>%
           purrr::flatten_chr() %>%
-          dplyr::as_tibble(.name_repair = "unique") %>%
+          tibble::enframe(name = NULL) %>%
           tidyr::drop_na() %>%
           dplyr::distinct() %>%
           purrr::flatten_chr())

--- a/R/get_agg_degree_in.R
+++ b/R/get_agg_degree_in.R
@@ -111,11 +111,12 @@ get_agg_degree_in <- function(graph,
 
   # Get the aggregate value of total degree based
   # on the aggregate function provided
+  fun <- match.fun(agg)
+
   indegree_agg <-
     indegree_df %>%
     dplyr::group_by() %>%
-    dplyr::summarize_(stats::as.formula(
-      paste0("~", agg, "(indegree, na.rm = TRUE)"))) %>%
+    dplyr::summarize(fun(indegree, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     purrr::flatten_dbl()
 

--- a/R/get_agg_degree_out.R
+++ b/R/get_agg_degree_out.R
@@ -111,11 +111,12 @@ get_agg_degree_out <- function(graph,
 
   # Get the aggregate value of total degree based
   # on the aggregate function provided
+  fun <- match.fun(agg)
+
   outdegree_agg <-
     outdegree_df %>%
     dplyr::group_by() %>%
-    dplyr::summarize_(stats::as.formula(
-      paste0("~", agg, "(outdegree, na.rm = TRUE)"))) %>%
+    dplyr::summarize(fun(outdegree, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     purrr::flatten_dbl()
 

--- a/R/get_agg_degree_total.R
+++ b/R/get_agg_degree_total.R
@@ -114,11 +114,12 @@ get_agg_degree_total <- function(graph,
 
   # Get the aggregate value of total degree based
   # on the aggregate function provided
+  fun <- match.fun(agg)
+
   total_degree_agg <-
     total_degree_df %>%
     dplyr::group_by() %>%
-    dplyr::summarize_(stats::as.formula(
-      paste0("~", agg, "(total_degree, na.rm = TRUE)"))) %>%
+    dplyr::summarize(fun(total_degree, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
     purrr::flatten_dbl()
 

--- a/R/get_edges.R
+++ b/R/get_edges.R
@@ -116,9 +116,9 @@ get_edges <- function(graph,
   if (return_values == "label") {
     edges_df <-
       edges_df %>%
-      dplyr::left_join(graph$nodes_df %>% dplyr::select_("id", "label"), by = c("from" = "id")) %>%
+      dplyr::left_join(graph$nodes_df %>% dplyr::select("id", "label"), by = c("from" = "id")) %>%
       dplyr::rename(from_label_ = label) %>%
-      dplyr::left_join(graph$nodes_df %>% dplyr::select_("id", "label"), by = c("to" = "id")) %>%
+      dplyr::left_join(graph$nodes_df %>% dplyr::select("id", "label"), by = c("to" = "id")) %>%
       dplyr::rename(to_label_ = label)
   }
 
@@ -159,11 +159,11 @@ get_edges <- function(graph,
     if (return_values == "id") {
       edges_df <-
         edges_df %>%
-        dplyr::select_("from", "to")
+        dplyr::select("from", "to")
     } else if (return_values == "label") {
       edges_df <-
         edges_df %>%
-        dplyr::select_("from_label_", "to_label_")
+        dplyr::select("from_label_", "to_label_")
     }
 
     return(edges_df)

--- a/R/layout_nodes_w_string.R
+++ b/R/layout_nodes_w_string.R
@@ -191,12 +191,12 @@ layout_nodes_w_string <- function(graph,
       if (sort_dir == "desc") {
         ndf_part <-
           ndf_part %>%
-          dplyr::arrange_(paste0("desc(", sort_attr, ")"))
+          dplyr::arrange(desc(!! sym(sort_attr)))
 
       } else {
         ndf_part <-
           ndf_part %>%
-          dplyr::arrange_(sort_attr)
+          dplyr::arrange(!! sym(sort_attr))
       }
     }
 

--- a/R/layout_nodes_w_string.R
+++ b/R/layout_nodes_w_string.R
@@ -184,7 +184,7 @@ layout_nodes_w_string <- function(graph,
     # Filter the graph `ndf`
     ndf_part <-
       ndf %>%
-      dplyr::filter_(paste0(node_attr, " == '", node_attr_val, "'"))
+      dplyr::filter(!! parse_expr(paste0(node_attr, " == '", node_attr_val, "'")))
 
     # Optionally apply sorting
     if (!is.null(sort)) {

--- a/R/mutate_edge_attrs.R
+++ b/R/mutate_edge_attrs.R
@@ -116,13 +116,7 @@ mutate_edge_attrs <- function(graph,
       reasons = "The variables `id`, `from`, or `to` cannot undergo mutation")
   }
 
-  for (i in 1:length(exprs)) {
-    edf <-
-      edf %>%
-      dplyr::mutate_(
-        .dots = stats::setNames(list((exprs %>% paste())[i]),
-                         names(exprs)[i]))
-  }
+  edf <- edf %>% dplyr::mutate(!!! enquos(...))
 
   # Update the graph
   graph$edges_df <- edf

--- a/R/mutate_edge_attrs_ws.R
+++ b/R/mutate_edge_attrs_ws.R
@@ -173,53 +173,17 @@ mutate_edge_attrs_ws <- function(graph,
       get_edge_ids(graph),
       suppressMessages(get_selection(graph)))
 
-  for (i in 1:length(exprs)) {
+  s <- edf$id %in% unselected_edges
+  order <- c(which(!s), which(s))
 
-    # Case where mutation occurs for an
-    # existing edge attribute
-    if (names(exprs)[i] %in% colnames(edf)) {
+  edf <-
+    dplyr::bind_rows(
+      edf %>% dplyr::filter(!(!! enquo(s))) %>% dplyr::mutate(!!! enquos(...)),
+      edf %>% dplyr::filter( (!! enquo(s)))
+    ) %>% dplyr::arrange(!! enquo(order))
 
-      edf_replacement <-
-        edf %>%
-        dplyr::mutate_(
-          .dots = stats::setNames(list((exprs %>% paste())[i]),
-                           names(exprs)[i]))
+  graph$edges_df <- edf
 
-      edf_replacement[
-        which(edf$id %in% unselected_edges), ] <-
-        edf[
-          which(edf$id %in% unselected_edges), ]
-
-      # Update the graph's edf
-      graph$edges_df <- edf_replacement
-
-      # Reobtain the changed edf for
-      # any subsequent mutations
-      edf <- get_edge_df(graph)
-    }
-
-    # Case where mutation creates a
-    # new edge attribute
-    if (!(names(exprs)[i] %in% colnames(edf))) {
-
-      edf_replacement <-
-        edf %>%
-        dplyr::mutate_(
-          .dots = stats::setNames(list((exprs %>% paste())[i]),
-                           names(exprs)[i]))
-
-      edf_replacement[
-        which(edf$id %in% unselected_edges),
-        which(colnames(edf_replacement) == names(exprs)[i])] <- NA
-
-      # Update the graph's edf
-      graph$edges_df <- edf_replacement
-
-      # Reobtain the changed edf for
-      # any subsequent mutations
-      edf <- get_edge_df(graph)
-    }
-  }
 
   # Update the `graph_log` df with an action
   graph$graph_log <-

--- a/R/mutate_node_attrs.R
+++ b/R/mutate_node_attrs.R
@@ -114,13 +114,7 @@ mutate_node_attrs <- function(graph,
       reasons = "The variable `id` cannot undergo mutation")
   }
 
-  for (i in 1:length(exprs)) {
-    ndf <-
-      ndf %>%
-      dplyr::mutate_(
-        .dots = stats::setNames(list((exprs %>% paste())[i]),
-                         names(exprs)[i]))
-  }
+  ndf <- ndf %>% dplyr::mutate(!!! enquos(...))
 
   # Update the graph
   graph$nodes_df <- ndf

--- a/R/select_nodes_by_degree.R
+++ b/R/select_nodes_by_degree.R
@@ -123,13 +123,8 @@ select_nodes_by_degree <- function(graph,
   # Get a data frame with node ID and degree types
   node_degree <-
     get_node_info(graph) %>%
-    dplyr::select(id, deg, indeg, outdeg)
-
-  for (i in 1:length(expressions)) {
-    node_degree <-
-      node_degree %>%
-      dplyr::filter_(expressions[i])
-  }
+    dplyr::select(id, deg, indeg, outdeg) %>%
+    dplyr::filter(!!! parse_exprs(expressions))
 
   # Get the node ID values from the filtered table
   nodes_selected <- node_degree$id

--- a/R/to_igraph.R
+++ b/R/to_igraph.R
@@ -54,7 +54,7 @@ to_igraph <- function(graph) {
   # exclude the `id` column
   edf <-
     graph$edges_df %>%
-    dplyr::select_("-id")
+    dplyr::select(-id)
 
   igraph::graph_from_data_frame(
     d = edf,

--- a/R/trav_both.R
+++ b/R/trav_both.R
@@ -305,15 +305,15 @@ trav_both <- function(graph,
       valid_nodes %>%
       dplyr::select(id) %>%
       dplyr::inner_join(edf %>% dplyr::select(from, to), by = c("id" = "from")) %>%
-      dplyr::inner_join(ndf %>% dplyr::select_("id", copy_attrs_from), by = c("to" = "id")) %>%
-      dplyr::select_("id", copy_attrs_from)
+      dplyr::inner_join(ndf %>% dplyr::select("id",!! enquo(copy_attrs_from)), by = c("to" = "id")) %>%
+      dplyr::select("id",!! enquo(copy_attrs_from))
 
     to_join <-
       valid_nodes %>%
       dplyr::select(id) %>%
       dplyr::inner_join(edf %>% dplyr::select(from, to), by = c("id" = "to")) %>%
-      dplyr::inner_join(ndf %>% dplyr::select_("id", copy_attrs_from), by = c("from" = "id")) %>%
-      dplyr::select_("id", copy_attrs_from)
+      dplyr::inner_join(ndf %>% dplyr::select("id",!! enquo(copy_attrs_from)), by = c("from" = "id")) %>%
+      dplyr::select("id",!! enquo(copy_attrs_from))
 
     nodes <-
       from_join %>%

--- a/R/trav_both.R
+++ b/R/trav_both.R
@@ -319,10 +319,9 @@ trav_both <- function(graph,
       from_join %>%
       dplyr::union_all(to_join) %>%
       dplyr::group_by(id) %>%
-      dplyr::summarize_(.dots = stats::setNames(
-        list(stats::as.formula(
-          paste0("~", agg, "(", copy_attrs_from, ", na.rm = TRUE)"))),
-        copy_attrs_from)) %>%
+      dplyr::summarize(!! copy_attrs_from :=
+                         match.fun(!! agg)(!! as.name(copy_attrs_from),
+                                           na.rm = TRUE)) %>%
       dplyr::right_join(ndf, by = "id") %>%
       dplyr::select(id, type, label, dplyr::everything()) %>%
       as.data.frame(stringsAsFactors = FALSE)

--- a/R/trav_both_edge.R
+++ b/R/trav_both_edge.R
@@ -306,25 +306,25 @@ trav_both_edge <- function(graph,
 
       from_join <-
         ndf %>%
-        dplyr::select_("id", copy_attrs_from) %>%
+        dplyr::select("id",!! enquo(copy_attrs_from)) %>%
         dplyr::filter(id %in% starting_nodes) %>%
         dplyr::right_join(
           valid_edges %>%
             dplyr::select(-rel) %>%
             dplyr::rename(e_id = id),
           by = c("id" = "from")) %>%
-        dplyr::select_("e_id", copy_attrs_from)
+        dplyr::select("e_id",!! enquo(copy_attrs_from))
 
       to_join <-
         ndf %>%
-        dplyr::select_("id", copy_attrs_from) %>%
+        dplyr::select("id",!! enquo(copy_attrs_from)) %>%
         dplyr::filter(id %in% starting_nodes) %>%
         dplyr::right_join(
           valid_edges %>%
             dplyr::select(-rel) %>%
             dplyr::rename(e_id = id),
           by = c("id" = "to")) %>%
-        dplyr::select_("e_id", copy_attrs_from)
+        dplyr::select("e_id",!! enquo(copy_attrs_from))
 
       if (!is.null(copy_attrs_as)) {
 
@@ -359,7 +359,7 @@ trav_both_edge <- function(graph,
 
       from_join <-
         ndf %>%
-        dplyr::select_("id", copy_attrs_from) %>%
+        dplyr::select("id",!! enquo(copy_attrs_from)) %>%
         dplyr::filter(id %in% starting_nodes)
 
       if (!is.null(copy_attrs_as)) {
@@ -403,11 +403,11 @@ trav_both_edge <- function(graph,
       # Drop the ".x" column
       from_join <-
         from_join %>%
-        dplyr::select_("e_id", copy_attrs_from)
+        dplyr::select("e_id",!! enquo(copy_attrs_from))
 
       to_join <-
         ndf %>%
-        dplyr::select_("id", copy_attrs_from) %>%
+        dplyr::select("id",!! enquo(copy_attrs_from)) %>%
         dplyr::filter(id %in% starting_nodes)
 
       if (!is.null(copy_attrs_as)) {
@@ -449,7 +449,7 @@ trav_both_edge <- function(graph,
       # Drop the ".x" column
       to_join <-
         to_join %>%
-        dplyr::select_("e_id", copy_attrs_from)
+        dplyr::select("e_id",!! enquo(copy_attrs_from))
 
       edges <-
         dplyr::bind_rows(

--- a/R/trav_both_edge.R
+++ b/R/trav_both_edge.R
@@ -346,10 +346,9 @@ trav_both_edge <- function(graph,
         dplyr::left_join(edf, by = c("e_id" = "id")) %>%
         dplyr::rename(id = e_id) %>%
         dplyr::group_by(id) %>%
-        dplyr::summarize_(.dots = stats::setNames(
-          list(stats::as.formula(
-            paste0("~", agg, "(", copy_attrs_from, ", na.rm = TRUE)"))),
-          copy_attrs_from)) %>%
+        dplyr::summarize(!! copy_attrs_from :=
+                           match.fun(!! agg)(!! as.name(copy_attrs_from),
+                                             na.rm = TRUE)) %>%
         dplyr::right_join(edf, by = "id") %>%
         dplyr::select(id, from, to, rel, dplyr::everything()) %>%
         as.data.frame(stringsAsFractions = FALSE)
@@ -482,9 +481,9 @@ trav_both_edge <- function(graph,
         dplyr::arrange(e_id) %>%
         dplyr::rename(id = e_id) %>%
         dplyr::group_by(id) %>%
-        dplyr::summarize_(.dots = stats::setNames(
-          list(stats::as.formula(
-            paste0("~", agg, "(", copy_attrs_from, ", na.rm = TRUE)"))), copy_attrs_from)) %>%
+        dplyr::summarize(!! copy_attrs_from :=
+                            match.fun(!! agg)(!! as.name(copy_attrs_from),
+                                              na.rm = TRUE)) %>%
         dplyr::ungroup() %>%
         dplyr::right_join(edf, by = "id")
 

--- a/R/trav_in.R
+++ b/R/trav_in.R
@@ -334,10 +334,9 @@ trav_in <- function(graph,
       nodes <-
         nodes %>%
         dplyr::group_by(id) %>%
-        dplyr::summarize_(.dots = stats::setNames(
-          list(stats::as.formula(
-            paste0("~", agg, "(", copy_attrs_from, ", na.rm = TRUE)"))),
-          copy_attrs_from)) %>%
+        dplyr::summarize(!! copy_attrs_from :=
+                           match.fun(!! agg)(!! as.name(copy_attrs_from),
+                                             na.rm = TRUE)) %>%
         dplyr::ungroup()
     }
 

--- a/R/trav_in.R
+++ b/R/trav_in.R
@@ -325,8 +325,8 @@ trav_in <- function(graph,
       valid_nodes %>%
       dplyr::select(id) %>%
       dplyr::inner_join(edf %>% dplyr::select(from, to), by = c("id" = "from")) %>%
-      dplyr::inner_join(ndf %>% dplyr::select_("id", copy_attrs_from), by = c("to" = "id")) %>%
-      dplyr::select_("id", copy_attrs_from)
+      dplyr::inner_join(ndf %>% dplyr::select("id",!! enquo(copy_attrs_from)), by = c("to" = "id")) %>%
+      dplyr::select("id",!! enquo(copy_attrs_from))
 
     # If the values to be copied are numeric,
     # perform aggregation on the values

--- a/R/trav_in_edge.R
+++ b/R/trav_in_edge.R
@@ -312,7 +312,7 @@ trav_in_edge <- function(graph,
     ndf_2 <-
       ndf %>%
       dplyr::filter(id %in% starting_nodes) %>%
-      dplyr::select_("id", copy_attrs_from)
+      dplyr::select("id",!! enquo(copy_attrs_from))
 
     if (!is.null(copy_attrs_as)) {
 

--- a/R/trav_in_node.R
+++ b/R/trav_in_node.R
@@ -319,7 +319,7 @@ trav_in_node <- function(graph,
       starting_edges %>%
       dplyr::semi_join(valid_nodes, by = "to") %>%
       dplyr::left_join(edf, by = c("edge" = "id")) %>%
-      dplyr::select_("to.y", copy_attrs_from)
+      dplyr::select("to.y",!! enquo(copy_attrs_from))
 
 
     if (!is.null(copy_attrs_as)) {

--- a/R/trav_in_node.R
+++ b/R/trav_in_node.R
@@ -338,10 +338,9 @@ trav_in_node <- function(graph,
       nodes %>%
       dplyr::rename(id = to.y) %>%
       dplyr::group_by(id) %>%
-      dplyr::summarize_(.dots = stats::setNames(
-        list(stats::as.formula(
-          paste0("~", agg, "(", copy_attrs_from, ", na.rm = TRUE)"))),
-        copy_attrs_from)) %>%
+      dplyr::summarize(!! copy_attrs_from :=
+                         match.fun(!! agg)(!! as.name(copy_attrs_from),
+                                           na.rm = TRUE)) %>%
       dplyr::right_join(ndf, by = "id") %>%
       dplyr::select(id, type, label, dplyr::everything()) %>%
       as.data.frame(stringsAsFactors = FALSE)

--- a/R/trav_out.R
+++ b/R/trav_out.R
@@ -328,8 +328,8 @@ trav_out <- function(graph,
       valid_nodes %>%
       dplyr::select(id) %>%
       dplyr::inner_join(edf %>% dplyr::select(from, to), by = c("id" = "to")) %>%
-      dplyr::inner_join(ndf %>% dplyr::select_("id", copy_attrs_from), by = c("from" = "id")) %>%
-      dplyr::select_("id", copy_attrs_from)
+      dplyr::inner_join(ndf %>% dplyr::select("id",!! enquo(copy_attrs_from)), by = c("from" = "id")) %>%
+      dplyr::select("id",!! enquo(copy_attrs_from))
 
     # If the values to be copied are numeric,
     # perform aggregation on the values

--- a/R/trav_out.R
+++ b/R/trav_out.R
@@ -337,10 +337,9 @@ trav_out <- function(graph,
       nodes <-
         nodes %>%
         dplyr::group_by(id) %>%
-        dplyr::summarize_(.dots = stats::setNames(
-          list(stats::as.formula(
-            paste0("~", agg, "(", copy_attrs_from, ", na.rm = TRUE)"))),
-          copy_attrs_from)) %>%
+        dplyr::summarize(!! copy_attrs_from :=
+                           match.fun(!! agg)(!! as.name(copy_attrs_from),
+                                             na.rm = TRUE)) %>%
         dplyr::ungroup()
     }
 

--- a/R/trav_out_edge.R
+++ b/R/trav_out_edge.R
@@ -294,7 +294,7 @@ trav_out_edge <- function(graph,
     ndf_2 <-
       ndf %>%
       dplyr::filter(id %in% starting_nodes) %>%
-      dplyr::select_("id", copy_attrs_from)
+      dplyr::select("id",!! enquo(copy_attrs_from))
 
     if (!is.null(copy_attrs_as)) {
 

--- a/R/trav_out_node.R
+++ b/R/trav_out_node.R
@@ -336,10 +336,9 @@ trav_out_node <- function(graph,
       nodes %>%
       dplyr::rename(id = from.y) %>%
       dplyr::group_by(id) %>%
-      dplyr::summarize_(.dots = stats::setNames(
-        list(stats::as.formula(
-          paste0("~", agg, "(", copy_attrs_from, ", na.rm = TRUE)"))),
-        copy_attrs_from)) %>%
+      dplyr::summarize(!! copy_attrs_from :=
+                         match.fun(!! agg)(!! as.name(copy_attrs_from),
+                                           na.rm = TRUE)) %>%
       dplyr::right_join(ndf, by = "id") %>%
       dplyr::select(id, type, label, dplyr::everything()) %>%
       as.data.frame(stringsAsFactors = FALSE)

--- a/R/trav_out_node.R
+++ b/R/trav_out_node.R
@@ -318,7 +318,7 @@ trav_out_node <- function(graph,
       starting_edges %>%
       dplyr::semi_join(valid_nodes, by = "from") %>%
       dplyr::left_join(edf, by = c("edge" = "id")) %>%
-      dplyr::select_("from.y", copy_attrs_from)
+      dplyr::select("from.y",!! enquo(copy_attrs_from))
 
     if (!is.null(copy_attrs_as)) {
 

--- a/R/trav_reverse_edge.R
+++ b/R/trav_reverse_edge.R
@@ -113,44 +113,16 @@ trav_reverse_edge <- function(graph,
   edf <- graph$edges_df
 
   # Get the available reverse edges
-  reverse_edges <-
-    edf %>%
-    {
-      reverse_edges <- dplyr::as_tibble()
-      for (i in 1:length(edges_to)) {
-        reverse_edges <-
-          edf %>%
-          dplyr::filter_(
-            paste0(
-              "from == ",
-              edges_to[i],
-              " & to == ",
-              edges_from[i])) %>%
-          dplyr::bind_rows(reverse_edges)
-      }
-      reverse_edges
-    }
+  reverse_edges_df <- data.frame(to = edges_from, from = edges_to)
+  reverse_edges <- edf %>% dplyr::inner_join(reverse_edges_df)
 
   # Add the reverse edges to the existing,
   # selected edges
   if (add_to_selection) {
+    edges_df <- data.frame(to = edges_to, from = edges_from)
     edges <-
       edf %>%
-      {
-        edges <- dplyr::as_tibble()
-        for (i in 1:length(edges_to)) {
-          edges <-
-            edf %>%
-            dplyr::filter_(
-              paste0(
-                "from == ",
-                edges_from[i],
-                " & to == ",
-                edges_to[i])) %>%
-            dplyr::bind_rows(edges)
-        }
-        edges
-      } %>%
+      dplyr::inner_join(edges_df) %>%
       dplyr::bind_rows(reverse_edges)
   } else {
     edges <- reverse_edges

--- a/R/utils.R
+++ b/R/utils.R
@@ -240,12 +240,12 @@ is_attr_unique_and_non_na <- function(graph,
 
   # Are all values not NA?
   all_is_not_na <-
-    df %>% dplyr::select_(attr) %>%
+    df %>% dplyr::select(!! enquo(attr)) %>%
     is.na %>% magrittr::not() %>% all()
 
   # Are all values distinct?
   all_values_distinct <-
-    df %>% dplyr::select_(attr) %>% dplyr::distinct() %>% nrow() ==
+    df %>% dplyr::select(!! enquo(attr)) %>% dplyr::distinct() %>% nrow() ==
     nrow(df)
 
   if (all_is_not_na & all_values_distinct) {


### PR DESCRIPTION
I had saw that there were many warnings generated on tests, mostly because the deprecated dplyr underscore functions (like "select_") were being used. This removes those warnings and moves to the new dplyr style of using !! and quosures.

I did my best to make the minimal changes to move to the new functions, but in some cases I simplified the code because it was easier.