### PR TITLE
add envir arguments to grViz and replace_in_spec

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # DiagrammeR 1.0.6.9000 (Unreleased)
 
+* Added the `envir` argument to the `grViz` and `replace_in_spec` functions.
+
 # DiagrammeR 1.0.6.1
 
 * Removed the `set_df_as_node_attr()`, `set_df_as_edge_attr()`, and `get_attr_dfs()` functions.

--- a/R/grViz.R
+++ b/R/grViz.R
@@ -14,6 +14,7 @@
 #'   graphic in pixels.
 #' @param height An optional parameter for specifying the height of the
 #'   resulting graphic in pixels.
+#' @param envir The environment in which substitution functionality takes place.
 #'
 #' @return An object of class `htmlwidget` that will intelligently print itself
 #'   into HTML in a variety of contexts including the R console, within R
@@ -25,7 +26,8 @@ grViz <- function(diagram = "",
                   allow_subst = TRUE,
                   options = NULL,
                   width = NULL,
-                  height = NULL) {
+                  height = NULL,
+                  envir = parent.frame()) {
 
   # Check for a connection or file
   if (inherits(diagram, "connection") ||
@@ -45,7 +47,7 @@ grViz <- function(diagram = "",
   }
 
   if (allow_subst == TRUE) {
-    diagram <- replace_in_spec(diagram)
+    diagram <- replace_in_spec(diagram, envir = envir)
   }
 
   # Single quotes within a diagram spec are problematic

--- a/R/spectools.R
+++ b/R/spectools.R
@@ -3,6 +3,7 @@
 #' Use Razor-like syntax to define a template for use in a `grViz` diagram.
 #'
 #' @param spec String spec to be parsed and evaluated.
+#' @inheritParams grViz
 #' @examples
 #' \dontrun{
 #' # a simple example to use a LETTER as a node label
@@ -37,7 +38,7 @@
 #' }
 #'
 #' @export
-replace_in_spec <- function(spec) {
+replace_in_spec <- function(spec, envir = parent.frame()) {
 
   # Directive for marking subscripted text in a label or tooltip '@_'
   if (grepl("@_", spec)) {
@@ -95,7 +96,7 @@ replace_in_spec <- function(spec) {
       eval_expressions <-
         c(
           eval_expressions,
-          list(eval(parse(text = split_references[i])))
+          list(eval(parse(text = split_references[i]), envir = envir))
         )
     }
 

--- a/man/grViz.Rd
+++ b/man/grViz.Rd
@@ -10,7 +10,8 @@ grViz(
   allow_subst = TRUE,
   options = NULL,
   width = NULL,
-  height = NULL
+  height = NULL,
+  envir = parent.frame()
 )
 }
 \arguments{
@@ -30,6 +31,8 @@ graphic in pixels.}
 
 \item{height}{An optional parameter for specifying the height of the
 resulting graphic in pixels.}
+
+\item{envir}{The environment in which substitution functionality takes place.}
 }
 \value{
 An object of class \code{htmlwidget} that will intelligently print itself

--- a/man/replace_in_spec.Rd
+++ b/man/replace_in_spec.Rd
@@ -4,10 +4,12 @@
 \alias{replace_in_spec}
 \title{Razor-like template for diagram specification}
 \usage{
-replace_in_spec(spec)
+replace_in_spec(spec, envir = parent.frame())
 }
 \arguments{
 \item{spec}{String spec to be parsed and evaluated.}
+
+\item{envir}{The environment in which substitution functionality takes place.}
 }
 \description{
 Use Razor-like syntax to define a template for use in a \code{grViz} diagram.


### PR DESCRIPTION
Currently, `replace_in_spec` calls `eval` with its default `envir` argument (i.e, `parent.frame()`).
This may cause object not found error in some cases.
Below is an reproducible example, which results error due to the `knit` parameter on YAML front matter.
Here, `rmarkdown::render` has `envir` argument (default: `parent.frame()`), and is causing `grViz` to find the object `foo`.

This PR fixes this problem.

````
---
title: "untitled"
output: html_vignette
knit: (function(...) rmarkdown::render(...))
---

```{r}
foo <- 'a'
DiagrammeR::grViz("digraph flowchart {
      tab1 [label = '@@1']
      tab1
      }
      [1]: foo
      ")
```
````