### PR TITLE
Only call `replace_na(replace = "")` on character columns

### DIFF
--- a/R/generate_dot.R
+++ b/R/generate_dot.R
@@ -98,30 +98,34 @@ generate_dot <- function(graph) {
   }
 
 
-  # Replace NA values with empty strings in `nodes_df`
+  # Replace NA values with empty strings in character columns of `nodes_df`
   if (!is.null(nodes_df)) {
 
     if (ncol(nodes_df) >= 4) {
+      vars <- base::setdiff(colnames(nodes_df), c("id", "type", "label"))
+      vars <- vars[purrr::map_lgl(nodes_df[vars], is.character)]
 
       nodes_df <-
         nodes_df %>%
         dplyr::mutate_at(
-          .vars = base::setdiff(colnames(nodes_df), c("id", "type", "label")),
+          .vars = vars,
           .funs =  ~ tidyr::replace_na(., "")
         )
     }
   }
 
 
-  # Replace NA values with empty strings in `edges_df`
+  # Replace NA values with empty strings in character columns of `edges_df`
   if (!is.null(edges_df)) {
 
     if (ncol(edges_df) >= 5) {
+      vars <- base::setdiff(colnames(edges_df), c("id", "from", "to", "rel"))
+      vars <- vars[purrr::map_lgl(edges_df[vars], is.character)]
 
       edges_df <-
         edges_df %>%
         dplyr::mutate_at(
-          .vars = base::setdiff(colnames(edges_df), c("id", "from", "to", "rel")),
+          .vars = vars,
           .funs =  ~ tidyr::replace_na(., "")
         )
     }


### PR DESCRIPTION
We are updating `tidyr::replace_na()` to utilize vctrs, and that results in slightly stricter / more correct type conversions. See https://github.com/tidyverse/tidyr/pull/1219

We noticed in revdeps that this package indirectly broke 4 of our revdeps. An easy way to reproduce is to install that PR and run:

``` r
library(heuristicsmineR)

x <- causal_net(
  L_heur_1,
  type_nodes = causal_custom(attribute = "timestamp"),
  type_edges = causal_custom(attribute = "timestamp")
)

rendered <- render_causal_net(x)
#> Error: Problem with `mutate()` column `color_level`.
#> ℹ `color_level = (structure(function (..., .x = ..1, .y = ..2, . = ..1) ...`.
#> x Can't convert `replace` <character> to match type of `data` <double>.
```

The problem boils down to the fact that, with the current approach,`replace_na()` has the potential to be called on a numeric column, but you are using a replacement value of `""`. This is no longer allowed.

I have a feeling you wanted to only replace `NA_character_` with `""` for character columns, so that is what this PR changed.