### PR TITLE
Fix bug "clusters from data.frames broken? #403"

### DIFF
--- a/R/generate_dot.R
+++ b/R/generate_dot.R
@@ -452,7 +452,6 @@ generate_dot <- function(graph) {
       } else if ('cluster' %in% colnames(nodes_df)) {
 
         cluster_vals <- nodes_df$cluster
-        cluster_vals[cluster_vals == ""] <- NA_character_
 
         clustered_node_block <- character(0)
         clusters <- split(node_block, cluster_vals)


### PR DESCRIPTION
Fixes rich-iannone/DiagrammeR#403

Fix bug where unclustered nodes were being deleted if other nodes that are in clusters were present.  Problem was this line which has been deleted:
          cluster_vals[cluster_vals == ""] <- NA_character_
made the non-clustered nodes get dropped when this line got run:
          clusters <- split(node_block, cluster_vals)
Since elsewhere in the code, all NA values are converted to "", keeping non-clustered nodes with the "" value avoids them being dropped by split().