### PR TITLE
Add @family to link node, edge, and save/view documentation

### DIFF
--- a/R/add_edge.R
+++ b/R/add_edge.R
@@ -100,6 +100,7 @@
 #' # newly created edge
 #' graph_2 %>% get_edge_df()
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 add_edge <- function(graph,
                      from,

--- a/R/add_edge_clone.R
+++ b/R/add_edge_clone.R
@@ -63,6 +63,7 @@
 #' # Display the graph's internal
 #' # edge data frame
 #' graph_3 %>% get_edge_df()
+#' @family Edge creation and removal
 #' @export
 add_edge_clone <- function(graph,
                            edge,

--- a/R/add_edge_df.R
+++ b/R/add_edge_df.R
@@ -36,6 +36,7 @@
 #' graph %>%
 #'   get_edges(
 #'     return_type = "vector")
+#' @family Edge creation and removal
 #' @export
 add_edge_df <- function(graph,
                         edge_df) {

--- a/R/add_edges_from_table.R
+++ b/R/add_edges_from_table.R
@@ -79,6 +79,7 @@
 #'   get_edge_df() %>%
 #'   head()
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 add_edges_from_table <- function(graph,
                                  table,

--- a/R/add_edges_w_string.R
+++ b/R/add_edges_w_string.R
@@ -56,6 +56,7 @@
 #' # edge data frame (it's the
 #' # same as before)
 #' graph_node_label %>% get_edge_df()
+#' @family Edge creation and removal
 #' @export
 add_edges_w_string <- function(graph,
                                edges,

--- a/R/add_forward_edges_ws.R
+++ b/R/add_forward_edges_ws.R
@@ -53,6 +53,7 @@
 #' # Get the graph's edge data frame
 #' graph %>% get_edge_df()
 #'
+#' @family Edge creation and removal
 #' @export
 add_forward_edges_ws <- function(graph,
                                  rel = NULL) {

--- a/R/add_n_node_clones.R
+++ b/R/add_n_node_clones.R
@@ -44,7 +44,7 @@
 #' # node data frame: nodes `4`,
 #' # `5`, and `6` are clones of `1`
 #' graph %>% get_node_df()
-#'
+#' @family Node creation and removal
 #' @export
 add_n_node_clones <- function(graph,
                               n,

--- a/R/add_n_nodes.R
+++ b/R/add_n_nodes.R
@@ -24,7 +24,7 @@
 #'
 #' # Get the graph's node IDs
 #' graph %>% get_node_ids()
-#'
+#' @family Node creation and removal
 #' @export
 add_n_nodes <- function(graph,
                         n,

--- a/R/add_n_nodes_ws.R
+++ b/R/add_n_nodes_ws.R
@@ -72,7 +72,7 @@
 #'
 #' # Get the graph's edges
 #' graph %>% get_edges()
-#'
+#' @family Node creation and removal
 #' @export
 add_n_nodes_ws <- function(graph,
                            n,

--- a/R/add_node.R
+++ b/R/add_node.R
@@ -44,7 +44,7 @@
 #' # View the graph's internal
 #' # node data frame (ndf)
 #' graph %>% get_node_df()
-#'
+#' @family Node creation and removal
 #' @export
 add_node <- function(graph,
                      type = NULL,

--- a/R/add_node_clones_ws.R
+++ b/R/add_node_clones_ws.R
@@ -82,7 +82,7 @@
 #' # edges between the selected
 #' # nodes and their clones
 #' graph %>% get_edge_df()
-#'
+#' @family Node creation and removal
 #' @export
 add_node_clones_ws <- function(graph,
                                add_edges = FALSE,

--- a/R/add_node_df.R
+++ b/R/add_node_df.R
@@ -44,7 +44,7 @@
 #' # node data frame using the
 #' # `get_node_df()` function
 #' graph %>% get_node_df()
-#'
+#' @family Node creation and removal
 #' @export
 add_node_df <- function(graph,
                         node_df) {

--- a/R/add_nodes_from_df_cols.R
+++ b/R/add_nodes_from_df_cols.R
@@ -63,7 +63,7 @@
 #' # get made with columns that
 #' # are not character class columns
 #' graph %>% get_node_df()
-#'
+#' @family Node creation and removal
 #' @export
 add_nodes_from_df_cols <- function(graph,
                                    df,

--- a/R/add_nodes_from_table.R
+++ b/R/add_nodes_from_table.R
@@ -84,6 +84,7 @@
 #'   colnames()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 add_nodes_from_table <- function(graph,
                                  table,

--- a/R/add_reverse_edges_ws.R
+++ b/R/add_reverse_edges_ws.R
@@ -57,6 +57,7 @@
 #' # Get the graph's edge data frame
 #' graph %>% get_edge_df()
 #'
+#' @family Edge creation and removal
 #' @export
 add_reverse_edges_ws <- function(graph,
                                  rel = NULL,

--- a/R/colorize_node_attrs.R
+++ b/R/colorize_node_attrs.R
@@ -104,6 +104,7 @@
 #'
 #' @import RColorBrewer
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 colorize_node_attrs <- function(graph,
                                 node_attr_from,

--- a/R/copy_edge_attrs.R
+++ b/R/copy_edge_attrs.R
@@ -45,6 +45,7 @@
 #' graph %>% get_edge_df()
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 copy_edge_attrs <- function(graph,
                             edge_attr_from,

--- a/R/copy_node_attrs.R
+++ b/R/copy_node_attrs.R
@@ -51,6 +51,7 @@
 #' graph %>% get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 copy_node_attrs <- function(graph,
                             node_attr_from,

--- a/R/create_edge_df.R
+++ b/R/create_edge_df.R
@@ -53,6 +53,7 @@
 #' # Display the edge data frame
 #' edf
 #'
+#' @family Edge creation and removal
 #' @export
 create_edge_df <- function(from,
                            to,

--- a/R/create_node_df.R
+++ b/R/create_node_df.R
@@ -53,7 +53,7 @@
 #'
 #' # Display the node data frame
 #' node_df
-#'
+#' @family Node creation and removal
 #' @export
 create_node_df <- function(n,
                            type = NULL,

--- a/R/delete_edge.R
+++ b/R/delete_edge.R
@@ -90,6 +90,7 @@
 #'     to = "two") %>%
 #'   count_edges()
 #'
+#' @family Edge creation and removal
 #' @export
 delete_edge <- function(graph,
                         from = NULL,

--- a/R/delete_edges_ws.R
+++ b/R/delete_edges_ws.R
@@ -40,7 +40,7 @@
 #'
 #' # Get a count of edges in the graph
 #' graph %>% count_edges()
-#'
+#' @family Edge creation and removal
 #' @export
 delete_edges_ws <- function(graph) {
 

--- a/R/delete_loop_edges_ws.R
+++ b/R/delete_loop_edges_ws.R
@@ -41,7 +41,7 @@
 #' # Count the number of loop
 #' # edges remaining in the graph
 #' graph %>% count_loop_edges()
-#'
+#' @family Edge creation and removal
 #' @export
 delete_loop_edges_ws <- function(graph) {
 

--- a/R/delete_node.R
+++ b/R/delete_node.R
@@ -26,7 +26,7 @@
 #' # since there were edges between the
 #' # removed node to and from other nodes
 #' graph %>% get_edges()
-#'
+#' @family Node creation and removal
 #' @export
 delete_node <- function(graph,
                         node) {

--- a/R/delete_nodes_ws.R
+++ b/R/delete_nodes_ws.R
@@ -41,7 +41,7 @@
 #'
 #' # Get a count of nodes in the graph
 #' graph %>% count_nodes()
-#'
+#' @family Node creation and removal
 #' @export
 delete_nodes_ws <- function(graph) {
 

--- a/R/docs_node_edge_aes_data.R
+++ b/R/docs_node_edge_aes_data.R
@@ -15,4 +15,5 @@
 #'   attributes. The helper function [edge_data()] is strongly recommended for
 #'   use here as it helps bind data specifically to the created edges.
 #' @name node_edge_aes_data
+#' @family Aesthetics
 NULL

--- a/R/drop_edge_attrs.R
+++ b/R/drop_edge_attrs.R
@@ -42,6 +42,7 @@
 #' graph %>% get_edge_df()
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 drop_edge_attrs <- function(graph,
                             edge_attr) {

--- a/R/drop_node_attrs.R
+++ b/R/drop_node_attrs.R
@@ -41,6 +41,7 @@
 #' graph %>% get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 drop_node_attrs <- function(graph,
                             node_attr) {

--- a/R/edge_aes.R
+++ b/R/edge_aes.R
@@ -117,7 +117,7 @@
 #' # been inserted
 #' graph %>%
 #'   get_edge_df()
-#'
+#' @family Aesthetics
 #' @export
 edge_aes <- function(style = NULL,
                      penwidth = NULL,

--- a/R/edge_data.R
+++ b/R/edge_data.R
@@ -25,7 +25,7 @@
 #' # been inserted
 #' graph %>% get_edge_df()
 #' }
-#'
+#' @family Edge creation and removal
 #' @export
 edge_data <- function(...) {
 

--- a/R/export_graph.R
+++ b/R/export_graph.R
@@ -46,7 +46,7 @@
 #' #     file_name = "mypng.png",
 #' #     file_type = "PNG"
 #' #   )
-#'
+#' @family Display and Save
 #' @export
 export_graph <- function(graph,
                          file_name = NULL,

--- a/R/join_edge_attrs.R
+++ b/R/join_edge_attrs.R
@@ -50,7 +50,7 @@
 #' # Get the graph's internal edf to show that the
 #' # join has been made
 #' graph %>% get_edge_df()
-#'
+#' @family Edge creation and removal
 #' @export
 join_edge_attrs <- function(graph,
                             df,

--- a/R/join_node_attrs.R
+++ b/R/join_node_attrs.R
@@ -61,7 +61,7 @@
 #' # Get the graph's internal ndf to show that
 #' # this join has been made
 #' graph %>% get_node_df()
-#'
+#' @family Node creation and removal
 #' @export
 join_node_attrs <- function(graph,
                             df,

--- a/R/layout_nodes_w_string.R
+++ b/R/layout_nodes_w_string.R
@@ -76,7 +76,7 @@
 #' # to confirm that `x` and `y` values
 #' # were added to each of the nodes
 #' graph %>% get_node_df()
-#'
+#' @family Node creation and removal
 #' @export
 layout_nodes_w_string <- function(graph,
                                   layout,

--- a/R/mutate_edge_attrs.R
+++ b/R/mutate_edge_attrs.R
@@ -72,6 +72,7 @@
 #' graph %>% get_edge_df()
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 mutate_edge_attrs <- function(graph,
                               ...) {

--- a/R/mutate_edge_attrs_ws.R
+++ b/R/mutate_edge_attrs_ws.R
@@ -114,6 +114,7 @@
 #' graph %>% get_edge_df()
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 mutate_edge_attrs_ws <- function(graph,
                                  ...) {

--- a/R/mutate_node_attrs.R
+++ b/R/mutate_node_attrs.R
@@ -72,6 +72,7 @@
 #' graph %>% get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 mutate_node_attrs <- function(graph,
                               ...) {

--- a/R/mutate_node_attrs_ws.R
+++ b/R/mutate_node_attrs_ws.R
@@ -116,6 +116,7 @@
 #' graph %>% get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 mutate_node_attrs_ws <- function(graph,
                                  ...) {

--- a/R/node_aes.R
+++ b/R/node_aes.R
@@ -114,7 +114,7 @@
 #'     ),
 #'     edge_aes = edge_aes(color = "blue")
 #'   )
-#'
+#' @family Aesthetics
 #' @export
 node_aes <- function(shape = NULL,
                      style = NULL,

--- a/R/node_data.R
+++ b/R/node_data.R
@@ -23,7 +23,7 @@
 #' # data attributes have been
 #' # inserted
 #' graph %>% get_node_df()
-#'
+#' @family Node creation and removal
 #' @export
 node_data <- function(...) {
 

--- a/R/recode_edge_attrs.R
+++ b/R/recode_edge_attrs.R
@@ -60,6 +60,7 @@
 #' graph %>% get_edge_df()
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 recode_edge_attrs <- function(graph,
                               edge_attr_from,

--- a/R/recode_node_attrs.R
+++ b/R/recode_node_attrs.R
@@ -74,6 +74,7 @@
 #' graph %>% get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 recode_node_attrs <- function(graph,
                               node_attr_from,

--- a/R/rename_edge_attrs.R
+++ b/R/rename_edge_attrs.R
@@ -42,6 +42,7 @@
 #' graph %>% get_edge_df()
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 rename_edge_attrs <- function(graph,
                               edge_attr_from,

--- a/R/rename_node_attrs.R
+++ b/R/rename_node_attrs.R
@@ -48,6 +48,7 @@
 #' graph %>% get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 rename_node_attrs <- function(graph,
                               node_attr_from,

--- a/R/render_graph.R
+++ b/R/render_graph.R
@@ -59,6 +59,7 @@
 #' }
 #'
 #' @import glue glue
+#' @family Display and Save
 #' @export
 render_graph <- function(graph,
                          layout = NULL,

--- a/R/render_graph_from_graph_series.R
+++ b/R/render_graph_from_graph_series.R
@@ -44,6 +44,7 @@
 #'   graph_series = series,
 #'   graph_no = 2)
 #' }
+#' @family Display and Save
 #' @export
 render_graph_from_graph_series <- function(graph_series,
                                            graph_no,

--- a/R/rescale_edge_attrs.R
+++ b/R/rescale_edge_attrs.R
@@ -85,6 +85,7 @@
 #' graph %>% get_edge_df()
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 rescale_edge_attrs <- function(graph,
                                edge_attr_from,

--- a/R/rescale_node_attrs.R
+++ b/R/rescale_node_attrs.R
@@ -82,6 +82,7 @@
 #' graph %>% get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 rescale_node_attrs <- function(graph,
                                node_attr_from,

--- a/R/rev_edge_dir.R
+++ b/R/rev_edge_dir.R
@@ -28,7 +28,7 @@
 #' # Inspect the graph's edges
 #' # after their reversal
 #' graph %>% get_edges()
-#'
+#' @family Edge creation and removal
 #' @export
 rev_edge_dir <- function(graph) {
 

--- a/R/rev_edge_dir_ws.R
+++ b/R/rev_edge_dir_ws.R
@@ -46,7 +46,7 @@
 #' # Inspect the graph's edges
 #' # after their reversal
 #' graph %>% get_edges()
-#'
+#' @family Edge creation and removal
 #' @export
 rev_edge_dir_ws <- function(graph) {
 

--- a/R/save_graph.R
+++ b/R/save_graph.R
@@ -30,7 +30,7 @@
 #' #   open_graph(
 #' #     file = "gnp_graph.dgr"
 #' # )
-#'
+#' @family Display and Save
 #' @export
 save_graph <- function(x,
                        file) {

--- a/R/set_df_as_edge_attr.R
+++ b/R/set_df_as_edge_attr.R
@@ -50,7 +50,7 @@
 #'   set_df_as_edge_attr(
 #'     edge = 1,
 #'     df = df)
-#'
+#' @family Edge creation and removal
 #' @export
 set_df_as_edge_attr <- function(graph,
                                 edge,

--- a/R/set_df_as_node_attr.R
+++ b/R/set_df_as_node_attr.R
@@ -65,7 +65,7 @@
 #'   set_df_as_node_attr(
 #'     node = 2,
 #'     df = df_2)
-#'
+#' @family Node creation and removal
 #' @export
 set_df_as_node_attr <- function(graph,
                                 node,

--- a/R/set_edge_attr_to_display.R
+++ b/R/set_edge_attr_to_display.R
@@ -68,6 +68,7 @@
 #'   get_edge_df()
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 set_edge_attr_to_display <- function(graph,
                                      attr = NULL,

--- a/R/set_edge_attrs.R
+++ b/R/set_edge_attrs.R
@@ -74,6 +74,7 @@
 #'     to = 1)
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 set_edge_attrs <- function(graph,
                            edge_attr,

--- a/R/set_edge_attrs_ws.R
+++ b/R/set_edge_attrs_ws.R
@@ -46,6 +46,7 @@
 #' graph %>% get_edge_df()
 #'
 #' @import rlang
+#' @family Edge creation and removal
 #' @export
 set_edge_attrs_ws <- function(graph,
                               edge_attr,

--- a/R/set_node_attr_to_display.R
+++ b/R/set_node_attr_to_display.R
@@ -68,6 +68,7 @@
 #'   get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 set_node_attr_to_display <- function(graph,
                                      attr = NULL,

--- a/R/set_node_attr_w_fcn.R
+++ b/R/set_node_attr_w_fcn.R
@@ -92,7 +92,7 @@
 #' # Inspect the graph's internal
 #' # node data frame
 #' graph_3 %>% get_node_df()
-#'
+#' @family Node creation and removal
 #' @export
 set_node_attr_w_fcn <- function(graph,
                                 node_attr_fcn,

--- a/R/set_node_attrs.R
+++ b/R/set_node_attrs.R
@@ -58,6 +58,7 @@
 #' graph %>% get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 set_node_attrs <- function(graph,
                            node_attr,

--- a/R/set_node_attrs_ws.R
+++ b/R/set_node_attrs_ws.R
@@ -47,6 +47,7 @@
 #' graph %>% get_node_df()
 #'
 #' @import rlang
+#' @family Node creation and removal
 #' @export
 set_node_attrs_ws <- function(graph,
                               node_attr,

--- a/R/set_node_position.R
+++ b/R/set_node_position.R
@@ -87,7 +87,7 @@
 #'
 #' # View the graph's node data frame
 #' graph %>% get_node_df()
-#'
+#' @family Node creation and removal
 #' @export
 set_node_position <- function(graph,
                               node,

--- a/man/add_edge.Rd
+++ b/man/add_edge.Rd
@@ -120,3 +120,32 @@ graph_2 <-
 # newly created edge
 graph_2 \%>\% get_edge_df()
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/add_edge_clone.Rd
+++ b/man/add_edge_clone.Rd
@@ -76,3 +76,32 @@ graph_3 <-
 # edge data frame
 graph_3 \%>\% get_edge_df()
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/add_edge_df.Rd
+++ b/man/add_edge_df.Rd
@@ -47,3 +47,32 @@ graph \%>\%
   get_edges(
     return_type = "vector")
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/add_edges_from_table.Rd
+++ b/man/add_edges_from_table.Rd
@@ -104,3 +104,32 @@ graph_2 \%>\%
   get_edge_df() \%>\%
   head()
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/add_edges_w_string.Rd
+++ b/man/add_edges_w_string.Rd
@@ -69,3 +69,32 @@ graph_node_label <-
 # same as before)
 graph_node_label \%>\% get_edge_df()
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/add_forward_edges_ws.Rd
+++ b/man/add_forward_edges_ws.Rd
@@ -65,3 +65,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/add_n_node_clones.Rd
+++ b/man/add_n_node_clones.Rd
@@ -56,5 +56,35 @@ graph <-
 # node data frame: nodes `4`,
 # `5`, and `6` are clones of `1`
 graph \%>\% get_node_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/add_n_nodes.Rd
+++ b/man/add_n_nodes.Rd
@@ -51,5 +51,35 @@ graph <-
 
 # Get the graph's node IDs
 graph \%>\% get_node_ids()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/add_n_nodes_ws.Rd
+++ b/man/add_n_nodes_ws.Rd
@@ -115,5 +115,35 @@ graph \%>\% get_node_ids()
 
 # Get the graph's edges
 graph \%>\% get_edges()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/add_node.Rd
+++ b/man/add_node.Rd
@@ -84,5 +84,35 @@ graph <-
 # View the graph's internal
 # node data frame (ndf)
 graph \%>\% get_node_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/add_node_clones_ws.Rd
+++ b/man/add_node_clones_ws.Rd
@@ -95,5 +95,35 @@ graph <-
 # edges between the selected
 # nodes and their clones
 graph \%>\% get_edge_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/add_node_df.Rd
+++ b/man/add_node_df.Rd
@@ -54,5 +54,35 @@ graph <-
 # node data frame using the
 # `get_node_df()` function
 graph \%>\% get_node_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/add_nodes_from_df_cols.Rd
+++ b/man/add_nodes_from_df_cols.Rd
@@ -82,5 +82,35 @@ graph <-
 # get made with columns that
 # are not character class columns
 graph \%>\% get_node_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/add_nodes_from_table.Rd
+++ b/man/add_nodes_from_table.Rd
@@ -105,3 +105,34 @@ graph_3 \%>\%
   colnames()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/add_reverse_edges_ws.Rd
+++ b/man/add_reverse_edges_ws.Rd
@@ -77,3 +77,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/colorize_node_attrs.Rd
+++ b/man/colorize_node_attrs.Rd
@@ -128,3 +128,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/copy_edge_attrs.Rd
+++ b/man/copy_edge_attrs.Rd
@@ -56,3 +56,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/copy_node_attrs.Rd
+++ b/man/copy_node_attrs.Rd
@@ -62,3 +62,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/create_edge_df.Rd
+++ b/man/create_edge_df.Rd
@@ -66,3 +66,32 @@ edf <-
 edf
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/create_node_df.Rd
+++ b/man/create_node_df.Rd
@@ -66,5 +66,35 @@ node_df <-
 
 # Display the node data frame
 node_df
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/delete_edge.Rd
+++ b/man/delete_edge.Rd
@@ -104,3 +104,32 @@ graph_labeled_nodes \%>\%
   count_edges()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/delete_edges_ws.Rd
+++ b/man/delete_edges_ws.Rd
@@ -50,5 +50,33 @@ graph <-
 
 # Get a count of edges in the graph
 graph \%>\% count_edges()
-
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/delete_loop_edges_ws.Rd
+++ b/man/delete_loop_edges_ws.Rd
@@ -51,5 +51,33 @@ graph <-
 # Count the number of loop
 # edges remaining in the graph
 graph \%>\% count_loop_edges()
-
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/delete_node.Rd
+++ b/man/delete_node.Rd
@@ -36,5 +36,35 @@ graph \%>\% get_node_ids()
 # since there were edges between the
 # removed node to and from other nodes
 graph \%>\% get_edges()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/delete_nodes_ws.Rd
+++ b/man/delete_nodes_ws.Rd
@@ -51,5 +51,35 @@ graph <-
 
 # Get a count of nodes in the graph
 graph \%>\% count_nodes()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/drop_edge_attrs.Rd
+++ b/man/drop_edge_attrs.Rd
@@ -52,3 +52,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/drop_node_attrs.Rd
+++ b/man/drop_node_attrs.Rd
@@ -51,3 +51,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/edge_aes.Rd
+++ b/man/edge_aes.Rd
@@ -189,5 +189,10 @@ graph <-
 # been inserted
 graph \%>\%
   get_edge_df()
-
 }
+\seealso{
+Other Aesthetics: 
+\code{\link{node_aes}()},
+\code{\link{node_edge_aes_data}}
+}
+\concept{Aesthetics}

--- a/man/edge_data.Rd
+++ b/man/edge_data.Rd
@@ -34,5 +34,33 @@ graph <-
 # been inserted
 graph \%>\% get_edge_df()
 }
-
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/export_graph.Rd
+++ b/man/export_graph.Rd
@@ -66,5 +66,11 @@ graph <-
 #     file_name = "mypng.png",
 #     file_type = "PNG"
 #   )
-
 }
+\seealso{
+Other Display and Save: 
+\code{\link{render_graph_from_graph_series}()},
+\code{\link{render_graph}()},
+\code{\link{save_graph}()}
+}
+\concept{Display and Save}

--- a/man/join_edge_attrs.Rd
+++ b/man/join_edge_attrs.Rd
@@ -62,5 +62,33 @@ graph <-
 # Get the graph's internal edf to show that the
 # join has been made
 graph \%>\% get_edge_df()
-
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/join_node_attrs.Rd
+++ b/man/join_node_attrs.Rd
@@ -73,5 +73,35 @@ graph <-
 # Get the graph's internal ndf to show that
 # this join has been made
 graph \%>\% get_node_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/layout_nodes_w_string.Rd
+++ b/man/layout_nodes_w_string.Rd
@@ -98,5 +98,35 @@ graph <-
 # to confirm that `x` and `y` values
 # were added to each of the nodes
 graph \%>\% get_node_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/mutate_edge_attrs.Rd
+++ b/man/mutate_edge_attrs.Rd
@@ -82,3 +82,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/mutate_edge_attrs_ws.Rd
+++ b/man/mutate_edge_attrs_ws.Rd
@@ -125,3 +125,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/mutate_node_attrs.Rd
+++ b/man/mutate_node_attrs.Rd
@@ -82,3 +82,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/mutate_node_attrs_ws.Rd
+++ b/man/mutate_node_attrs_ws.Rd
@@ -127,3 +127,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/node_aes.Rd
+++ b/man/node_aes.Rd
@@ -175,5 +175,10 @@ graph <-
     ),
     edge_aes = edge_aes(color = "blue")
   )
-
 }
+\seealso{
+Other Aesthetics: 
+\code{\link{edge_aes}()},
+\code{\link{node_edge_aes_data}}
+}
+\concept{Aesthetics}

--- a/man/node_data.Rd
+++ b/man/node_data.Rd
@@ -32,5 +32,35 @@ graph <-
 # data attributes have been
 # inserted
 graph \%>\% get_node_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/node_edge_aes_data.Rd
+++ b/man/node_edge_aes_data.Rd
@@ -25,3 +25,9 @@ use here as it helps bind data specifically to the created edges.}
 \description{
 Options for node and edge aesthetics and data
 }
+\seealso{
+Other Aesthetics: 
+\code{\link{edge_aes}()},
+\code{\link{node_aes}()}
+}
+\concept{Aesthetics}

--- a/man/recode_edge_attrs.Rd
+++ b/man/recode_edge_attrs.Rd
@@ -78,3 +78,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/recode_node_attrs.Rd
+++ b/man/recode_node_attrs.Rd
@@ -92,3 +92,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/rename_edge_attrs.Rd
+++ b/man/rename_edge_attrs.Rd
@@ -53,3 +53,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/rename_node_attrs.Rd
+++ b/man/rename_node_attrs.Rd
@@ -59,3 +59,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/render_graph.Rd
+++ b/man/render_graph.Rd
@@ -82,3 +82,10 @@ create_graph() \%>\%
 }
 
 }
+\seealso{
+Other Display and Save: 
+\code{\link{export_graph}()},
+\code{\link{render_graph_from_graph_series}()},
+\code{\link{save_graph}()}
+}
+\concept{Display and Save}

--- a/man/render_graph_from_graph_series.Rd
+++ b/man/render_graph_from_graph_series.Rd
@@ -64,3 +64,10 @@ render_graph_from_graph_series(
   graph_no = 2)
 }
 }
+\seealso{
+Other Display and Save: 
+\code{\link{export_graph}()},
+\code{\link{render_graph}()},
+\code{\link{save_graph}()}
+}
+\concept{Display and Save}

--- a/man/rescale_edge_attrs.Rd
+++ b/man/rescale_edge_attrs.Rd
@@ -108,3 +108,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/rescale_node_attrs.Rd
+++ b/man/rescale_node_attrs.Rd
@@ -105,3 +105,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/rev_edge_dir.Rd
+++ b/man/rev_edge_dir.Rd
@@ -37,5 +37,33 @@ graph <-
 # Inspect the graph's edges
 # after their reversal
 graph \%>\% get_edges()
-
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/rev_edge_dir_ws.Rd
+++ b/man/rev_edge_dir_ws.Rd
@@ -56,5 +56,33 @@ graph <-
 # Inspect the graph's edges
 # after their reversal
 graph \%>\% get_edges()
-
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/save_graph.Rd
+++ b/man/save_graph.Rd
@@ -40,5 +40,11 @@ gnp_graph <-
 #   open_graph(
 #     file = "gnp_graph.dgr"
 # )
-
 }
+\seealso{
+Other Display and Save: 
+\code{\link{export_graph}()},
+\code{\link{render_graph_from_graph_series}()},
+\code{\link{render_graph}()}
+}
+\concept{Display and Save}

--- a/man/set_df_as_edge_attr.Rd
+++ b/man/set_df_as_edge_attr.Rd
@@ -61,5 +61,33 @@ graph <-
   set_df_as_edge_attr(
     edge = 1,
     df = df)
-
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/set_df_as_node_attr.Rd
+++ b/man/set_df_as_node_attr.Rd
@@ -76,5 +76,35 @@ graph <-
   set_df_as_node_attr(
     node = 2,
     df = df_2)
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/set_edge_attr_to_display.Rd
+++ b/man/set_edge_attr_to_display.Rd
@@ -80,3 +80,32 @@ graph \%>\%
   get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attrs_ws}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/set_edge_attrs.Rd
+++ b/man/set_edge_attrs.Rd
@@ -87,3 +87,32 @@ graph <-
     to = 1)
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs_ws}()}
+}
+\concept{Edge creation and removal}

--- a/man/set_edge_attrs_ws.Rd
+++ b/man/set_edge_attrs_ws.Rd
@@ -58,3 +58,32 @@ graph <-
 graph \%>\% get_edge_df()
 
 }
+\seealso{
+Other Edge creation and removal: 
+\code{\link{add_edge_clone}()},
+\code{\link{add_edge_df}()},
+\code{\link{add_edges_from_table}()},
+\code{\link{add_edges_w_string}()},
+\code{\link{add_edge}()},
+\code{\link{add_forward_edges_ws}()},
+\code{\link{add_reverse_edges_ws}()},
+\code{\link{copy_edge_attrs}()},
+\code{\link{create_edge_df}()},
+\code{\link{delete_edges_ws}()},
+\code{\link{delete_edge}()},
+\code{\link{delete_loop_edges_ws}()},
+\code{\link{drop_edge_attrs}()},
+\code{\link{edge_data}()},
+\code{\link{join_edge_attrs}()},
+\code{\link{mutate_edge_attrs_ws}()},
+\code{\link{mutate_edge_attrs}()},
+\code{\link{recode_edge_attrs}()},
+\code{\link{rename_edge_attrs}()},
+\code{\link{rescale_edge_attrs}()},
+\code{\link{rev_edge_dir_ws}()},
+\code{\link{rev_edge_dir}()},
+\code{\link{set_df_as_edge_attr}()},
+\code{\link{set_edge_attr_to_display}()},
+\code{\link{set_edge_attrs}()}
+}
+\concept{Edge creation and removal}

--- a/man/set_node_attr_to_display.Rd
+++ b/man/set_node_attr_to_display.Rd
@@ -80,3 +80,34 @@ graph \%>\%
   get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/set_node_attr_w_fcn.Rd
+++ b/man/set_node_attr_w_fcn.Rd
@@ -104,5 +104,35 @@ graph_3 <-
 # Inspect the graph's internal
 # node data frame
 graph_3 \%>\% get_node_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/set_node_attrs.Rd
+++ b/man/set_node_attrs.Rd
@@ -70,3 +70,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/set_node_attrs_ws.Rd
+++ b/man/set_node_attrs_ws.Rd
@@ -59,3 +59,34 @@ graph <-
 graph \%>\% get_node_df()
 
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs}()},
+\code{\link{set_node_position}()}
+}
+\concept{Node creation and removal}

--- a/man/set_node_position.Rd
+++ b/man/set_node_position.Rd
@@ -100,5 +100,35 @@ graph <-
 
 # View the graph's node data frame
 graph \%>\% get_node_df()
-
 }
+\seealso{
+Other Node creation and removal: 
+\code{\link{add_n_node_clones}()},
+\code{\link{add_n_nodes_ws}()},
+\code{\link{add_n_nodes}()},
+\code{\link{add_node_clones_ws}()},
+\code{\link{add_node_df}()},
+\code{\link{add_nodes_from_df_cols}()},
+\code{\link{add_nodes_from_table}()},
+\code{\link{add_node}()},
+\code{\link{colorize_node_attrs}()},
+\code{\link{copy_node_attrs}()},
+\code{\link{create_node_df}()},
+\code{\link{delete_nodes_ws}()},
+\code{\link{delete_node}()},
+\code{\link{drop_node_attrs}()},
+\code{\link{join_node_attrs}()},
+\code{\link{layout_nodes_w_string}()},
+\code{\link{mutate_node_attrs_ws}()},
+\code{\link{mutate_node_attrs}()},
+\code{\link{node_data}()},
+\code{\link{recode_node_attrs}()},
+\code{\link{rename_node_attrs}()},
+\code{\link{rescale_node_attrs}()},
+\code{\link{set_df_as_node_attr}()},
+\code{\link{set_node_attr_to_display}()},
+\code{\link{set_node_attr_w_fcn}()},
+\code{\link{set_node_attrs_ws}()},
+\code{\link{set_node_attrs}()}
+}
+\concept{Node creation and removal}


### PR DESCRIPTION
This is a documentation-only PR.  It adds `@family` sections to many help files to link them together and help the user find various functions.