### PR TITLE
Rework dependency check to throw errors

### DIFF
--- a/R/export_graph.R
+++ b/R/export_graph.R
@@ -87,12 +87,10 @@ export_graph <- function(graph,
     }
   }
 
-  if ((file_type == "PNG" | file_type == "png") &&
-      requireNamespace("DiagrammeRsvg", quietly = TRUE) &&
-      requireNamespace("rsvg", quietly = TRUE)) {
+  if (file_type == "PNG" | file_type == "png") {
 
     # Stop function if `DiagrammeRsvg` package is not available
-    if (!("DiagrammeRsvg" %in% rownames(utils::installed.packages()))) {
+    if (!requireNamespace("DiagrammeRsvg", quietly = TRUE)) {
 
       emit_error(
         fcn_name = fcn_name,
@@ -101,9 +99,9 @@ export_graph <- function(graph,
           "please install the `DiagrammeRsvg` package and retry",
           "pkg installed using `devtools::install_github('rich-iannone/DiagrammeRsvg')`"))
     }
-
+    
     # Stop function if `rsvg` package is not available
-    if (!("rsvg" %in% rownames(utils::installed.packages()))) {
+    if (!requireNamespace("rsvg", quietly = TRUE)) {
 
       emit_error(
         fcn_name = fcn_name,
@@ -112,7 +110,7 @@ export_graph <- function(graph,
           "please install the `rsvg` package and retry",
           "pkg installed using `install.packages('rsvg')`"))
     }
-
+    
     if (!is.null(title)) {
 
       graph <- add_global_graph_attrs(graph, "label", title, "graph")
@@ -134,12 +132,10 @@ export_graph <- function(graph,
     )
   }
 
-  if ((file_type == "PDF" | file_type == "pdf") &&
-    requireNamespace("DiagrammeRsvg", quietly = TRUE) &&
-    requireNamespace("rsvg", quietly = TRUE)) {
+  if (file_type == "PDF" | file_type == "pdf") {
 
     # Stop function if `DiagrammeRsvg` package is not available
-    if (!("DiagrammeRsvg" %in% rownames(utils::installed.packages()))) {
+    if (!requireNamespace("DiagrammeRsvg", quietly = TRUE)) {
 
       emit_error(
         fcn_name = fcn_name,
@@ -150,7 +146,7 @@ export_graph <- function(graph,
     }
 
     # Stop function if `rsvg` package is not available
-    if (!("rsvg" %in% rownames(utils::installed.packages()))) {
+    if (!requireNamespace("rsvg", quietly = TRUE)) {
 
       emit_error(
         fcn_name = fcn_name,
@@ -180,12 +176,10 @@ export_graph <- function(graph,
     )
   }
 
-  if ((file_type == "SVG" | file_type == "svg") &&
-      requireNamespace("DiagrammeRsvg", quietly = TRUE) &&
-      requireNamespace("rsvg", quietly = TRUE)) {
+  if (file_type == "SVG" | file_type == "svg") {
 
     # Stop function if `DiagrammeRsvg` package is not available
-    if (!("DiagrammeRsvg" %in% rownames(utils::installed.packages()))) {
+    if (!requireNamespace("DiagrammeRsvg", quietly = TRUE)) {
 
       emit_error(
         fcn_name = fcn_name,
@@ -196,7 +190,7 @@ export_graph <- function(graph,
     }
 
     # Stop function if `rsvg` package is not available
-    if (!("rsvg" %in% rownames(utils::installed.packages()))) {
+    if (!requireNamespace("rsvg", quietly = TRUE)) {
 
       emit_error(
         fcn_name = fcn_name,


### PR DESCRIPTION
Reworked to throw errors if a dependency doesn't exist _before_ skipping if the package doesn't exist.

Fixes  #478