### PR TITLE
Fix user-provided hexadecimal node and edge coloring from issue 289

### DIFF
--- a/R/colorize_edge_attrs.R
+++ b/R/colorize_edge_attrs.R
@@ -106,30 +106,40 @@ colorize_edge_attrs <- function(graph,
     num_recodings <- length(cut_points) - 1
   }
 
-  # If the number of recodings lower than any Color
-  # Brewer palette, shift palette to `viridis`
-  if ((num_recodings < 3 | num_recodings > 10) & palette %in%
-      c(row.names(RColorBrewer::brewer.pal.info))) {
-    palette <- "viridis"
+  # Handle vector of hexadecimal or named colors
+  if (length(palette) > 1) {
+    # Verify colors are valid
+    if (!all(tolower(palette) %in% x11_hex()$hex)) {
+      emit_error(fcn_name = fcn_name,
+                 reasons = "The color palette contains invalid hexadecimal values.")
+    }
+    if (length(palette) < num_recodings) {
+      # Revert to viridis if provided color vector is too short
+      palette <- "viridis"
+    } else {
+      color_palette <- toupper(palette)[1:num_recodings]
+    }
   }
 
-  # Stop function if color palette is not `viridis`
-  # or any of the RColorBrewer palettes
+  # Handle viridis and ColorBrewer palette name input
   if (length(palette) == 1) {
-    if (!(palette %in%
-          c(row.names(RColorBrewer::brewer.pal.info),
-            "viridis"))) {
+    # If the number of recodings lower than any Color
+    # Brewer palette, shift palette to `viridis`
+    if ((num_recodings < 3 | num_recodings > 10) & palette %in%
+        c(row.names(RColorBrewer::brewer.pal.info))) {
+      palette <- "viridis"
+    }
 
+    # or any of the RColorBrewer palettes
+    if (!(palette %in% c(row.names(RColorBrewer::brewer.pal.info),
+                         "viridis"))) {
       emit_error(
         fcn_name = fcn_name,
         reasons = "The color palette is not an `RColorBrewer` or `viridis` palette")
     }
-  }
 
-  # Obtain a color palette
-  if (length(palette) == 1) {
-    if (palette %in%
-        row.names(RColorBrewer::brewer.pal.info)) {
+    # Obtain a color palette
+    if (palette %in% row.names(RColorBrewer::brewer.pal.info)) {
       color_palette <- RColorBrewer::brewer.pal(num_recodings, palette)
     } else if (palette == "viridis") {
       color_palette <- viridis::viridis(num_recodings)

--- a/R/colorize_node_attrs.R
+++ b/R/colorize_node_attrs.R
@@ -153,29 +153,40 @@ colorize_node_attrs <- function(graph,
     num_recodings <- length(cut_points) - 1
   }
 
-  # If the number of recodings lower than any Color
-  # Brewer palette, shift palette to `viridis`
-  if ((num_recodings < 3 | num_recodings > 10) & palette %in%
-      c(row.names(RColorBrewer::brewer.pal.info))) {
-    palette <- "viridis"
+  # Handle vector of hexadecimal or named colors
+  if (length(palette) > 1) {
+    # Verify colors are valid
+    if (!all(tolower(palette) %in% x11_hex()$hex)) {
+      emit_error(fcn_name = fcn_name,
+                 reasons = "The color palette contains invalid hexadecimal values.")
+    }
+    if (length(palette) < num_recodings) {
+      # Revert to viridis if provided color vector is too short
+      palette <- "viridis"
+    } else {
+      color_palette <- toupper(palette)[1:num_recodings]
+    }
   }
 
-  # or any of the RColorBrewer palettes
+  # Handle viridis and ColorBrewer palette name input
   if (length(palette) == 1) {
-    if (!(palette %in%
-          c(row.names(RColorBrewer::brewer.pal.info),
-            "viridis"))) {
+    # If the number of recodings lower than any Color
+    # Brewer palette, shift palette to `viridis`
+    if ((num_recodings < 3 | num_recodings > 10) & palette %in%
+        c(row.names(RColorBrewer::brewer.pal.info))) {
+      palette <- "viridis"
+    }
 
+    # or any of the RColorBrewer palettes
+    if (!(palette %in% c(row.names(RColorBrewer::brewer.pal.info),
+                         "viridis"))) {
       emit_error(
         fcn_name = fcn_name,
         reasons = "The color palette is not an `RColorBrewer` or `viridis` palette")
     }
-  }
 
-  # Obtain a color palette
-  if (length(palette) == 1) {
-    if (palette %in%
-        row.names(RColorBrewer::brewer.pal.info)) {
+    # Obtain a color palette
+    if (palette %in% row.names(RColorBrewer::brewer.pal.info)) {
       color_palette <- RColorBrewer::brewer.pal(num_recodings, palette)
     } else if (palette == "viridis") {
       color_palette <- viridis::viridis(num_recodings)

--- a/tests/testthat/test-colorize_nodes_edges.R
+++ b/tests/testthat/test-colorize_nodes_edges.R
@@ -182,6 +182,52 @@ test_that("Adding color based on node attributes is possible", {
   expect_match(
     graph$nodes_df$fillcolor,
     "#[0-9A-F]{6}")
+
+  # Bucketize as before but color according to hexadecimal vector input
+  graph <-
+    create_graph() %>%
+    add_gnm_graph(
+      n = 10,
+      m = 22,
+      node_data = node_data(
+        value = 1:10),
+      set_seed = 23) %>%
+    colorize_node_attrs(
+      node_attr_from = value,
+      node_attr_to = fillcolor,
+      cut_points = c(1, 3, 5, 7, 9),
+      palette = c("#458b00", "#8b3e2f", "#00eeee", "#556b2f", "#9932cc",
+                  "#698b69", "#cd2626", "#4a4a4a"))
+
+  # Expect that there are 5 colors in the
+  # `fillcolor` column
+  expect_equal(
+    length(
+      unique(
+        graph$nodes_df$fillcolor)), 5)
+
+  # Expect that each value in the `fillcolor`
+  # column is a properly-formed hexadecimal color
+  # code
+  expect_match(
+    graph$nodes_df$fillcolor,
+    "#[0-9A-F]{6}")
+
+  # Expect error when given mix of valid and invalid hexadecimal colors
+  expect_error(
+    create_graph() %>%
+      add_gnm_graph(
+        n = 10,
+        m = 22,
+        node_data = node_data(
+          value = 1:10),
+        set_seed = 23) %>%
+      colorize_node_attrs(
+        node_attr_from = value,
+        node_attr_to = fillcolor,
+        cut_points = c(1, 3, 5, 7, 9),
+        palette = c("#458b00l15", "foo", "#00eeee", "bar", "orange")))
+
 })
 
 test_that("Adding color based on edge attributes is possible", {
@@ -351,4 +397,48 @@ test_that("Adding color based on edge attributes is possible", {
   expect_match(
     graph$edges_df$labelfontcolor,
     "#[0-9A-F]{6}")
+
+  # Color edges according to hexadecimal vector input
+  graph <-
+    create_graph() %>%
+    add_gnm_graph(
+      n = 10,
+      m = 10,
+      edge_data = edge_data(
+        weight = rnorm(10, 5, 2)),
+      set_seed = 23) %>%
+    set_edge_attrs(
+      edge_attr = "rel",
+      values = c("A", "A", "B", "B", "D",
+                 "A", "B", "C", "D", "A")) %>%
+    colorize_edge_attrs(
+      edge_attr_from = rel,
+      edge_attr_to = color,
+      palette = c("#458b00", "#8b3e2f", "#00eeee", "#556b2f", "#9932cc",
+                  "#698b69", "#cd2626", "#4a4a4a"))
+
+  # Expect that each value in the `color`
+  # column is a properly-formed hexadecimal color
+  # code
+  expect_match(
+    graph$edges_df$color,
+    "#[0-9A-F]{6}")
+
+  # Expect error message if given invalid hexadecimal color
+  expect_error(
+    create_graph() %>%
+    add_gnm_graph(
+      n = 10,
+      m = 10,
+      edge_data = edge_data(
+        weight = rnorm(10, 5, 2)),
+      set_seed = 23) %>%
+    set_edge_attrs(
+      edge_attr = "rel",
+      values = c("A", "A", "B", "B", "D",
+                 "A", "B", "C", "D", "A")) %>%
+    colorize_edge_attrs(
+      edge_attr_from = rel,
+      edge_attr_to = color,
+      palette = c("#458b00l15", "foo", "#00eeee", "bar", "orange")))
 })


### PR DESCRIPTION
This is a fix for #289 and an analogous problem with `colorize_edge_attrs`.

For both edge (`colorize_edge_attrs`) and node (`colorize_node_attrs`) coloring, this verifies that any `palette` argument with length greater than 1 consists of valid hexadecimal colors. If it does and the number of elements is sufficient for the number of information levels to be encoded, the provided colors are used. When the number of provided colors is insufficient, the default palette of `viridis` is used.

There are also new tests to ensure the resulting colors are valid hexadecimal values and to check that invalid color inputs generate an error message.