### PR TITLE
fix failure of mermaid() for file input

### DIFF
--- a/R/mermaid.R
+++ b/R/mermaid.R
@@ -132,6 +132,7 @@ mermaid <- function(diagram = "",
   if (is_connection_or_file) {
 
     diagram <- readLines(diagram, encoding = "UTF-8", warn = FALSE)
+    diagram <- paste0(diagram, collapse = "\n")
 
   } else {
 


### PR DESCRIPTION
With version 1.0.9, `mermaid()` stopped working for file inputs. Instead of an image, it returns the code for the graph. I think the reason is that you removed the line from the function that combines all the lines of the file into a single character. Putting this line back resolved the issue for me.

I would appreciate if you could fix this issue. Thanks!