### PR TITLE
Switch `generate_dot()` to use double quotes instead of single quotes

### DIFF
--- a/R/generate_dot.R
+++ b/R/generate_dot.R
@@ -33,7 +33,7 @@ generate_dot <- function(graph) {
     graph_attrs <-
       global_attrs %>%
       dplyr::filter(attr_type == "graph") %>%
-      dplyr::mutate(string = paste0(attr, " = '", value, "'"))
+      dplyr::mutate(string = paste0(attr, " = \"", value, "\""))
 
     graph_attrs <-
       graph_attrs %>%
@@ -47,7 +47,7 @@ generate_dot <- function(graph) {
     node_attrs <-
       global_attrs %>%
       dplyr::filter(attr_type == "node") %>%
-      dplyr::mutate(string = paste0(attr, " = '", value, "'"))
+      dplyr::mutate(string = paste0(attr, " = \"", value, "\""))
 
     node_attrs <-
       node_attrs %>%
@@ -75,7 +75,7 @@ generate_dot <- function(graph) {
     edge_attrs <-
       global_attrs %>%
       dplyr::filter(attr_type == "edge") %>%
-      dplyr::mutate(string = paste0(attr, " = '", value, "'"))
+      dplyr::mutate(string = paste0(attr, " = \"", value, "\""))
 
     edge_attrs <-
       edge_attrs %>%
@@ -402,7 +402,7 @@ generate_dot <- function(graph) {
                            !is.na(nodes_df[i, j]))) {
               attribute <-
                 paste0(colnames(nodes_df)[j],
-                       " = ", "'", nodes_df[i, j], "'")
+                       " = ", "\"", nodes_df[i, j], "\"")
             } else if (all(!(colnames(nodes_df)[j] %in%
                              c("label", "tooltip")),
                            is.na(nodes_df[i, j]))) {
@@ -412,7 +412,7 @@ generate_dot <- function(graph) {
                            !is.na(nodes_df[i, j]))) {
               attribute <-
                 paste0(colnames(nodes_df)[j],
-                       " = ", "'", nodes_df[i, j], "'")
+                       " = ", "\"", nodes_df[i, j], "\"")
             }
             attr_string <- c(attr_string, attribute)
           }
@@ -426,7 +426,7 @@ generate_dot <- function(graph) {
         # Generate a line of node objects when an
         # attribute string exists
         if (exists("attr_string")) {
-          line <- paste0("  '", nodes_df[i, 1], "'",
+          line <- paste0("  \"", nodes_df[i, 1], "\"",
                          " [", attr_string, "] ")
         }
 
@@ -434,9 +434,9 @@ generate_dot <- function(graph) {
         # attribute string doesn't exist
         if (!exists("attr_string")) {
           line <-
-            paste0("  '",
+            paste0("  \"",
                    nodes_df[i, 1],
-                   "'")
+                   "\"")
         }
         node_block <- c(node_block, line)
       }
@@ -469,8 +469,8 @@ generate_dot <- function(graph) {
           } else {
             cluster_block <-
               paste0(
-                "subgraph cluster", i, "{\nlabel='",
-                names(clusters)[[i]], "'\n",
+                "subgraph cluster", i, "{\nlabel=\"",
+                names(clusters)[[i]], "\"\n",
                 paste0(clusters[[i]], collapse = "\n"), "}\n"
               )
           }
@@ -575,8 +575,8 @@ generate_dot <- function(graph) {
                                edges_df[i, j] != '')) {
                   attribute <-
                     paste0(colnames(edges_df)[j],
-                           " = ", "'", edges_df[i, j],
-                           "'")
+                           " = ", "\"", edges_df[i, j],
+                           "\"")
                 } else if (all(!(colnames(edges_df)[j] %in%
                                  c("edgetooltip", "headtooltip",
                                    "label", "labeltooltip",
@@ -593,7 +593,7 @@ generate_dot <- function(graph) {
                                edges_df[i, j] != '')) {
                   attribute <-
                     paste0(colnames(edges_df)[j],
-                           " = ", "'", edges_df[i, j], "'")
+                           " = ", "\"", edges_df[i, j], "\"")
                 }
                 attr_string <- c(attr_string, attribute)
               }
@@ -608,9 +608,9 @@ generate_dot <- function(graph) {
             # attribute string exists
             if (exists("attr_string")) {
               line <-
-                paste0("'", edges_df[i, from_column], "'",
+                paste0("\"", edges_df[i, from_column], "\"",
                        ifelse(directed, "->", "--"),
-                       "'", edges_df[i, to_column], "'",
+                       "\"", edges_df[i, to_column], "\"",
                        paste0(" [", attr_string, "] "))
             }
 
@@ -619,9 +619,9 @@ generate_dot <- function(graph) {
             if (!exists("attr_string")) {
               line <-
                 paste0("  ",
-                       "'", edges_df[i, from_column], "'",
+                       "\"", edges_df[i, from_column], "\"",
                        ifelse(directed, "->", "--"),
-                       "'", edges_df[i, to_column], "'",
+                       "\"", edges_df[i, to_column], "\"",
                        " ")
             }
             edge_block <- c(edge_block, line)

--- a/tests/testthat/test-generate_dot.R
+++ b/tests/testthat/test-generate_dot.R
@@ -3,13 +3,13 @@ context("Generate dot syntax from graph objects")
 # helper functions
 node <- function(id, label = NA) {
   if(all(is.na(label))) {
-    paste0("'", id, "'")
+    paste0("\"", id, "\"")
   } else {
-    paste0("'", id, "' \\[label = '", label, "'\\]")
+    paste0("\"", id, "\" \\[label = \"", label, "\"\\]")
   }
 }
-edge <- function(from, to) paste0("'", from, "'->'", to, "'")
-attrib_block <- "\\[[[:alnum:]'=.,[:space:]]*\\]"
+edge <- function(from, to) paste0("\"", from, "\"->\"", to, "\"")
+attrib_block <- "\\[[[:alnum:]\"=.,[:space:]]*\\]"
 
 expect_dot <- function(graph, pattern) {
   expect_match(


### PR DESCRIPTION
This commit addresses [this issue](https://github.com/rich-iannone/DiagrammeR/issues/491).

The command-line `dot` throws a syntax error with single quotes, as it expects strings to be surrounded by double quotes. `generate_dot()` previously used single quotes in writing the dot code, but this PR changes that to double quotes.