### PR TITLE
Fix warnings in tests (don't use tidyselect, igraph deprecated features) + gh actions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^man/figures/.*$
 vignettes
 ^codecov\.yml$
+^\.github$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,10 +1,10 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -18,17 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-11, r: '4.1'}
-          - {os: macos-11, r: '4.2'}
-          - {os: windows-latest, r: '4.1'}
-          - {os: windows-latest, r: '4.2'}
-          - {os: ubuntu-latest, r: '3.6'}
-          - {os: ubuntu-latest, r: '4.0'}
-          - {os: ubuntu-latest, r: '4.1'}
-          - {os: ubuntu-latest, r: '4.2'}
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,34 +1,48 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: main
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 name: pkgdown
 
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
     concurrency:
-       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-
-      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Install package
-        run: R CMD INSTALL .
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
 
-      - name: Build and deploy pkgdown site
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,50 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr
+          needs: coverage
+
+      - name: Test coverage
+        run: |
+          covr::codecov(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+          )
+        shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/R/add_edge.R
+++ b/R/add_edge.R
@@ -152,7 +152,7 @@ add_edge <- function(
     max()
 
   if (is.null(rel)) {
-    rel <- as.character(NA)
+    rel <- NA_character_
   }
 
   # Collect edge aesthetic attributes

--- a/R/add_edge_clone.R
+++ b/R/add_edge_clone.R
@@ -133,7 +133,7 @@ add_edge_clone <- function(
     graph %>%
     get_edge_df() %>%
     dplyr::filter(id == edge) %>%
-    dplyr::select(4:n_col_edf)
+    dplyr::select(4:dplyr::all_of(n_col_edf))
 
   # Create the requested edge
   graph <-

--- a/R/add_edges_from_table.R
+++ b/R/add_edges_from_table.R
@@ -238,14 +238,14 @@ add_edges_from_table <- function(
   if (!("rel" %in% colnames(edf))) {
     edf <-
       edf %>%
-      dplyr::mutate(rel = as.character(NA))
+      dplyr::mutate(rel = NA_character_)
   }
 
   # Use the `select()` function to arrange the
   # column rows and then convert to a data frame
   edf <-
     edf %>%
-    dplyr::select(from, to, rel, dplyr::everything()) %>%
+    dplyr::relocate(from, to, rel) %>%
     as.data.frame(stringsAsFactors = FALSE)
 
   # Remove any rows where there is an NA in either

--- a/R/add_forward_edges_ws.R
+++ b/R/add_forward_edges_ws.R
@@ -95,7 +95,7 @@ add_forward_edges_ws <- function(
 
   # If no value(s) provided for `rel`, set to NA
   if (is.null(rel)) {
-    rel <- as.character(NA)
+    rel <- NA_character_
   }
 
   # Get a vector of edges available in the

--- a/R/add_graph_action.R
+++ b/R/add_graph_action.R
@@ -125,7 +125,7 @@ add_graph_action <- function(
       action_index = ifelse(nrow(graph$graph_actions) == 0, 1,
                             max(graph$graph_actions$action_index) + 1),
       action_name = ifelse(!is.null(action_name), action_name,
-                           as.character(NA)),
+                           NA_character_),
       expression = char_expr,
       stringsAsFactors = FALSE)
 

--- a/R/add_n_nodes.R
+++ b/R/add_n_nodes.R
@@ -54,11 +54,11 @@ add_n_nodes <- function(
   }
 
   if (is.null(type)) {
-    type <- as.character(NA)
+    type <- NA_character_
   }
 
   if (is.null(label)) {
-    label <- as.character(NA)
+    label <- NA_character_
   }
 
   # Collect node aesthetic attributes
@@ -78,7 +78,7 @@ add_n_nodes <- function(
     if ("id" %in% colnames(node_aes_tbl)) {
       node_aes_tbl <-
         node_aes_tbl %>%
-        dplyr::select(-id)
+        dplyr::select(-"id")
     }
   }
 
@@ -93,13 +93,13 @@ add_n_nodes <- function(
 
       node_data_tbl <-
         dplyr::as_tibble(node_data) %>%
-        dplyr::select(-index__)
+        dplyr::select(-"index__")
     }
 
     if ("id" %in% colnames(node_data_tbl)) {
       node_data_tbl <-
         node_data_tbl %>%
-        dplyr::select(-id)
+        dplyr::select(-"id")
     }
   }
 

--- a/R/add_n_nodes_ws.R
+++ b/R/add_n_nodes_ws.R
@@ -138,15 +138,15 @@ add_n_nodes_ws <- function(
   }
 
   if (is.null(type)) {
-    type <- as.character(NA)
+    type <- NA_character_
   }
 
   if (is.null(label)) {
-    label <- as.character(NA)
+    label <- NA_character_
   }
 
   if (is.null(rel)) {
-    rel <- as.character(NA)
+    rel <- NA_character_
   }
 
   # Get the number of nodes in the graph
@@ -290,13 +290,13 @@ add_n_nodes_ws <- function(
 
       node_data_tbl <-
         dplyr::as_tibble(node_data) %>%
-        dplyr::select(-index__)
+        dplyr::select(-"index__")
     }
 
     if ("id" %in% colnames(node_data_tbl)) {
       node_data_tbl <-
         node_data_tbl %>%
-        dplyr::select(-id)
+        dplyr::select(-"id")
     }
   }
 

--- a/R/add_n_nodes_ws.R
+++ b/R/add_n_nodes_ws.R
@@ -347,8 +347,7 @@ add_n_nodes_ws <- function(
 
     node_aes_tbl <-
       node_aes_tbl %>%
-      dplyr::mutate(id = new_node_id) %>%
-      dplyr::select(id, dplyr::everything())
+      dplyr::mutate(id = new_node_id, .before = 0)
 
     columns_to_select <-
       c("id", base::setdiff(colnames(graph$nodes_df), colnames(node_aes_tbl)))
@@ -359,7 +358,7 @@ add_n_nodes_ws <- function(
           dplyr::filter(!(id %in% new_node_id)),
         graph$nodes_df %>%
           dplyr::filter(id %in% new_node_id) %>%
-          dplyr::select(columns_to_select) %>%
+          dplyr::select(dplyr::all_of(columns_to_select)) %>%
           dplyr::left_join(node_aes_tbl, by = "id"))
   }
 
@@ -368,8 +367,7 @@ add_n_nodes_ws <- function(
 
     node_data_tbl <-
       node_data_tbl %>%
-      dplyr::mutate(id = new_node_id) %>%
-      dplyr::select(id, dplyr::everything())
+      dplyr::mutate(id = new_node_id, .before = 0)
 
     columns_to_select <-
       c("id", base::setdiff(colnames(graph$nodes_df), colnames(node_data_tbl)))
@@ -380,7 +378,7 @@ add_n_nodes_ws <- function(
           dplyr::filter(!(id %in% new_node_id)),
         graph$nodes_df %>%
           dplyr::filter(id %in% new_node_id) %>%
-          dplyr::select(columns_to_select) %>%
+          dplyr::select(dplyr::all_of(columns_to_select)) %>%
           dplyr::left_join(node_data_tbl, by = "id"))
   }
 
@@ -389,8 +387,7 @@ add_n_nodes_ws <- function(
 
     edge_aes_tbl <-
       edge_aes_tbl %>%
-      dplyr::mutate(id = new_edge_id) %>%
-      dplyr::select(id, dplyr::everything())
+      dplyr::mutate(id = new_edge_id, .before = 0)
 
     columns_to_select <-
       c("id", base::setdiff(colnames(graph$edges_df), colnames(edge_aes_tbl)))
@@ -401,7 +398,7 @@ add_n_nodes_ws <- function(
           dplyr::filter(!(id %in% new_edge_id)),
         graph$edges_df %>%
           dplyr::filter(id %in% new_edge_id) %>%
-          dplyr::select(columns_to_select) %>%
+          dplyr::select(dplyr::all_of(columns_to_select)) %>%
           dplyr::left_join(edge_aes_tbl, by = "id"))
   }
 
@@ -410,8 +407,7 @@ add_n_nodes_ws <- function(
 
     edge_data_tbl <-
       edge_data_tbl %>%
-      dplyr::mutate(id = new_edge_id) %>%
-      dplyr::select(id, dplyr::everything())
+      dplyr::mutate(id = new_edge_id, .before = 0)
 
     columns_to_select <-
       c("id", base::setdiff(colnames(graph$edges_df), colnames(edge_data_tbl)))
@@ -422,7 +418,7 @@ add_n_nodes_ws <- function(
           dplyr::filter(!(id %in% new_edge_id)),
         graph$edges_df %>%
           dplyr::filter(id %in% new_edge_id) %>%
-          dplyr::select(columns_to_select) %>%
+          dplyr::select(dplyr::all_of(columns_to_select)) %>%
           dplyr::left_join(edge_data_tbl, by = "id"))
   }
 

--- a/R/add_node.R
+++ b/R/add_node.R
@@ -87,11 +87,11 @@ add_node <- function(
   edges_created <- graph$last_edge
 
   if (is.null(type)) {
-    type <- as.character(NA)
+    type <- NA_character_
   }
 
   if (is.null(label)) {
-    label <- as.character(NA)
+    label <- NA_character_
   }
 
   # Collect node aesthetic attributes

--- a/R/add_nodes_from_df_cols.R
+++ b/R/add_nodes_from_df_cols.R
@@ -126,7 +126,7 @@ add_nodes_from_df_cols <- function(
   # Exclude any columns that are not character class
   df <-
     dplyr::as_tibble(df) %>%
-    dplyr::select(columns) %>%
+    dplyr::select(dplyr::all_of(columns)) %>%
     dplyr::select_if(is.character)
 
   # Create an empty `nodes` vector

--- a/R/add_nodes_from_table.R
+++ b/R/add_nodes_from_table.R
@@ -247,10 +247,10 @@ add_nodes_from_table <- function(
   # Move any additional columns from the
   # external table to `ndf`
   ndf <-
-    ndf %>%
     dplyr::bind_cols(
-      csv %>%
-        dplyr::select(columns_to_add))
+      ndf,
+      dplyr::select(csv, dplyr::all_of(columns_to_add))
+      )
 
   # Get the number of nodes in the graph
   nodes_graph_1 <- graph %>% count_nodes()

--- a/R/add_reverse_edges_ws.R
+++ b/R/add_reverse_edges_ws.R
@@ -76,7 +76,7 @@ add_reverse_edges_ws <- function(
   fcn_name <- get_calling_fcn()
 
   # Validation: Graph object is valid
-  if (graph_object_valid(graph) == FALSE) {
+  if (!graph_object_valid(graph)) {
 
     emit_error(
       fcn_name = fcn_name,
@@ -84,7 +84,7 @@ add_reverse_edges_ws <- function(
   }
 
   # Validation: Graph contains edges
-  if (graph_contains_edges(graph) == FALSE) {
+  if (!graph_contains_edges(graph)) {
 
     emit_error(
       fcn_name = fcn_name,
@@ -92,7 +92,7 @@ add_reverse_edges_ws <- function(
   }
 
   # Validation: Graph object has valid edge selection
-  if (graph_contains_edge_selection(graph) == FALSE) {
+  if (!graph_contains_edge_selection(graph)) {
 
     emit_error(
       fcn_name = fcn_name,
@@ -104,7 +104,7 @@ add_reverse_edges_ws <- function(
 
   # If no value(s) provided for `rel`, set to NA
   if (is.null(rel)) {
-    rel <- as.character(NA)
+    rel <- NA_character_
   }
 
   # Get a vector of edges available in the

--- a/R/count_asymmetric_node_pairs.R
+++ b/R/count_asymmetric_node_pairs.R
@@ -44,7 +44,7 @@ count_asymmetric_node_pairs <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/count_automorphisms.R
+++ b/R/count_automorphisms.R
@@ -43,7 +43,7 @@ count_automorphisms <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an undirected graph

--- a/R/count_mutual_node_pairs.R
+++ b/R/count_mutual_node_pairs.R
@@ -43,7 +43,7 @@ count_mutual_node_pairs <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/count_s_connected_cmpts.R
+++ b/R/count_s_connected_cmpts.R
@@ -41,7 +41,7 @@ count_s_connected_cmpts <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/count_unconnected_node_pairs.R
+++ b/R/count_unconnected_node_pairs.R
@@ -42,7 +42,7 @@ count_unconnected_node_pairs <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/count_w_connected_cmpts.R
+++ b/R/count_w_connected_cmpts.R
@@ -36,7 +36,7 @@ count_w_connected_cmpts <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/create_edge_df.R
+++ b/R/create_edge_df.R
@@ -78,7 +78,7 @@ create_edge_df <- function(
   # if `rel` is NULL, create character vector with
   # NA values; class as character otherwise
   if (is.null(rel)) {
-    rel <- rep(as.character(NA), length(from))
+    rel <- rep(NA_character_, length(from))
   } else {
     rel <- as.character(rel)
   }
@@ -96,7 +96,7 @@ create_edge_df <- function(
         length(rel) < length(from)) {
       rel <-
         c(rel,
-          rep(as.character(NA),
+          rep(NA_character_,
               (length(from) - length(rel))))
     }
 
@@ -125,7 +125,7 @@ create_edge_df <- function(
           length(extras[[i]]) < length(from)) {
         extras[[i]] <-
           c(extras[[i]],
-            rep(as.character(NA),
+            rep(NA_character_,
                 (length(from) -
                    length(extras[[i]]))))
       }

--- a/R/create_node_df.R
+++ b/R/create_node_df.R
@@ -84,7 +84,7 @@ create_node_df <- function(
   }
 
   if (is.null(type)) {
-    type <- rep(as.character(NA), n)
+    type <- rep(NA_character_, n)
   }
 
   if (!is.null(type)) {
@@ -99,7 +99,7 @@ create_node_df <- function(
     if (length(type) > 1 &
         length(type) < n) {
       type <-
-        c(type, rep(as.character(NA), (n - length(type))))
+        c(type, rep(NA_character_, (n - length(type))))
     }
 
     # Trim vectors with number of values exceeding the
@@ -146,7 +146,7 @@ create_node_df <- function(
 
   # Interpret node label values
   if (is.null(label)) {
-    label <- rep(as.character(NA), n)
+    label <- rep(NA_character_, n)
   } else if (inherits(label, "numeric") |
              inherits(label, "character")) {
     label <- as.character(label)
@@ -155,7 +155,7 @@ create_node_df <- function(
     if (label == TRUE) {
       label <- as.character(1:n)
     } else {
-      label <- rep(as.character(NA), n)
+      label <- rep(NA_character_, n)
     }
   }
 

--- a/R/delete_global_graph_attrs.R
+++ b/R/delete_global_graph_attrs.R
@@ -138,7 +138,7 @@ delete_global_graph_attrs <- function(
     global_attrs_to_remove <-
       dplyr::tibble(
         attr = as.character(attr),
-        value = as.character(NA),
+        value = NA_character_,
         attr_type = as.character(attr_type)) %>%
       as.data.frame(stringsAsFactors = FALSE)
 

--- a/R/do_bfs.R
+++ b/R/do_bfs.R
@@ -84,7 +84,7 @@ do_bfs <- function(
   }
 
   # Validation: Graph contains nodes
-  if (graph_contains_nodes(graph) == FALSE) {
+  if (!graph_contains_nodes(graph)) {
 
     emit_error(
       fcn_name = fcn_name,

--- a/R/do_bfs.R
+++ b/R/do_bfs.R
@@ -107,7 +107,7 @@ do_bfs <- function(
       igraph::bfs(
         graph = ig_graph,
         root = node,
-        neimode = "all")
+        mode = "all")
 
   } else if (direction == "out") {
 
@@ -115,7 +115,7 @@ do_bfs <- function(
       igraph::bfs(
         graph = ig_graph,
         root = node,
-        neimode = "out")
+        mode = "out")
 
   } else if (direction == "in") {
 
@@ -123,7 +123,7 @@ do_bfs <- function(
       igraph::bfs(
         graph = ig_graph,
         root = node,
-        neimode = "in")
+        mode = "in")
 
   } else if (!(direction %in% c("all", "out", "in"))) {
 

--- a/R/do_dfs.R
+++ b/R/do_dfs.R
@@ -107,7 +107,7 @@ do_dfs <- function(
       igraph::dfs(
         graph = ig_graph,
         root = node,
-        neimode = "all")
+        mode = "all")
 
   } else if (direction == "out") {
 
@@ -115,7 +115,7 @@ do_dfs <- function(
       igraph::dfs(
         graph = ig_graph,
         root = node,
-        neimode = "out")
+        mode = "out")
 
   } else if (direction == "in") {
 
@@ -123,7 +123,7 @@ do_dfs <- function(
       igraph::dfs(
         graph = ig_graph,
         root = node,
-        neimode = "in")
+        mode = "in")
 
   } else if (!(direction %in% c("all", "out", "in"))) {
 

--- a/R/from_igraph.R
+++ b/R/from_igraph.R
@@ -64,7 +64,7 @@ from_igraph <- function(igraph,
       cbind(
         nodes_df,
         data.frame(
-          type = rep(as.character(NA), nrow(nodes_df)),
+          type = rep(NA_character_, nrow(nodes_df)),
           stringsAsFactors = FALSE))
   }
 
@@ -81,7 +81,7 @@ from_igraph <- function(igraph,
       cbind(
         nodes_df,
         data.frame(
-          label = rep(as.character(NA), nrow(nodes_df)),
+          label = rep(NA_character_, nrow(nodes_df)),
           stringsAsFactors = FALSE))
   }
 
@@ -127,7 +127,7 @@ from_igraph <- function(igraph,
       cbind(
         edges_df,
         data.frame(
-          rel = rep(as.character(NA), nrow(edges_df)),
+          rel = rep(NA_character_, nrow(edges_df)),
           stringsAsFactors = FALSE))
   }
 

--- a/R/generate_dot.R
+++ b/R/generate_dot.R
@@ -180,7 +180,7 @@ generate_dot <- function(graph) {
 
       edges_df <-
         edges_df %>%
-        dplyr::mutate(label = as.character(NA))
+        dplyr::mutate(label = NA_character_)
     }
 
     label_col <- which(colnames(edges_df) == "label")

--- a/R/get_adhesion.R
+++ b/R/get_adhesion.R
@@ -42,7 +42,7 @@ get_adhesion <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/get_girth.R
+++ b/R/get_girth.R
@@ -42,7 +42,7 @@ get_girth <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/get_max_eccentricity.R
+++ b/R/get_max_eccentricity.R
@@ -45,7 +45,7 @@ get_max_eccentricity <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/get_mean_distance.R
+++ b/R/get_mean_distance.R
@@ -42,7 +42,7 @@ get_mean_distance <- function(graph) {
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/get_min_cut_between.R
+++ b/R/get_min_cut_between.R
@@ -84,7 +84,7 @@ get_min_cut_between <- function(
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/get_min_eccentricity.R
+++ b/R/get_min_eccentricity.R
@@ -62,7 +62,7 @@ get_min_eccentricity <- function(
 
   # If the graph is empty, then return NA
   if (nrow(graph$nodes_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/get_reciprocity.R
+++ b/R/get_reciprocity.R
@@ -66,7 +66,7 @@ get_reciprocity <- function(graph) {
   # cannot return any valid reciprocity
   # value
   if (nrow(graph$edges_df) == 0) {
-    return(as.numeric(NA))
+    return(NA_real_)
   }
 
   # Convert the graph to an igraph object

--- a/R/import_graph.R
+++ b/R/import_graph.R
@@ -169,8 +169,8 @@ import_graph <- function(
     edges <-
       edges %>%
       dplyr::mutate(id = 1:n_rows) %>%
-      dplyr::mutate(rel = as.character(NA)) %>%
-      dplyr::select(id, from, to, rel, dplyr::everything()) %>%
+      dplyr::mutate(rel = NA_character_) %>%
+      dplyr::relocate(id, from, to, rel) %>%
       as.data.frame(stringsAsFactors = FALSE)
 
     # Create a node data frame
@@ -179,16 +179,16 @@ import_graph <- function(
         dplyr::tibble(
           id = edges %>%
             dplyr::as_tibble() %>%
-            dplyr::select(from) %>%
+            dplyr::select("from") %>%
             purrr::flatten_int()),
         dplyr::tibble(
           id = edges %>%
             dplyr::as_tibble() %>%
-            dplyr::select(to) %>%
+            dplyr::select("to") %>%
             purrr::flatten_int())) %>%
       dplyr::distinct() %>%
       dplyr::arrange(id) %>%
-      dplyr::mutate(type = as.character(NA)) %>%
+      dplyr::mutate(type = NA_character_) %>%
       dplyr::mutate(label = as.character(id)) %>%
       as.data.frame(stringsAsFactors = FALSE)
 
@@ -234,7 +234,7 @@ import_graph <- function(
             strsplit(
               mtx_document[first_line:length(mtx_document)],
               " ")))),
-        type = as.character(NA),
+        type = NA_character_,
         label = as.integer(unique(
           unlist(
             strsplit(
@@ -344,8 +344,8 @@ import_graph <- function(
     all_nodes <-
       dplyr::tibble(
         id = node_id,
-        type = as.character(NA),
-        label = as.character(NA)) %>%
+        type = NA_character_,
+        label = NA_character_) %>%
       as.data.frame(stringsAsFactors = FALSE)
 
     if (exists("node_label")) {

--- a/R/join_edge_attrs.R
+++ b/R/join_edge_attrs.R
@@ -119,7 +119,7 @@ join_edge_attrs <- function(
   # Sort the columns in `edges`
   edges <-
     edges %>%
-    dplyr::select(id, from, to, rel, dplyr::everything())
+    dplyr::relocate(id, from, to, rel)
 
   # Modify the graph object
   graph$edges_df <- edges

--- a/R/join_node_attrs.R
+++ b/R/join_node_attrs.R
@@ -150,7 +150,7 @@ join_node_attrs <- function(
   # Ensure that the column ordering is correct
   nodes <-
     nodes %>%
-    dplyr::select(id, type, label, dplyr::everything())
+    dplyr::relocate(id, type, label)
 
   # Modify the graph object
   graph$nodes_df <- nodes

--- a/R/print.R
+++ b/R/print.R
@@ -53,12 +53,12 @@ print.dgr_graph <- function(x, ...) {
       paste0(
         x$nodes_df$type %>%
           unique() %>%
-          base::setdiff(as.character(NA)) %>%
+          base::setdiff(NA_character_) %>%
           length(), " val",
         ifelse(
           x$nodes_df$type %>%
             unique() %>%
-            base::setdiff(as.character(NA)) %>%
+            base::setdiff(NA_character_) %>%
             length() > 1, "s", ""))
 
   } else if (!any(is.na(x$nodes_df$type))) {
@@ -67,7 +67,7 @@ print.dgr_graph <- function(x, ...) {
       paste0(
         x$nodes_df$type %>%
           unique() %>%
-          base::setdiff(as.character(NA)) %>%
+          base::setdiff(NA_character_) %>%
           length(), " vals - complete")
   }
 
@@ -81,12 +81,12 @@ print.dgr_graph <- function(x, ...) {
       paste0(
         x$nodes_df$label %>%
           unique() %>%
-          base::setdiff(as.character(NA)) %>%
+          base::setdiff(NA_character_) %>%
           length(), " val",
         ifelse(
           x$nodes_df$label %>%
             unique() %>%
-            base::setdiff(as.character(NA)) %>%
+            base::setdiff(NA_character_) %>%
             length() > 1, "s", ""))
 
   } else if (!any(is.na(x$nodes_df$label))) {
@@ -95,10 +95,10 @@ print.dgr_graph <- function(x, ...) {
       paste0(
         x$nodes_df$label %>%
           unique() %>%
-          base::setdiff(as.character(NA)) %>%
+          base::setdiff(NA_character_) %>%
           length(), " vals - complete")
 
-    if (any(duplicated(x$nodes_df$label)) == FALSE) {
+    if (!any(duplicated(x$nodes_df$label))) {
 
       node_label_status <-
         paste0(
@@ -157,12 +157,12 @@ print.dgr_graph <- function(x, ...) {
       paste0(
         x$edges_df$rel %>%
           unique() %>%
-          base::setdiff(as.character(NA)) %>%
+          base::setdiff(NA_character_) %>%
           length(), " val",
         ifelse(
           x$edges_df$rel %>%
             unique() %>%
-            base::setdiff(as.character(NA)) %>%
+            base::setdiff(NA_character_) %>%
             length() > 1, "s", ""))
 
   } else if (!any(is.na(x$edges_df$rel))) {
@@ -170,7 +170,7 @@ print.dgr_graph <- function(x, ...) {
       paste0(
         x$edges_df$rel %>%
           unique() %>%
-          base::setdiff(as.character(NA)) %>%
+          base::setdiff(NA_character_) %>%
           length(), " vals - complete")
   }
 

--- a/R/rev_edge_dir_ws.R
+++ b/R/rev_edge_dir_ws.R
@@ -110,7 +110,7 @@ rev_edge_dir_ws <- function(graph) {
     dplyr::filter(id %in% edge_ids) %>%
     dplyr::filter(from != to) %>%
     dplyr::rename(from = to, to = from) %>%
-    dplyr::select(id, from, to, dplyr::everything()) %>%
+    dplyr::relocate("id", "from", "to") %>%
     dplyr::bind_rows(., edges %>% dplyr::filter(!(id %in% edge_ids)))
 
   # Modify the graph object

--- a/R/set_edge_attr_to_display.R
+++ b/R/set_edge_attr_to_display.R
@@ -190,7 +190,7 @@ set_edge_attr_to_display <- function(
 
     display_col <-
       dplyr::case_when(
-        display_col == "is_na" ~ as.character(NA),
+        display_col == "is_na" ~ NA_character_,
         TRUE ~ display_col) %>%
       as.data.frame(stringsAsFactors = FALSE)
   }
@@ -206,8 +206,7 @@ set_edge_attr_to_display <- function(
   # modify the ordering of the columns
   edf <-
     dplyr::bind_cols(edf, display_col) %>%
-    dplyr::select(
-      id, from, to, rel, display, dplyr::everything())
+    dplyr::relocate(id, from, to, rel, display)
 
   # Replace the graph's edge data frame with `edf`
   graph$edges_df <- edf

--- a/R/set_edge_attrs.R
+++ b/R/set_edge_attrs.R
@@ -174,7 +174,7 @@ set_edge_attrs <- function(
     if (!(edge_attr %in% colnames(edf))) {
       edf <-
         cbind(edf,
-              rep(as.character(NA), nrow(edf)))
+              rep(NA_character_, nrow(edf)))
 
       edf[, ncol(edf)] <-
         edf[, ncol(edf)]

--- a/R/set_node_attr_to_display.R
+++ b/R/set_node_attr_to_display.R
@@ -186,7 +186,7 @@ set_node_attr_to_display <- function(
 
     display_col <-
       dplyr::case_when(
-        display_col == "is_na" ~ as.character(NA),
+        display_col == "is_na" ~ NA_character_,
         TRUE ~ display_col) %>%
       as.data.frame(stringsAsFactors = FALSE)
   }
@@ -202,8 +202,7 @@ set_node_attr_to_display <- function(
   # modify the ordering of the columns
   ndf <-
     dplyr::bind_cols(ndf, display_col) %>%
-    dplyr::select(
-      id, type, label, display, dplyr::everything())
+    dplyr::relocate(id, type, label, display)
 
   # Replace the graph's node data frame with `ndf`
   graph$nodes_df <- ndf

--- a/R/set_node_attrs.R
+++ b/R/set_node_attrs.R
@@ -148,7 +148,7 @@ set_node_attrs <- function(
     if (!(node_attr %in% colnames(ndf))) {
       ndf <-
         cbind(ndf,
-              rep(as.character(NA), nrow(ndf)))
+              rep(NA_character_, nrow(ndf)))
 
       ndf[, ncol(ndf)] <-
         ndf[, ncol(ndf)]

--- a/R/set_node_position.R
+++ b/R/set_node_position.R
@@ -142,7 +142,7 @@ set_node_position <- function(
   if (!("x" %in% colnames(ndf))) {
     ndf <-
       ndf %>%
-      dplyr::mutate(x = as.numeric(NA))
+      dplyr::mutate(x = NA_real_)
   }
 
   # If the `y` node attribute doesn't exist, create
@@ -150,7 +150,7 @@ set_node_position <- function(
   if (!("y" %in% colnames(ndf))) {
     ndf <-
       ndf %>%
-      dplyr::mutate(y = as.numeric(NA))
+      dplyr::mutate(y = NA_real_)
   }
 
   if (use_labels == TRUE) {

--- a/R/trav_both.R
+++ b/R/trav_both.R
@@ -327,7 +327,7 @@ trav_both <- function(
                          match.fun(!! agg)(!! as.name(copy_attrs_from),
                                            na.rm = TRUE)) %>%
       dplyr::right_join(ndf, by = "id") %>%
-      dplyr::select(id, type, label, dplyr::everything()) %>%
+      dplyr::relocate(id, type, label) %>%
       as.data.frame(stringsAsFactors = FALSE)
 
     # Get column numbers that end with ".x" or ".y"

--- a/R/trav_both_edge.R
+++ b/R/trav_both_edge.R
@@ -348,13 +348,13 @@ trav_both_edge <- function(
         dplyr::bind_rows(
           from_join, to_join) %>%
         dplyr::left_join(edf, by = c("e_id" = "id")) %>%
-        dplyr::rename(id = e_id) %>%
+        dplyr::rename(id = "e_id") %>%
         dplyr::group_by(id) %>%
         dplyr::summarize(!! copy_attrs_from :=
                            match.fun(!! agg)(!! as.name(copy_attrs_from),
                                              na.rm = TRUE)) %>%
         dplyr::right_join(edf, by = "id") %>%
-        dplyr::select(id, from, to, rel, dplyr::everything()) %>%
+        dplyr::relocate("id", "from", "to", "rel") %>%
         as.data.frame(stringsAsFractions = FALSE)
     }
 
@@ -483,12 +483,11 @@ trav_both_edge <- function(
       joined_edges <-
         edges %>%
         dplyr::arrange(e_id) %>%
-        dplyr::rename(id = e_id) %>%
+        dplyr::rename(id = "e_id") %>%
         dplyr::group_by(id) %>%
         dplyr::summarize(!! copy_attrs_from :=
                             match.fun(!! agg)(!! as.name(copy_attrs_from),
-                                              na.rm = TRUE)) %>%
-        dplyr::ungroup() %>%
+                                              na.rm = TRUE), .groups = "drop") %>%
         dplyr::right_join(edf, by = "id")
 
       # Get column numbers that end with ".x" or ".y"
@@ -514,7 +513,7 @@ trav_both_edge <- function(
 
       edges <-
         joined_edges %>%
-        dplyr::select(id, from, to, rel, dplyr::everything()) %>%
+        dplyr::relocate("id", "from", "to", "rel") %>%
         dplyr::arrange(id) %>%
         as.data.frame(stringsAsFractions = FALSE)
     }

--- a/R/trav_in.R
+++ b/R/trav_in.R
@@ -347,7 +347,7 @@ trav_in <- function(
     nodes <-
       nodes %>%
       dplyr::right_join(ndf, by = "id") %>%
-      dplyr::select(id, type, label, dplyr::everything()) %>%
+      dplyr::relocate("id", "type", "label") %>%
       dplyr::arrange(id) %>%
       as.data.frame(stringsAsFactors = FALSE)
 

--- a/R/trav_in_edge.R
+++ b/R/trav_in_edge.R
@@ -337,9 +337,9 @@ trav_in_edge <- function(
       edges <-
         ndf_2 %>%
         dplyr::right_join(edf, c("id" = "to")) %>%
-        dplyr::rename(to = id) %>%
-        dplyr::rename(id = id.y) %>%
-        dplyr::select(id, from, to, rel, dplyr::everything()) %>%
+        dplyr::rename(to = "id") %>%
+        dplyr::rename(id = "id.y") %>%
+        dplyr::relocate("id", "from", "to", "rel") %>%
         dplyr::arrange(id)
     }
 
@@ -375,7 +375,7 @@ trav_in_edge <- function(
       # Reorder columns
       edges <-
         edges %>%
-        dplyr::select(id, from, to, rel, dplyr::everything()) %>%
+        dplyr::relocate("id", "from", "to", "rel") %>%
         dplyr::arrange(id)
     }
 

--- a/R/trav_in_node.R
+++ b/R/trav_in_node.R
@@ -346,7 +346,7 @@ trav_in_node <- function(
                          match.fun(!! agg)(!! as.name(copy_attrs_from),
                                            na.rm = TRUE)) %>%
       dplyr::right_join(ndf, by = "id") %>%
-      dplyr::select(id, type, label, dplyr::everything()) %>%
+      dplyr::relocate("id", "type", "label") %>%
       as.data.frame(stringsAsFactors = FALSE)
 
     # If edge attribute exists as a column in the ndf
@@ -376,7 +376,7 @@ trav_in_node <- function(
       # Reorder columns
       nodes <-
         nodes %>%
-        dplyr::select(id, type, label, dplyr::everything())
+        dplyr::relocate("id", "type", "label")
     }
 
     # Update the graph's internal node data frame

--- a/R/trav_out.R
+++ b/R/trav_out.R
@@ -350,7 +350,7 @@ trav_out <- function(
     nodes <-
       nodes %>%
       dplyr::right_join(ndf, by = "id") %>%
-      dplyr::select(id, type, label, dplyr::everything()) %>%
+      dplyr::relocate(id, type, label) %>%
       as.data.frame(stringsAsFactors = FALSE)
 
     # Get column numbers that end with ".x" or ".y"

--- a/R/trav_out_edge.R
+++ b/R/trav_out_edge.R
@@ -319,8 +319,8 @@ trav_out_edge <- function(
       edges <-
         ndf_2 %>%
         dplyr::right_join(edf, c("id" = "from")) %>%
-        dplyr::rename(from = id.y) %>%
-        dplyr::select(id, from, to, rel, dplyr::everything())
+        dplyr::rename(from = "id.y") %>%
+        dplyr::relocate("id", "from", "to", "rel")
     }
 
     # If the node attribute exists as a column in the edf
@@ -356,7 +356,7 @@ trav_out_edge <- function(
       # Reorder columns
       edges <-
         edges %>%
-        dplyr::select(id, from, to, rel, dplyr::everything())
+        dplyr::relocate("id", "from", "to", "rel")
     }
 
     # Update the graph's internal node data frame

--- a/R/trav_out_node.R
+++ b/R/trav_out_node.R
@@ -344,7 +344,7 @@ trav_out_node <- function(
                          match.fun(!! agg)(!! as.name(copy_attrs_from),
                                            na.rm = TRUE)) %>%
       dplyr::right_join(ndf, by = "id") %>%
-      dplyr::select(id, type, label, dplyr::everything()) %>%
+      dplyr::relocate(id, type, label) %>%
       as.data.frame(stringsAsFactors = FALSE)
 
     # If edge attribute exists as a column in the ndf
@@ -374,7 +374,7 @@ trav_out_node <- function(
       # Reorder columns
       nodes <-
         nodes %>%
-        dplyr::select(id, type, label, dplyr::everything())
+        dplyr::relocate("id", "type", "label")
     }
 
     # Update the graph's internal node data frame

--- a/R/utils.R
+++ b/R/utils.R
@@ -126,7 +126,7 @@ node_edge_selection_properties <- function(graph) {
 
   } else {
 
-    selection_type <- as.character(NA)
+    selection_type <- NA_character_
     selection_count <- 0
     selection_count_str <- "no nodes or edges"
   }
@@ -814,15 +814,15 @@ get_df_ids <- function(graph_df) {
     if ("df_id" %in% colnames(graph_df)) {
 
       graph_df %>%
-        dplyr::select(df_id) %>%
+        dplyr::select("df_id") %>%
         dplyr::filter(!is.na(df_id)) %>%
-        dplyr::pull(df_id)
+        dplyr::pull("df_id")
     } else {
-      return(as.character(NA))
+      return(NA_character_)
     }
 
   } else if (nrow(graph_df) == 0) {
-    return(as.character(NA))
+    return(NA_character_)
   }
 }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,12 +24,11 @@ library(DiagrammeR)
 
 <!-- badges: start -->
 <a href="https://cran.r-project.org/package=DiagrammeR"><img src="https://www.r-pkg.org/badges/version/DiagrammeR" alt="CRAN status" /></a>
-<a href="https://github.com/rich-iannone/DiagrammeR/actions/workflows/R-CMD-check.yaml"><img src="https://github.com/rich-iannone/DiagrammeR/actions/workflows/R-CMD-check.yaml/badge.svg" alt="R build status" /></a>
+[![R-CMD-check](https://github.com/rich-iannone/DiagrammeR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rich-iannone/DiagrammeR/actions/workflows/R-CMD-check.yaml)
 <a href="https://app.codecov.io/gh/rich-iannone/DiagrammeR?branch=main"><img src="https://codecov.io/gh/rich-iannone/DiagrammeR/branch/main/graph/badge.svg" alt="Coverage status" /></a>
 
 <a href="https://CRAN.R-project.org/package=DiagrammeR"><img src="https://cranlogs.r-pkg.org/badges/DiagrammeR" alt="Monthly Downloads"></a>
 <a href="https://CRAN.R-project.org/package=DiagrammeR"><img src="https://cranlogs.r-pkg.org/badges/grand-total/DiagrammeR" alt="Total Downloads"></a>
-
 <a href="https://www.contributor-covenant.org/version/2/1/code_of_conduct.html"><img src="https://img.shields.io/badge/Contributor%20Covenant-v2.1%20adopted-ff69b4.svg" alt="Contributor Covenant" /></a>
 <!-- badges: end -->
 <hr style="color:transparent" />

--- a/tests/testthat/test-add_forward_reverse_edges.R
+++ b/tests/testthat/test-add_forward_reverse_edges.R
@@ -35,11 +35,12 @@ test_that("forward edges can be added given a selection of edges", {
 
   # Expect the edges have the same definition
   # of `1->2`
-  expect_true(
-    all(get_edges(graph) == "1->2"))
+  expect_in(
+    get_edges(graph),
+    "1->2")
 
   # Expect `rel` values of `a`, `b`, and `c`
-  expect_equivalent(
+  expect_equal(
     graph$edges_df$rel,
     c("a", "b", "c"))
 })

--- a/tests/testthat/test-add_graphs.R
+++ b/tests/testthat/test-add_graphs.R
@@ -980,7 +980,7 @@ test_that("Adding a full graph is possible", {
   # Expect type values to be character NA values
   expect_equal(
     unique(graph$nodes_df$type),
-    as.character(NA))
+    NA_character_)
 
   # Create a graph and add a full graph
   # with 3 nodes to it; discard loops
@@ -1337,7 +1337,7 @@ test_that("Adding a full graph is possible", {
   # character NA values
   expect_equal(
     graph$nodes_df$label,
-    rep(as.character(NA), 3))
+    rep(NA_character_, 3))
 
   # Expect that the `rel` edge attr
   # has the value `connected_to` for

--- a/tests/testthat/test-add_node_edge.R
+++ b/tests/testthat/test-add_node_edge.R
@@ -9,51 +9,46 @@ test_that("adding a node to a graph is possible", {
 
   # Expect that names in this graph object match a
   # prescribed set of names
-  expect_true(all(
-    names(graph) ==
-      c(
-        "graph_info",
-        "nodes_df",
-        "edges_df",
-        "global_attrs",
-        "directed",
-        "last_node",
-        "last_edge",
-        "node_selection",
-        "edge_selection",
-        "cache",
-        "graph_actions",
-        "graph_log"
-      )
-  ))
+  expect_named(
+    graph,
+    c(
+      "graph_info",
+      "nodes_df",
+      "edges_df",
+      "global_attrs",
+      "directed",
+      "last_node",
+      "last_edge",
+      "node_selection",
+      "edge_selection",
+      "cache",
+      "graph_actions",
+      "graph_log"
+    )
+  )
 
   # Expect a graph object of class `dgr_graph`
-  expect_is(
+  expect_s3_class(
     graph, "dgr_graph")
 
   # Expect that the `global_attrs` components is not NULL
   expect_true(
     !is.null(graph$global_attrs))
 
-  # Expect that the `nodes_df` component is a data frame
-  expect_is(
-    graph$nodes_df, "data.frame")
-
-  # Expect that the `edges_df` component is a data frame
-  expect_is(
-    graph$edges_df, "data.frame")
+  # Expect that the `nodes_df` and  `edges_df`  component are a data frame
+  expect_s3_class(graph$nodes_df, "data.frame")
+  expect_s3_class(graph$edges_df, "data.frame")
 
   # Expect that the graph is a directed graph
-  expect_true(
-    graph$directed == TRUE)
+  expect_true(graph$directed)
 
   # Expect that the `nodes_df` data frame has 3 columns
-  expect_true(
-    ncol(graph$nodes_df) == 3)
+  expect_equal(
+    ncol(graph$nodes_df), 3)
 
   # Expect that the `nodes_df` data frame has 2 rows
-  expect_true(
-    nrow(graph$nodes_df) == 2)
+  expect_equal(
+    nrow(graph$nodes_df), 2)
 
   # Add a node with attributes to the graph
   graph_3 <-
@@ -105,8 +100,8 @@ test_that("adding a node to a graph is possible", {
       from = 3)
 
   # Expect that `edges_df` is not NULL
-  expect_true(
-    !is.null(graph_from$edges_df))
+  expect_false(
+    is.null(graph_from$edges_df))
 
   # Expect that the new node is available in the graph
   expect_true(
@@ -140,8 +135,8 @@ test_that("adding a node to a graph is possible", {
       to = 3)
 
   # Expect that `edges_df` is not NULL
-  expect_true(
-    !is.null(graph_to$edges_df))
+  expect_false(
+    is.null(graph_to$edges_df))
 
   # Expect that the new node is available in the graph
   expect_true(
@@ -177,8 +172,8 @@ test_that("adding a node to a graph is possible", {
       to = 2)
 
   # Expect that `edges_df` is not NULL
-  expect_true(
-    !is.null(graph_to_from$edges_df))
+  expect_false(
+    is.null(graph_to_from$edges_df))
 
   # Expect that the new node is available in the graph
   expect_true(
@@ -239,51 +234,45 @@ test_that("adding an edge to a graph is possible", {
 
   # Expect that names in this graph object match a
   # prescribed set of names
-  expect_true(all(
-    names(graph) ==
-      c(
-        "graph_info",
-        "nodes_df",
-        "edges_df",
-        "global_attrs",
-        "directed",
-        "last_node",
-        "last_edge",
-        "node_selection",
-        "edge_selection",
-        "cache",
-        "graph_actions",
-        "graph_log"
-      )
-  ))
+  expect_named(
+    graph,
+    c(
+      "graph_info",
+      "nodes_df",
+      "edges_df",
+      "global_attrs",
+      "directed",
+      "last_node",
+      "last_edge",
+      "node_selection",
+      "edge_selection",
+      "cache",
+      "graph_actions",
+      "graph_log"
+    )
+  )
 
   # Expect a graph object of class `dgr_graph`
-  expect_is(
+  expect_s3_class(
     graph, "dgr_graph")
 
   # Expect that the `global_attrs` components is not NULL
-  expect_true(
-    !is.null(graph$global_attrs))
+  expect_false(
+    is.null(graph$global_attrs))
 
   # Expect that the `nodes_df` component is a data frame
-  expect_is(
+  expect_s3_class(
     graph$nodes_df, "data.frame")
 
   # Expect that the `edges_df` component is a data frame
-  expect_is(
+  expect_s3_class(
     graph$edges_df, "data.frame")
 
   # Expect that the graph is a directed graph
-  expect_true(
-    graph$directed == TRUE)
+  expect_true(graph$directed)
 
-  # Expect that the `nodes_df` data frame has 4 columns
-  expect_true(
-    ncol(graph$edges_df) == 4)
-
-  # Expect that the `nodes_df` data frame has 1 row
-  expect_true(
-    nrow(graph$edges_df) == 1)
+  # Expect that the `nodes_df` data frame has 1 row and 4 columns
+  expect_equal(dim(graph$edges_df),  c(1, 4))
 
   # Expect an error when attempting to add more than 1 edge
   expect_error(
@@ -320,9 +309,10 @@ test_that("adding an edge to a graph is possible", {
 
   # Expect that the edges in the graph are:
   # `3->4` and `4->1`
-  expect_true(
-    all(
-      c("3->4", "4->1") %in% get_edges(graph_2)))
+  expect_contains(
+    get_edges(graph_2),
+    c("3->4", "4->1")
+  )
 })
 
 test_that("adding several nodes to a graph at once is possible", {
@@ -487,13 +477,16 @@ test_that("adding several nodes from a selected node is possible", {
       rel = "related")
 
   # Expect that all edges have a `rel` set
-  expect_true(
-    all(graph$edges_df$rel == "related"))
+  expect_in(
+    graph$edges_df$rel,
+    "related"
+  )
 
   # Expect that all new nodes have a `type` set
-  expect_true(
-    all(
-      get_node_df(graph)[11:20, 2] == "new"))
+  expect_in(
+    get_node_df(graph)[11:20, 2],
+    "new"
+  )
 })
 
 test_that("adding several nodes to a selected node is possible", {
@@ -573,12 +566,12 @@ test_that("adding several nodes to a selected node is possible", {
       rel = "related")
 
   # Expect that all edges have a `rel` set
-  expect_true(
-    all(graph$edges_df$rel == "related"))
+  expect_in(
+    graph$edges_df$rel,"related")
 
   # Expect that all new nodes have a `type` set
-  expect_true(
-    all(graph$nodes_df$type[11:20] == "new"))
+  expect_in(
+    graph$nodes_df$type[11:20], "new")
 })
 
 test_that("adding several edges with a string is possible", {
@@ -794,10 +787,8 @@ test_that("adding node clones with a selection is possible", {
   # `label` attributes for the
   # last 3 nodes in the graph
   expect_true(
-    all(
-      is.na(
-        graph_1 %>%
-          get_node_df())[4:6, 3]))
+    all(is.na(get_node_df(graph_1)[4:6, 3]))
+    )
 
   # Create clones of all nodes
   # in the selection but assign
@@ -814,23 +805,20 @@ test_that("adding node clones with a selection is possible", {
   # Expect nodes with ID values
   # from 1 to 6
   expect_equal(
-    (graph_2 %>%
-       get_node_df)[, 1], 1:6)
+    get_node_df(graph_2)[, 1], 1:6)
 
   # Expect cloned values for the
   # `type` attribute for the
   # last 3 nodes in the graph
   expect_equal(
-    (graph_2 %>%
-       get_node_df())[4:6, 2],
+    get_node_df(graph_2)[4:6, 2],
     c("a", "b", "c"))
 
   # Expect specific values for the
   # `label` attributes for the
   # last 3 nodes in the graph
   expect_equal(
-    (graph_2 %>%
-       get_node_df())[4:6, 3],
+    get_node_df(graph_2)[4:6, 3],
     c("a", "b", "v"))
 
   # Create clones of all nodes
@@ -850,25 +838,21 @@ test_that("adding node clones with a selection is possible", {
   # Expect nodes with ID values
   # from 1 to 6
   expect_equal(
-    (graph_3 %>%
-       get_node_df)[, 1], 1:6)
+    get_node_df(graph_3)[, 1], 1:6)
 
   # Expect cloned values for the
   # `type` attribute for the
   # last 3 nodes in the graph
   expect_equal(
-    (graph_3 %>%
-       get_node_df())[4:6, 2],
+    get_node_df(graph_3)[4:6, 2],
     c("a", "b", "c"))
 
   # Expect NA values for the
   # `label` attributes for the
   # last 3 nodes in the graph
   expect_true(
-    all(
-      is.na(
-        graph_3 %>%
-          get_node_df())[4:6, 3]))
+    all(is.na(get_node_df(graph_3))[4:6, 3])
+    )
 
   # Expect 5 edges in the graph
   expect_equal(
@@ -877,24 +861,22 @@ test_that("adding node clones with a selection is possible", {
   # Expect edges with ID values
   # from 1 to 5
   expect_equal(
-    (graph_3 %>%
-       get_edge_df)[, 1], 1:5)
+    get_edge_df(graph_3)[, 1],
+    1:5)
 
   # Expect that specific edges have
   # been created
   expect_equal(
-    (graph_3 %>%
-       get_edges)[3:5],
-    c("1->4", "2->5", "3->6"))
+    get_edges(graph_3)[3:5],
+    c("1->4", "2->5", "3->6")
+    )
 
   # Expect NA values for the
   # `rel` attributes for the
   # last 3 edges in the graph
   expect_true(
-    all(
-      is.na(
-        (graph_3 %>%
-          get_edge_df())[3:5, 4])))
+    all(is.na(get_edge_df(graph_3)[3:5, 4]))
+    )
 
   # Create clones of all nodes
   # in the selection and
@@ -913,25 +895,20 @@ test_that("adding node clones with a selection is possible", {
   # Expect nodes with ID values
   # from 1 to 6
   expect_equal(
-    (graph_4 %>%
-       get_node_df)[, 1], 1:6)
+       get_node_df(graph_4)[, 1], 1:6)
 
   # Expect cloned values for the
   # `type` attribute for the
   # last 3 nodes in the graph
   expect_equal(
-    (graph_4 %>%
-       get_node_df())[4:6, 2],
+    get_node_df(graph_4)[4:6, 2],
     c("a", "b", "c"))
 
   # Expect NA values for the
   # `label` attributes for the
   # last 3 nodes in the graph
   expect_true(
-    all(
-      is.na(
-        graph_4 %>%
-          get_node_df())[4:6, 3]))
+    all(is.na(get_node_df(graph_4))[4:6, 3]))
 
   # Expect 5 edges in the graph
   expect_equal(
@@ -940,24 +917,20 @@ test_that("adding node clones with a selection is possible", {
   # Expect edges with ID values
   # from 1 to 5
   expect_equal(
-    (graph_4 %>%
-       get_edge_df)[, 1], 1:5)
+    get_edge_df(graph_4)[, 1], 1:5)
 
   # Expect that specific edges have
   # been created
   expect_equal(
-    (graph_4 %>%
-       get_edges)[3:5],
+    get_edges(graph_4)[3:5],
     c("4->1", "5->2", "6->3"))
 
   # Expect NA values for the
   # `rel` attributes for the
   # last 3 edges in the graph
   expect_true(
-    all(
-      is.na(
-        (graph_4 %>%
-           get_edge_df())[3:5, 4])))
+    all(is.na(get_edge_df(graph_4)[3:5, 4]))
+    )
 })
 
 test_that("adding edge clones is possible", {
@@ -1010,11 +983,9 @@ test_that("adding edge clones is possible", {
 
   # Expect that both edges will be have
   # the same `rel` values
-  expect_equal(
-    unique(edf_1[, 4]), "a")
+  expect_in(edf_1[, 4], "a")
 
   # Expect that both edges will be have
   # the same `color` values
-  expect_equal(
-    unique(edf_1[, 5]), "steelblue")
+  expect_in(edf_1[, 5], "steelblue")
 })

--- a/tests/testthat/test-add_node_edge.R
+++ b/tests/testthat/test-add_node_edge.R
@@ -345,12 +345,12 @@ test_that("adding several nodes to a graph at once is possible", {
   # Expect that no `type` values have been set
   expect_equal(
     get_node_df(graph)[, 2],
-    rep(as.character(NA), 10))
+    rep(NA_character_, 10))
 
   # Expect that no `label` values have been set
   expect_equal(
     get_node_df(graph)[, 3],
-    rep(as.character(NA), 10))
+    rep(NA_character_, 10))
 
   # Create a graph with 10 nodes of a specified type
   graph <- create_graph()
@@ -380,7 +380,7 @@ test_that("adding several nodes to a graph at once is possible", {
   # Expect that `label` values have not been set
   expect_equal(
     get_node_df(graph)[, 3],
-    rep(as.character(NA), 10))
+    rep(NA_character_, 10))
 })
 
 test_that("adding several nodes to a graph at once (with extra attrs) is possible", {
@@ -403,12 +403,12 @@ test_that("adding several nodes to a graph at once (with extra attrs) is possibl
   # Expect that no `type` values have been set
   expect_equal(
     get_node_df(graph)[, 2],
-    rep(as.character(NA), 10))
+    rep(NA_character_, 10))
 
   # Expect that no `label` values have been set
   expect_equal(
     get_node_df(graph)[, 3],
-    rep(as.character(NA), 10))
+    rep(NA_character_, 10))
 })
 
 test_that("adding several nodes from a selected node is possible", {
@@ -458,7 +458,7 @@ test_that("adding several nodes from a selected node is possible", {
   # for any of the edges
   expect_equal(
     graph$edges_df$rel,
-    rep(as.character(NA), 10))
+    rep(NA_character_, 10))
 
   # Create another empty graph
   graph <- create_graph()
@@ -544,7 +544,7 @@ test_that("adding several nodes to a selected node is possible", {
   # for any of the edges
   expect_equal(
     graph$edges_df$rel,
-    rep(as.character(NA), 10))
+    rep(NA_character_, 10))
 
   # Create another empty graph
   graph <- create_graph()
@@ -611,7 +611,7 @@ test_that("adding several edges with a string is possible", {
   # for any of the edges
   expect_equal(
     graph$edges_df$rel,
-    rep(as.character(NA), 9))
+    rep(NA_character_, 9))
 
   # Create another empty graph
   graph <- create_graph()
@@ -749,7 +749,7 @@ test_that("adding node clones is possible", {
   # have NA `label` values
   expect_equal(
     ndf_2[4:6, 3],
-    rep(as.character(NA), 3))
+    rep(NA_character_, 3))
 })
 
 test_that("adding node clones with a selection is possible", {

--- a/tests/testthat/test-add_node_edge_df.R
+++ b/tests/testthat/test-add_node_edge_df.R
@@ -37,55 +37,57 @@ test_that("adding a node df to a graph is possible", {
 
   # Expect that names in these graph objects match a
   # prescribed set of names
-  expect_true(
-    all(
-      names(graph_2) ==
-        c(
-          "graph_info",
-          "nodes_df",
-          "edges_df",
-          "global_attrs",
-          "directed",
-          "last_node",
-          "last_edge",
-          "node_selection",
-          "edge_selection",
-          "cache",
-          "graph_actions",
-          "graph_log")))
+  expect_named(
+    graph_2,
+    c(
+      "graph_info",
+      "nodes_df",
+      "edges_df",
+      "global_attrs",
+      "directed",
+      "last_node",
+      "last_edge",
+      "node_selection",
+      "edge_selection",
+      "cache",
+      "graph_actions",
+      "graph_log"
+    )
+  )
 
-  expect_true(
-    all(
-      names(graph_3) ==
-        c(
-          "graph_info",
-          "nodes_df",
-          "edges_df",
-          "global_attrs",
-          "directed",
-          "last_node",
-          "last_edge",
-          "node_selection",
-          "edge_selection",
-          "cache",
-          "graph_actions",
-          "graph_log")))
+  expect_named(
+    graph_3,
+    c(
+      "graph_info",
+      "nodes_df",
+      "edges_df",
+      "global_attrs",
+      "directed",
+      "last_node",
+      "last_edge",
+      "node_selection",
+      "edge_selection",
+      "cache",
+      "graph_actions",
+      "graph_log"
+    )
+  )
 
   # Expect graph objects of class `dgr_graph`
-  expect_is(graph_2, "dgr_graph")
-  expect_is(graph_3, "dgr_graph")
+  expect_s3_class(graph_2, "dgr_graph")
+  expect_s3_class(graph_3, "dgr_graph")
 
   # Expect that the `nodes_df` component is a data frame
-  expect_is(graph_2$nodes_df, "data.frame")
-  expect_is(graph_3$nodes_df, "data.frame")
+  expect_s3_class(graph_2$nodes_df, "data.frame")
+  expect_s3_class(graph_3$nodes_df, "data.frame")
 
   # Expect that the `nodes_df` data frame has 4 and 8 rows
-  expect_true(nrow(graph_2$nodes_df) == 4)
-  expect_true(nrow(graph_3$nodes_df) == 8)
+  expect_equal(nrow(graph_2$nodes_df), 4)
+  expect_equal(nrow(graph_3$nodes_df), 8)
 
   # Expect that the `nodes_df` data frame has 5 columns
-  expect_true(ncol(graph_2$nodes_df) == 5)
-  expect_true(ncol(graph_3$nodes_df) == 5)
+  expect_equal(ncol(graph_2$nodes_df), 5)
+  expect_equal(ncol(graph_3$nodes_df), 5)
 })
 
 test_that("adding an edge df to a graph is possible", {
@@ -143,20 +145,20 @@ test_that("adding an edge df to a graph is possible", {
       edge_df = edges)
 
   # Expect a graph object of class `dgr_graph`
-  expect_is(
+  expect_s3_class(
     graph_3, "dgr_graph")
 
   # Expect that the `edges_df` component is a data frame
-  expect_is(
+  expect_s3_class(
     graph_3$edges_df, "data.frame")
 
   # Expect that the `edges_df` data frame has 3 rows
-  expect_true(
-    nrow(graph_3$edges_df) == 3)
+  expect_equal(
+    nrow(graph_3$edges_df), 3)
 
   # Expect that the `edges_df` data frame has 4 columns
-  expect_true(
-    ncol(graph_3$edges_df) == 4)
+  expect_equal(
+    ncol(graph_3$edges_df), 4)
 
   # Add another edge to a graph that already has some
   # edges defined
@@ -166,6 +168,6 @@ test_that("adding an edge df to a graph is possible", {
       edge_df = create_edge_df(from = 2, to = 4))
 
   # Expect that the `edges_df` data frame has 4 rows
-  expect_true(
-    nrow(graph_3$edges_df) == 4)
+  expect_equal(
+    nrow(graph_3$edges_df), 4)
 })

--- a/tests/testthat/test-add_nodes_edges_from_table.R
+++ b/tests/testthat/test-add_nodes_edges_from_table.R
@@ -858,6 +858,6 @@ test_that("adding nodes from several table columns to a graph is possible", {
   # for the last three nodes (others are not set)
   expect_equal(
     graph %>% get_node_df() %>% .$type,
-    c(rep(as.character(NA), 12),
+    c(rep(NA_character_, 12),
       rep("new", 3)))
 })

--- a/tests/testthat/test-add_nodes_edges_from_table.R
+++ b/tests/testthat/test-add_nodes_edges_from_table.R
@@ -211,13 +211,12 @@ test_that("adding nodes from a table to a graph is possible", {
 
   # Expect that there aren't any NA values in the
   # graph's `label` column
-  expect_true(
-    all(!is.na(graph_2_df$nodes_df[, 3])))
+  expect_false(
+    anyNA(graph_2_df$nodes_df[, 3]))
 
   # Expect that the values in the `label` are
   # of the character class
-  expect_true(
-    is.character(graph_2_df$nodes_df[, 3]))
+  expect_type(graph_2_df$nodes_df[, 3], "character")
 
   # Add nodes from the df; also apply a static value
   # for `type` as `currency`
@@ -230,8 +229,7 @@ test_that("adding nodes from a table to a graph is possible", {
 
   # Expect that all values set for the `type`
   # attribute are `currency`
-  expect_true(
-    all(graph_3_df$nodes_df[, 2] == "currency"))
+  expect_in(graph_3_df$nodes_df[, 2], "currency")
 
   # Add nodes from the df; drop some of the
   # incoming columns
@@ -246,8 +244,8 @@ test_that("adding nodes from a table to a graph is possible", {
   # Expect that the node attributes `exponent`
   # and `currency_name` do not appear in the graph's
   # internal node data frame
-  expect_true(
-    !all(c("exponent", "currency_name") %in%
+  expect_false(
+    all(c("exponent", "currency_name") %in%
            colnames(graph_4_df$nodes_df)))
 
   # Add nodes from the df; assign a table column
@@ -262,9 +260,9 @@ test_that("adding nodes from a table to a graph is possible", {
 
   # Expect that all values set for the `type`
   # attribute are have certain values (including NA)
-  expect_true(
-    all(graph_5_df$nodes_df[, 2] %in%
-          c("0", "1", "2", "3", "4", NA)))
+  expect_in(
+    graph_5_df$nodes_df[, 2],
+    c("0", "1", "2", "3", "4", NA))
 })
 
 test_that("adding edges from a table to a graph is possible", {

--- a/tests/testthat/test-cache_attrs.R
+++ b/tests/testthat/test-cache_attrs.R
@@ -130,13 +130,10 @@ test_that("Getting a cache is possible", {
       graph = graph_cache,
       name = "closeness_vector")
 
-  # Expect a vector of length 10
-  expect_equal(
-    length(cached), 10)
+  # Expect a numeric vector of length 10
+  expect_length(cached, 10)
+  expect_type(cached, "double")
 
-  # Expect the vector to be `numeric`
-  expect_is(
-    cached, "numeric")
 
   # Expect that the cached values in `cached` are
   # equivalent to those in `graph$cache`
@@ -148,13 +145,9 @@ test_that("Getting a cache is possible", {
     get_cache(
       graph = graph_cache)
 
-  # Expect a vector of length 10
-  expect_equal(
-    length(cached_last), 10)
-
-  # Expect the vector to be `numeric`
-  expect_is(
-    cached_last, "numeric")
+  # Expect a numeric vector of length 10
+  expect_length(cached_last, 10)
+  expect_type(cached_last, "double")
 
   # Create a new graph
   graph <-
@@ -168,6 +161,5 @@ test_that("Getting a cache is possible", {
 
   # Expect NA when trying to obtain a cache that is
   # not present
-  expect_true(
-    is.na(get_cache(graph)))
+  expect_true(is.na(get_cache(graph)))
 })

--- a/tests/testthat/test-colorize_nodes_edges.R
+++ b/tests/testthat/test-colorize_nodes_edges.R
@@ -33,8 +33,7 @@ test_that("Adding color based on node attributes is possible", {
 
   # Expect that the `fillcolor` column has
   # been created in the node data frame
-  expect_true(
-    "fillcolor" %in% colnames(graph$nodes_df))
+  expect_contains(colnames(graph$nodes_df), "fillcolor")
 
   # Expect that there are as many different
   # colors in the `fillcolor` column as there
@@ -65,8 +64,7 @@ test_that("Adding color based on node attributes is possible", {
 
   # Expect that the `color` column has
   # been created in the node data frame
-  expect_true(
-    "color" %in% colnames(graph$nodes_df))
+  expect_contains(colnames(graph$nodes_df), "color")
 
   # Expect that there are as many different
   # colors in the `color` column as there
@@ -106,15 +104,11 @@ test_that("Adding color based on node attributes is possible", {
 
   # Expect that the `fillcolor` column has
   # been created in the node data frame
-  expect_true(
-    "fillcolor" %in% colnames(graph$nodes_df))
+  expect_contains(colnames(graph$nodes_df), "fillcolor")
 
   # Expect that there are 5 colors in the
   # `fillcolor` column
-  expect_equal(
-    length(
-      unique(
-        graph$nodes_df$fillcolor)), 5)
+  expect_length(unique(graph$nodes_df$fillcolor), 5)
 
   # Expect that each value in the `fillcolor`
   # column is a properly-formed hexadecimal color
@@ -141,10 +135,7 @@ test_that("Adding color based on node attributes is possible", {
 
   # Expect that there are 5 colors in the
   # `fillcolor` column
-  expect_equal(
-    length(
-      unique(
-        graph$nodes_df$fillcolor)), 5)
+  expect_length(unique(graph$nodes_df$fillcolor), 5)
 
   # Expect that each value in the `color` column
   # is a properly-formed hexadecimal color code
@@ -171,10 +162,7 @@ test_that("Adding color based on node attributes is possible", {
 
   # Expect that there are 5 colors in the
   # `fillcolor` column
-  expect_equal(
-    length(
-      unique(
-        graph$nodes_df$fillcolor)), 5)
+  expect_length(unique(graph$nodes_df$fillcolor), 5)
 
   # Expect that each value in the `fillcolor`
   # column is a properly-formed hexadecimal color
@@ -202,10 +190,7 @@ test_that("Adding color based on node attributes is possible", {
 
   # Expect that there are 5 colors in the
   # `fillcolor` column
-  expect_equal(
-    length(
-      unique(
-        graph$nodes_df$fillcolor)), 5)
+  expect_length(unique(graph$nodes_df$fillcolor), 5)
 
   # Expect that each value in the `fillcolor`
   # column is a properly-formed hexadecimal color
@@ -264,11 +249,10 @@ test_that("Adding color based on edge attributes is possible", {
 
   # Expect that the `color` and `fontcolor`
   # columns have been created in the edf
-  expect_true(
-    "color" %in% colnames(graph$edges_df))
-
-  expect_true(
-    "fontcolor" %in% colnames(graph$edges_df))
+  expect_contains(
+    colnames(graph$edges_df),
+    c("color", "fontcolor")
+  )
 
   # Expect that there are as many different
   # colors in the `color` and `fontcolor`
@@ -308,13 +292,14 @@ test_that("Adding color based on edge attributes is possible", {
 
   # Expect that the `labelfontcolor` column has
   # been created in the edge data frame
-  expect_true(
-    "labelfontcolor" %in% colnames(graph$edges_df))
+  expect_contains(
+    colnames(graph$edges_df),
+    "labelfontcolor"
+    )
 
   # Expect that there are 4 colors in the
   # `labelfontcolor` column
-  expect_equal(
-    length(unique(graph$edges_df$labelfontcolor)), 4)
+  expect_length(unique(graph$edges_df$labelfontcolor), 4)
 
   # Expect that each value in the `labelfontcolor`
   # column is a properly-formed hexadecimal color
@@ -352,8 +337,7 @@ test_that("Adding color based on edge attributes is possible", {
 
   # Expect that there are 4 colors in the
   # `labelfontcolor` column
-  expect_equal(
-    length(unique(graph$edges_df$labelfontcolor)), 4)
+  expect_length(unique(graph$edges_df$labelfontcolor), 4)
 
   # Expect that each value in the `labelfontcolor`
   # column is a properly-formed hexadecimal color

--- a/tests/testthat/test-combine_graphs.R
+++ b/tests/testthat/test-combine_graphs.R
@@ -32,51 +32,50 @@ test_that("graphs can be combined", {
     combine_graphs(graph_1, graph_2)
 
   # Expect a graph object of class `dgr_graph`
-  expect_is(
+  expect_s3_class(
     combined_graph_1, "dgr_graph")
 
   # Expect that names in graph object match a
   # prescribed set of names
-  expect_true(
-    all(
-      names(combined_graph_1) ==
-        c(
-          "graph_info",
-          "nodes_df",
-          "edges_df",
-          "global_attrs",
-          "directed",
-          "last_node",
-          "last_edge",
-          "node_selection",
-          "edge_selection",
-          "cache",
-          "graph_actions",
-          "graph_log")))
+  expect_in(
+    names(combined_graph_1),
+    c(
+      "graph_info",
+      "nodes_df",
+      "edges_df",
+      "global_attrs",
+      "directed",
+      "last_node",
+      "last_edge",
+      "node_selection",
+      "edge_selection",
+      "cache",
+      "graph_actions",
+      "graph_log"
+    )
+  )
 
   # Expect that the `global_attrs` graph component
   # is not NULL
-  expect_true(
-    !is.null(combined_graph_1$global_attrs))
+  expect_false(is.null(combined_graph_1$global_attrs))
 
   # Expect that the `is_graph_directed()` function
   # will return TRUE
-  expect_true(
-    is_graph_directed(combined_graph_1))
+  expect_true(is_graph_directed(combined_graph_1))
 
   # Expect that the `nodes_df` df has 3 columns
-  expect_true(
-    ncol(combined_graph_1$nodes_df) == 3)
+  expect_equal(
+    ncol(combined_graph_1$nodes_df), 3)
 
   # Expect that the `nodes_df` df has 20 rows
-  expect_true(
-    nrow(combined_graph_1$nodes_df) == 20)
+  expect_equal(
+    nrow(combined_graph_1$nodes_df), 20)
 
   # Expect that the `edges_df` df has 4 columns
-  expect_true(
-    ncol(combined_graph_1$edges_df) == 4)
+  expect_equal(
+    ncol(combined_graph_1$edges_df), 4)
 
   # Expect that the `edges_df` df has 18 rows
-  expect_true(
-    nrow(combined_graph_1$edges_df) == 18)
+  expect_equal(
+    nrow(combined_graph_1$edges_df), 18)
 })

--- a/tests/testthat/test-copy_drop_mutate_recode_attrs.R
+++ b/tests/testthat/test-copy_drop_mutate_recode_attrs.R
@@ -20,8 +20,7 @@ test_that("Copying node attributes is possible", {
       node_attr_to = value_2)
 
   # Verify that the new column has been made
-  expect_true(
-    "value_2" %in% colnames(graph$nodes_df))
+  expect_contains(colnames(graph$nodes_df), "value_2")
 
   # Expect that the values in `value` and `value_2`
   # are identical
@@ -81,8 +80,7 @@ test_that("Copying edge attributes is possible", {
       edge_attr_to = value_2)
 
   # Verify that the new column has been made
-  expect_true(
-    "value_2" %in% colnames(graph$edges_df))
+  expect_contains(colnames(graph$edges_df), "value_2")
 
   # Expect that the values in `value` and `value_2`
   # are identical
@@ -144,8 +142,8 @@ test_that("Dropping node attributes is possible", {
     drop_node_attrs(node_attr = value)
 
   # Verify that the `value` column is not present
-  expect_true(
-    !("value" %in% colnames(graph$nodes_df)))
+  expect_false(
+    "value" %in% colnames(graph$nodes_df))
 
   # Expect an error if `node_attr` is any of
   # `nodes`, `node`, `type`, or `label`
@@ -185,8 +183,8 @@ test_that("Dropping edge attributes is possible", {
     drop_edge_attrs(edge_attr = value)
 
   # Verify that the `value` column is not present
-  expect_true(
-    !("value" %in% colnames(graph$edges_df)))
+  expect_false(
+    "value" %in% colnames(graph$edges_df))
 
   # Expect an error if `edge_attr` is any of
   # `from`, `to`, or `rel`
@@ -222,8 +220,7 @@ test_that("Renaming node attributes is possible", {
 
   # Expect that the `color` node attr is in the
   # graph's node data frame
-  expect_true(
-    "color" %in% colnames(graph$nodes_df))
+  expect_contains(colnames(graph$nodes_df), "color")
 
   # Expect that the `shape` node attr is not in the
   # graph's node data frame
@@ -307,8 +304,7 @@ test_that("Renaming edge attributes is possible", {
 
   # Expect that the `width` node attr is in the
   # graph's edge data frame
-  expect_true(
-    "width" %in% colnames(graph$edges_df))
+  expect_contains(colnames(graph$edges_df), "width")
 
   # Expect that the `penwidth` node attr is not in the
   # graph's node data frame
@@ -405,8 +401,7 @@ test_that("Mutating node attributes is possible", {
       value_2 = value * 2)
 
   # Verify that the new column has been made
-  expect_true(
-    "value_2" %in% colnames(graph$nodes_df))
+  expect_contains(colnames(graph$nodes_df), "value_2")
 
   # Expect each value in `value_2` to be 4
   expect_equal(
@@ -463,8 +458,7 @@ test_that("Mutating edge attributes is possible", {
       value_2 = value * 2)
 
   # Verify that the new column has been made
-  expect_true(
-    "value_2" %in% colnames(graph$edges_df))
+  expect_contains(colnames(graph$edges_df), "value_2")
 
   # Expect each value in `value_2` to be 4
   expect_equal(
@@ -594,8 +588,7 @@ test_that("Recoding node attributes is possible", {
       node_attr_to = value_2)
 
   # Verify that the new column has been made
-  expect_true(
-    "value_2" %in% colnames(graph$nodes_df))
+  expect_contains(colnames(graph$nodes_df), "value_2")
 
   # Expect each value in `value_2` to be 4
   expect_equal(
@@ -797,8 +790,7 @@ test_that("Recoding edge attributes is possible", {
       edge_attr_to = value_2)
 
   # Verify that the new column has been made
-  expect_true(
-    "value_2" %in% colnames(graph$edges_df))
+  expect_contains(colnames(graph$edges_df), "value_2")
 
   # Expect certain values in `value_2`
   expect_equal(

--- a/tests/testthat/test-count_entities.R
+++ b/tests/testthat/test-count_entities.R
@@ -13,7 +13,7 @@ test_that("getting a node count (with `count_nodes()`) is possible", {
 
   # Expect that the `total_count_of_nodes` object
   # is a named vector
-  expect_is(
+  expect_type(
     n_nodes, "integer")
 
   expect_equal(
@@ -33,11 +33,7 @@ test_that("getting an edge count (with `count_edges()`) is possible", {
 
   # Expect that the `n_edges` object is
   # an integer
-  expect_is(
-    n_edges, "integer")
-
-  expect_equal(
-    n_edges, 4)
+  expect_equal(n_edges, 4L)
 })
 
 test_that("getting a node/edge count for an empty graph is possible", {

--- a/tests/testthat/test-create_combine_edges.R
+++ b/tests/testthat/test-create_combine_edges.R
@@ -21,11 +21,9 @@ test_that("a correct edge data frame is generated", {
       color = "red")
 
   # Expect that data frames are generated
-  expect_is(
-    edges_1, "data.frame")
+  expect_s3_class(edges_1, "data.frame")
 
-  expect_is(
-    edges_2, "data.frame")
+  expect_s3_class(edges_2, "data.frame")
 
   # Expect that each of the edfs has 4 rows
   expect_equal(
@@ -52,7 +50,7 @@ test_that("a correct edge data frame is generated", {
       data = c(2.7, 8.9, 2.6, 0.6))
 
   # Expect that a data frame is generated
-  expect_is(
+  expect_s3_class(
     edges_var_1, "data.frame")
 
   # Expect that the data frame has 4 rows
@@ -77,7 +75,7 @@ test_that("a correct edge data frame is generated", {
       data = c(2.7, 8.9, 2.6, 0.6))
 
   # Expect that a data frame is generated
-  expect_is(
+  expect_s3_class(
     edges_var_2, "data.frame")
 
   # Expect that the data frame has 4 rows
@@ -115,7 +113,7 @@ test_that("two edge data frames can be successfully combined", {
     combine_edfs(edges_1, edges_2)
 
   # Expect that a data frame is generated
-  expect_is(
+  expect_s3_class(
     all_edges, "data.frame")
 
   # Expect that the combined edf has 8 rows
@@ -162,7 +160,7 @@ test_that("three edge data frames can be successfully combined", {
       edges_1, edges_2, edges_3)
 
   # Expect that a data frame is generated
-  expect_is(
+  expect_s3_class(
     all_edges, "data.frame")
 
   # Expect that the combined edf has 8 rows

--- a/tests/testthat/test-create_combine_nodes.R
+++ b/tests/testthat/test-create_combine_nodes.R
@@ -35,16 +35,16 @@ test_that("a correct node data frame is generated", {
   expect_equal(ncol(nodes_2), 7)
 
   # Expect that 'label = NULL' produces blank label columns
-  expect_equal(nodes_1$label, rep(as.character(NA), 4))
-  expect_equal(nodes_2$label, rep(as.character(NA), 4))
+  expect_equal(nodes_1$label, rep(NA_character_, 4))
+  expect_equal(nodes_2$label, rep(NA_character_, 4))
 
   # Expect that a single value repeats across rows
-  expect_true(all(nodes_1$type == rep("lower", 4)))
-  expect_true(all(nodes_2$color == rep("red", 4)))
+  expect_equal(nodes_1$type, rep("lower", 4))
+  expect_equal(nodes_2$color, rep("red", 4))
 
   # Expect that the numeric `data` values are numeric
-  expect_is(nodes_1$data, "numeric")
-  expect_is(nodes_2$data, "numeric")
+  expect_type(nodes_1$data, "double")
+  expect_type(nodes_2$data, "double")
 
   # Create a node data frame using a vector with length > 1 and
   # length < length(from | to)
@@ -53,7 +53,7 @@ test_that("a correct node data frame is generated", {
                    color = c("green", "green"))
 
   # Expect that a data frame is generated
-  expect_is(nodes_var_1, "data.frame")
+  expect_s3_class(nodes_var_1, "data.frame")
 
   # Expect that the data frame has 4 rows
   expect_equal(nrow(nodes_var_1), 4)
@@ -73,7 +73,7 @@ test_that("a correct node data frame is generated", {
     )
 
   # Expect that a data frame is generated
-  expect_is(nodes_var_2, "data.frame")
+  expect_s3_class(nodes_var_2, "data.frame")
 
   # Expect that the data frame has 4 rows
   expect_equal(nrow(nodes_var_2), 4)
@@ -135,21 +135,21 @@ test_that("node data frames can be successfully combined", {
   expect_equal(ncol(all_nodes), 7)
 
   # Expect that the 'label' columns has spaces for labels
-  expect_equal(all_nodes$label, rep(as.character(NA), 8))
+  expect_equal(all_nodes$label, rep(NA_character_, 8))
 
   # Expect that the rows combined correctly
-  expect_true(all(all_nodes[, 1] ==
-                    c(1, 2, 3, 4, 5, 6, 7, 8)))
-  expect_true(all(c(ndf_1[, 2], ndf_2[, 2]) ==
-                    all_nodes[, 2]))
+  expect_equal(all_nodes[, 1],
+               c(1, 2, 3, 4, 5, 6, 7, 8))
+  expect_equal(c(ndf_1[, 2], ndf_2[, 2]),
+              all_nodes[, 2])
   expect_equal(c(ndf_1[, 3], ndf_2[, 3]),
                all_nodes[, 3])
-  expect_true(all(c(ndf_1[, 4], ndf_2[, 4]) ==
-                    all_nodes[, 4]))
-  expect_true(all(c(ndf_1[, 5], ndf_2[, 5]) ==
-                    all_nodes[, 5]))
-  expect_true(all(c(ndf_1[, 6], ndf_2[, 6]) ==
-                    all_nodes[, 6]))
-  expect_true(all(c(ndf_1[, 7], ndf_2[, 7]) ==
-                    all_nodes[, 7]))
+  expect_equal(c(ndf_1[, 4], ndf_2[, 4]),
+               all_nodes[, 4])
+  expect_equal(c(ndf_1[, 5], ndf_2[, 5]),
+               all_nodes[, 5])
+  expect_equal(c(ndf_1[, 6], ndf_2[, 6]),
+               all_nodes[, 6])
+  expect_equal(c(ndf_1[, 7], ndf_2[, 7]),
+              all_nodes[, 7])
 })

--- a/tests/testthat/test-create_graph.R
+++ b/tests/testthat/test-create_graph.R
@@ -7,54 +7,45 @@ test_that("an empty graph object can be created and such an object is correct", 
 
   # Expect that names in graph object match a
   # prescribed set of names
-  expect_true(
-    all(
-      names(graph) ==
-        c(
-          "graph_info",
-          "nodes_df",
-          "edges_df",
-          "global_attrs",
-          "directed",
-          "last_node",
-          "last_edge",
-          "node_selection",
-          "edge_selection",
-          "cache",
-          "graph_actions",
-          "graph_log")))
+  expect_named(
+    graph,
+    c(
+      "graph_info",
+      "nodes_df",
+      "edges_df",
+      "global_attrs",
+      "directed",
+      "last_node",
+      "last_edge",
+      "node_selection",
+      "edge_selection",
+      "cache",
+      "graph_actions",
+      "graph_log"
+    )
+  )
 
   # Expect a graph object of class `dgr_graph`
-  expect_is(
-    graph, "dgr_graph")
+  expect_s3_class(graph, "dgr_graph")
 
-  # Expect that the `nodes_df` component is
+  # Expect that the `nodes_df` and  `edges_df` components are
   # a data frame
-  expect_is(
-    graph$nodes_df, "data.frame")
-
-  # Expect that the `edges_df` component is
-  # a data frame
-  expect_is(
-    graph$edges_df , "data.frame")
+  expect_s3_class(graph$nodes_df, "data.frame")
+  expect_s3_class(graph$edges_df , "data.frame")
 
   # Expect that the use of `is_graph_empty()` function
   # will result in TRUE
-  expect_true(
-    is_graph_empty(graph))
+  expect_true(is_graph_empty(graph))
 
   # Expect that the `global_attrs` component is not NULL
-  expect_true(
-    !is.null(graph$global_attrs))
+  expect_false(is.null(graph$global_attrs))
 
   # Expect that the empty graph is directed by default
-  expect_true(
-    graph$directed)
+  expect_true(graph$directed)
 
   # Expect that the `is_graph_directed()` function
   # will return TRUE
-  expect_true(
-    is_graph_directed(graph))
+  expect_true(is_graph_directed(graph))
 })
 
 test_that("a graph object with nodes can be created correctly", {
@@ -75,56 +66,49 @@ test_that("a graph object with nodes can be created correctly", {
 
   # Expect that names in this graph object match a
   # prescribed set of names
-  expect_true(
-    all(
-      names(graph) ==
-        c(
-          "graph_info",
-          "nodes_df",
-          "edges_df",
-          "global_attrs",
-          "directed",
-          "last_node",
-          "last_edge",
-          "node_selection",
-          "edge_selection",
-          "cache",
-          "graph_actions",
-          "graph_log")))
+  expect_in(
+    names(graph),
+    c(
+      "graph_info",
+      "nodes_df",
+      "edges_df",
+      "global_attrs",
+      "directed",
+      "last_node",
+      "last_edge",
+      "node_selection",
+      "edge_selection",
+      "cache",
+      "graph_actions",
+      "graph_log"
+    )
+  )
 
   # Expect a graph object of class `dgr_graph`
-  expect_is(
+  expect_s3_class(
     graph, "dgr_graph")
 
   # Expect that several of the graph components
   # are not NULL
-  expect_true(
-    !is.null(graph$nodes_df))
+  expect_false(is.null(graph$nodes_df))
 
-  expect_true(
-    !is.null(graph$global_attrs))
+  expect_false(is.null(graph$global_attrs))
 
-  # Expect that the `nodes_df` component is
+  # Expect that the `nodes_df` and `edges_df` component is
   # a data frame
-  expect_is(
-    graph$nodes_df, "data.frame")
-
-  # Expect that the `edges_df` component is
-  # a data frame
-  expect_is(
-    graph$edges_df , "data.frame")
+  expect_s3_class(graph$nodes_df, "data.frame")
+  expect_s3_class(graph$edges_df , "data.frame")
 
   # Expect that the graph is a directed graph
-  expect_true(
-    graph$directed == TRUE)
+  expect_true(graph$directed)
 
   # Expect that the `nodes_df` df has 7 columns
-  expect_true(
-    ncol(graph$nodes_df) == 7)
+  expect_equal(
+    ncol(graph$nodes_df), 7)
 
   # Expect that the `nodes_df` df has 4 rows
-  expect_true(
-    nrow(graph$nodes_df) == 4)
+  expect_equal(
+    nrow(graph$nodes_df), 4)
 })
 
 test_that("a graph object with nodes and edges can be created correctly", {
@@ -156,25 +140,26 @@ test_that("a graph object with nodes and edges can be created correctly", {
 
   # Expect that names in this graph object match a
   # prescribed set of names
-  expect_true(
-    all(
-      names(graph) ==
-        c(
-          "graph_info",
-          "nodes_df",
-          "edges_df",
-          "global_attrs",
-          "directed",
-          "last_node",
-          "last_edge",
-          "node_selection",
-          "edge_selection",
-          "cache",
-          "graph_actions",
-          "graph_log")))
+  expect_in(
+    names(graph),
+    c(
+      "graph_info",
+      "nodes_df",
+      "edges_df",
+      "global_attrs",
+      "directed",
+      "last_node",
+      "last_edge",
+      "node_selection",
+      "edge_selection",
+      "cache",
+      "graph_actions",
+      "graph_log"
+    )
+  )
 
   # Expect a graph object of class `dgr_graph`
-  expect_is(
+  expect_s3_class(
     graph, "dgr_graph")
 
   # Expect that the `global_attrs` component is not NULL
@@ -183,31 +168,31 @@ test_that("a graph object with nodes and edges can be created correctly", {
 
   # Expect that the `nodes_df` component is
   # a data frame
-  expect_is(
+  expect_s3_class(
     graph$nodes_df, "data.frame")
 
   # Expect that the `edges_df` component is
   # a data frame
-  expect_is(
+  expect_s3_class(
     graph$edges_df , "data.frame")
 
   # Expect that the graph is a directed graph
   expect_true(
-    graph$directed == TRUE)
+    graph$directed)
 
   # Expect that the `nodes_df` df has 7 columns
-  expect_true(
-    ncol(graph$nodes_df) == 7)
+  expect_equal(
+    ncol(graph$nodes_df), 7)
 
   # Expect that the `nodes_df` df has 4 rows
-  expect_true(
-    nrow(graph$nodes_df) == 4)
+  expect_equal(
+    nrow(graph$nodes_df), 4)
 
   # Expect that the `edges_df` df has 4 columns
-  expect_true(
-    ncol(graph$edges_df) == 4)
+  expect_equal(
+    ncol(graph$edges_df), 4)
 
   # Expect that the `edges_df` df has 3 rows
-  expect_true(
-    nrow(graph$edges_df) == 3)
+  expect_equal(
+    nrow(graph$edges_df), 3)
 })

--- a/tests/testthat/test-degree_total_in_out.R
+++ b/tests/testthat/test-degree_total_in_out.R
@@ -15,7 +15,7 @@ test_that("a degree data frame can be generated", {
   total_degree_df <- get_degree_total(graph)
 
   # Expect that the output is a data frame
-  expect_is(
+  expect_s3_class(
     total_degree_df, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -44,7 +44,7 @@ test_that("a degree data frame can be generated", {
       normalized = TRUE)
 
   # Expect that the output is a data frame
-  expect_is(
+  expect_s3_class(
     total_degree_df_norm, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -72,7 +72,7 @@ test_that("a degree data frame can be generated", {
   in_degree_df <- get_degree_in(graph)
 
   # Expect that the output is a data frame
-  expect_is(
+  expect_s3_class(
     in_degree_df, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -101,7 +101,7 @@ test_that("a degree data frame can be generated", {
       normalized = TRUE)
 
   # Expect that the output is a data frame
-  expect_is(
+  expect_s3_class(
     in_degree_df_norm, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -129,7 +129,7 @@ test_that("a degree data frame can be generated", {
   out_degree_df <- get_degree_out(graph)
 
   # Expect that the output is a data frame
-  expect_is(
+  expect_s3_class(
     out_degree_df, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -158,7 +158,7 @@ test_that("a degree data frame can be generated", {
       normalized = TRUE)
 
   # Expect that the output is a data frame
-  expect_is(
+  expect_s3_class(
     out_degree_df_norm, "data.frame")
 
   # Expect 2 columns in the data frame

--- a/tests/testthat/test-dfs_bfs.R
+++ b/tests/testthat/test-dfs_bfs.R
@@ -19,8 +19,7 @@ test_that("the dfs algorithm is functional", {
     do_dfs(node = 1)
 
   # Expect that an integer vector is returned
-  expect_is(
-    dfs_all, "integer")
+  expect_type(dfs_all, "integer")
 
   # Expect the length of the vector to be the
   # same as the number of nodes in the graph
@@ -39,8 +38,7 @@ test_that("the dfs algorithm is functional", {
     do_dfs()
 
   # Expect that an integer vector is returned
-  expect_is(
-    dfs_all_no_start, "integer")
+  expect_type(dfs_all_no_start, "integer")
 
   # Expect the length of the vector to be the
   # same as the number of nodes in the graph
@@ -56,8 +54,7 @@ test_that("the dfs algorithm is functional", {
       direction = "in")
 
   # Expect that an integer vector is returned
-  expect_is(
-    dfs_in, "integer")
+  expect_type(dfs_in, "integer")
 
   # Expect the length of the vector to be the
   # same as the number of nodes in the graph
@@ -78,8 +75,7 @@ test_that("the dfs algorithm is functional", {
       direction = "out")
 
   # Expect that an integer vector is returned
-  expect_is(
-    dfs_out, "integer")
+  expect_type(dfs_out, "integer")
 
   # Expect the length of the vector to be the
   # same as the number of nodes in the graph
@@ -123,8 +119,7 @@ test_that("the bfs algorithm is functional", {
     do_bfs(node = 1)
 
   # Expect that an integer vector is returned
-  expect_is(
-    bfs_all, "integer")
+  expect_type(bfs_all, "integer")
 
   # Expect the length of the vector to be the
   # same as the number of nodes in the graph
@@ -143,8 +138,7 @@ test_that("the bfs algorithm is functional", {
     do_bfs()
 
   # Expect that an integer vector is returned
-  expect_is(
-    bfs_all_no_start, "integer")
+  expect_type(bfs_all_no_start, "integer")
 
   # Expect the length of the vector to be the
   # same as the number of nodes in the graph
@@ -161,8 +155,7 @@ test_that("the bfs algorithm is functional", {
       direction = "in")
 
   # Expect that an integer vector is returned
-  expect_is(
-    bfs_in, "integer")
+  expect_type(bfs_in, "integer")
 
   # Expect the length of the vector to be the
   # same as the number of nodes in the graph
@@ -183,8 +176,7 @@ test_that("the bfs algorithm is functional", {
       direction = "out")
 
   # Expect that an integer vector is returned
-  expect_is(
-    bfs_out, "integer")
+  expect_type(bfs_out, "integer")
 
   # Expect the length of the vector to be the
   # same as the number of nodes in the graph

--- a/tests/testthat/test-get_cmty.R
+++ b/tests/testthat/test-get_cmty.R
@@ -14,7 +14,7 @@ test_that("the edge betweeness algorithm is functional", {
   edge_betweeness <- get_cmty_edge_btwns(graph)
 
   # Expect that a `data.frame` object is returned
-  expect_is(
+  expect_s3_class(
     edge_betweeness, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -39,12 +39,12 @@ test_that("the edge betweeness algorithm is functional", {
     c(1, 2, 3, 4, 5, 6))
 
   # Expect the first column to be integer
-  expect_is(
+  expect_type(
     edge_betweeness$id, "integer")
 
   # Expect the second column to be numeric
-  expect_is(
-    edge_betweeness$edge_btwns_group, "numeric")
+  expect_type(
+    edge_betweeness$edge_btwns_group, "double")
 })
 
 test_that("the fast-greedy algorithm is functional", {
@@ -61,7 +61,7 @@ test_that("the fast-greedy algorithm is functional", {
   fast_greedy <- get_cmty_fast_greedy(graph)
 
   # Expect that a `data.frame` object is returned
-  expect_is(
+  expect_s3_class(
     fast_greedy, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -85,12 +85,12 @@ test_that("the fast-greedy algorithm is functional", {
     c(1, 2, 3, 4, 5, 6))
 
   # Expect the first column to be integer
-  expect_is(
+  expect_type(
     fast_greedy$id, "integer")
 
   # Expect the second column to be numeric
-  expect_is(
-    fast_greedy$f_g_group, "numeric")
+  expect_type(
+    fast_greedy$f_g_group, "double")
 })
 
 test_that("the leading eigenvector algorithm is functional", {
@@ -107,7 +107,7 @@ test_that("the leading eigenvector algorithm is functional", {
   l_eigenvec <- get_cmty_l_eigenvec(graph)
 
   # Expect that a `data.frame` object is returned
-  expect_is(
+  expect_s3_class(
     l_eigenvec, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -131,11 +131,10 @@ test_that("the leading eigenvector algorithm is functional", {
     c(1, 2, 3, 4))
 
   # Expect the first column to be integer
-  expect_is(
-    l_eigenvec$id, "integer")
+  expect_type(l_eigenvec$id, "integer")
 
   # Expect the second column to be numeric
-  expect_is(l_eigenvec$l_eigenvec_group, "numeric")
+  expect_type(l_eigenvec$l_eigenvec_group, "double")
 })
 
 test_that("the Louvain algorithm is functional", {
@@ -152,7 +151,7 @@ test_that("the Louvain algorithm is functional", {
   louvain <- get_cmty_louvain(graph)
 
   # Expect that a `data.frame` object is returned
-  expect_is(
+  expect_s3_class(
     louvain, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -176,12 +175,12 @@ test_that("the Louvain algorithm is functional", {
     c(1, 2, 3, 4))
 
   # Expect the first column to be integer
-  expect_is(
+  expect_type(
     louvain$id, "integer")
 
   # Expect the second column to be numeric
-  expect_is(
-    louvain$louvain_group, "numeric")
+  expect_type(
+    louvain$louvain_group, "double")
 })
 
 test_that("the walktrap algorithm is functional", {
@@ -198,7 +197,7 @@ test_that("the walktrap algorithm is functional", {
   walktrap <- get_cmty_walktrap(graph)
 
   # Expect that a `data.frame` object is returned
-  expect_is(
+  expect_s3_class(
     walktrap, "data.frame")
 
   # Expect 2 columns in the data frame
@@ -206,8 +205,8 @@ test_that("the walktrap algorithm is functional", {
     ncol(walktrap), 2)
 
   # Expect specific column names in this data frame
-  expect_equal(
-    colnames(walktrap),
+  expect_named(
+    walktrap,
     c("id", "walktrap_group"))
 
   # Expect as many rows in the data frame as there
@@ -222,10 +221,10 @@ test_that("the walktrap algorithm is functional", {
     c(1, 2, 3, 4))
 
   # Expect the first column to be integer
-  expect_is(
+  expect_type(
     walktrap$id, "integer")
 
   # Expect the second column to be numeric
-  expect_is(
-    walktrap$walktrap_group, "numeric")
+  expect_type(
+    walktrap$walktrap_group, "double")
 })

--- a/tests/testthat/test-get_graph_metrics.R
+++ b/tests/testthat/test-get_graph_metrics.R
@@ -17,7 +17,7 @@ test_that("Getting a degree histogram is possible", {
       mode = "all")
 
   # Expect that `degree_hist_all` inherits from `data.frame`
-  expect_is(
+  expect_s3_class(
     degree_hist_all, "data.frame")
 
   # Expect certain column names for the `degree_hist_all` object
@@ -32,7 +32,7 @@ test_that("Getting a degree histogram is possible", {
       mode = "in")
 
   # Expect that `degree_hist_in` inherits from `data.frame`
-  expect_is(
+  expect_s3_class(
     degree_hist_in, "data.frame")
 
   # Expect certain column names for the `degree_hist_in` object
@@ -47,7 +47,7 @@ test_that("Getting a degree histogram is possible", {
       mode = "out")
 
   # Expect that `degree_hist_out` inherits from `data.frame`
-  expect_is(
+  expect_s3_class(
     degree_hist_out, "data.frame")
 
   # Expect certain column names for the `degree_hist_out` object
@@ -73,7 +73,7 @@ test_that("Getting degree distribution is possible", {
       mode = "all")
 
   # Expect that `degree_dist_all` inherits from `data.frame`
-  expect_is(
+  expect_s3_class(
     degree_dist_all, "data.frame")
 
   # Expect certain column names for the `degree_dist_all` object
@@ -88,7 +88,7 @@ test_that("Getting degree distribution is possible", {
       mode = "in")
 
   # Expect that `degree_dist_in` inherits from `data.frame`
-  expect_is(
+  expect_s3_class(
     degree_dist_in, "data.frame")
 
   # Expect certain column names for the `degree_dist_in` object
@@ -103,7 +103,7 @@ test_that("Getting degree distribution is possible", {
       mode = "out")
 
   # Expect that `degree_dist_out` inherits from `data.frame`
-  expect_is(
+  expect_s3_class(
     degree_dist_out, "data.frame")
 
   # Expect certain column names for the `degree_dist_out` object
@@ -125,23 +125,20 @@ test_that("Getting maximum eccentricity is possible", {
   max_eccen <- get_max_eccentricity(graph)
 
   # Expect that `max_eccen` is a numeric vector
-  expect_is(
-    max_eccen, "numeric")
+  expect_type(max_eccen, "double")
 
   # Expect that `max_eccen` is of length 1
-  expect_equal(
-    length(max_eccen), 1)
+  expect_length(max_eccen, 1)
 
   # Expect that `max_eccen` has the value 5
-  expect_equal(
-    max_eccen, 5)
+  expect_equal(max_eccen, 5)
 
   # Expect NA if there aren't any nodes
   # in the graph
   expect_equal(
     get_max_eccentricity(
       graph = create_graph()),
-    as.numeric(NA))
+    NA_real_)
 })
 
 test_that("Getting minimum eccentricity is possible", {
@@ -160,16 +157,13 @@ test_that("Getting minimum eccentricity is possible", {
       direction = "all")
 
   # Expect that `min_eccen` is a numeric vector
-  expect_is(
-    min_eccen, "numeric")
+  expect_type(min_eccen, "double")
 
   # Expect that `min_eccen` is of length 1
-  expect_equal(
-    length(min_eccen), 1)
+  expect_length(min_eccen, 1)
 
   # Expect that `min_eccen` has the value 2
-  expect_equal(
-    min_eccen, 2)
+  expect_equal(min_eccen, 2)
 
   # Expect certain values with different
   # values provided for `direction`
@@ -213,7 +207,7 @@ test_that("Getting graph eccentricity is possible", {
   graph_eccen <- get_eccentricity(graph)
 
   # Expect that `graph_eccen` is a data frame
-  expect_is(
+  expect_s3_class(
     graph_eccen, "data.frame")
 
   # Expect that `graph_eccen` has 10 rows
@@ -222,15 +216,15 @@ test_that("Getting graph eccentricity is possible", {
     nrow(graph_eccen), 10)
 
   # Expect certain column names for the `graph_eccen` object
-  expect_equal(
-    colnames(graph_eccen), c("id", "eccentricity"))
+  expect_named(
+    graph_eccen, c("id", "eccentricity"))
 
   # Expect that `eccentricity` column is numeric
-  expect_is(
-    graph_eccen$eccentricity, "numeric")
+  expect_type(
+    graph_eccen$eccentricity, "double")
 
   # Expect that `id` column has integer values
-  expect_is(
+  expect_type(
     graph_eccen$id, "integer")
 })
 
@@ -247,13 +241,13 @@ test_that("Getting graph periphery is possible", {
   graph_periphery <- get_periphery(graph)
 
   # Expect that `graph_periphery` is an integer vector
-  expect_is(
+  expect_type(
     graph_periphery, "integer")
 
   # Expect that `graph_periphery` has length 3 in
   # this case
-  expect_equal(
-    length(graph_periphery), 3)
+  expect_length(
+    graph_periphery, 3)
 
   # Expect certain values for the
   # `graph_periphery` object
@@ -290,7 +284,7 @@ test_that("Getting graph info is possible", {
     get_graph_info()
 
   # Expect that `graph_i` is a data frame
-  expect_is(
+  expect_s3_class(
     graph_i, "data.frame")
 
   # Expect that `graph_i` has 9 columns

--- a/tests/testthat/test-get_graph_metrics.R
+++ b/tests/testthat/test-get_graph_metrics.R
@@ -196,7 +196,8 @@ test_that("Getting minimum eccentricity is possible", {
   expect_equal(
     get_min_eccentricity(
       graph = create_graph()),
-    as.numeric(NA))
+    NA_real_
+  )
 })
 
 test_that("Getting graph eccentricity is possible", {
@@ -359,7 +360,7 @@ test_that("Getting graph adhesion is possible", {
 
   # Expect NA for the empty graph
   expect_equal(
-    get_adhesion(graph_empty), as.numeric(NA))
+    get_adhesion(graph_empty), NA_real_)
 })
 
 test_that("Getting graph girth is possible", {
@@ -388,7 +389,7 @@ test_that("Getting graph girth is possible", {
 
   # Expect NA for the empty graph
   expect_equal(
-    get_girth(graph_empty), as.numeric(NA))
+    get_girth(graph_empty), NA_real_)
 })
 
 test_that("Getting the mean distance for a graph is possible", {
@@ -417,7 +418,7 @@ test_that("Getting the mean distance for a graph is possible", {
 
   # Expect NA for the empty graph
   expect_equal(
-    get_mean_distance(graph_empty), as.numeric(NA))
+    get_mean_distance(graph_empty), NA_real_)
 })
 
 test_that("Getting the reciprocity for a graph is possible", {
@@ -499,7 +500,7 @@ test_that("Getting the minimum cut between nodes is possible", {
 
   # Expect NA for the empty graph
   expect_equal(
-    get_min_cut_between(graph_empty), as.numeric(NA))
+    get_min_cut_between(graph_empty), NA_real_)
 })
 
 test_that("Getting a count of graph automorphisms is possible", {
@@ -528,7 +529,7 @@ test_that("Getting a count of graph automorphisms is possible", {
 
   # Expect NA for the empty graph
   expect_equal(
-    count_automorphisms(graph_empty), as.numeric(NA))
+    count_automorphisms(graph_empty), NA_real_)
 })
 
 test_that("Getting a count of asymmetric node pairs is possible", {
@@ -557,7 +558,7 @@ test_that("Getting a count of asymmetric node pairs is possible", {
 
   # Expect NA for the empty graph
   expect_equal(
-    count_asymmetric_node_pairs(graph_empty), as.numeric(NA))
+    count_asymmetric_node_pairs(graph_empty), NA_real_)
 })
 
 test_that("Getting a count of mutual node pairs is possible", {
@@ -586,7 +587,7 @@ test_that("Getting a count of mutual node pairs is possible", {
 
   # Expect NA for the empty graph
   expect_equal(
-    count_mutual_node_pairs(graph_empty), as.numeric(NA))
+    count_mutual_node_pairs(graph_empty), NA_real_)
 })
 
 test_that("Getting a count of unconnected node pairs is possible", {
@@ -615,5 +616,5 @@ test_that("Getting a count of unconnected node pairs is possible", {
 
   # Expect NA for the empty graph
   expect_equal(
-    count_unconnected_node_pairs(graph_empty), as.numeric(NA))
+    count_unconnected_node_pairs(graph_empty), NA_real_)
 })

--- a/tests/testthat/test-get_graph_properties.R
+++ b/tests/testthat/test-get_graph_properties.R
@@ -19,7 +19,7 @@ test_that("Getting the graph object log is possible", {
 
   # Expect that the graph log is provided
   # as a tibble object
-  expect_is(
+  expect_s3_class(
     graph_log, "tbl_df")
 
   # Expect certain column names for the

--- a/tests/testthat/test-get_node_calculations.R
+++ b/tests/testthat/test-get_node_calculations.R
@@ -13,7 +13,7 @@ test_that("Getting betweenness is possible", {
   betweenness_vals <- get_betweenness(graph)
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     betweenness_vals, "data.frame")
 
   # Expect 2 columns in the df
@@ -27,13 +27,13 @@ test_that("Getting betweenness is possible", {
   # Expect node ID values in the first column
   expect_identical(
     betweenness_vals[, 1],
-    as.integer(1:10))
+    1:10)
 
   # Expect numerical values in the
   # second column
-  expect_is(
+  expect_type(
     betweenness_vals[, 2],
-    "numeric")
+    "double")
 })
 
 test_that("Getting closeness is possible", {
@@ -53,7 +53,7 @@ test_that("Getting closeness is possible", {
       direction = "all")
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     closeness_vals_all, "data.frame")
 
   # Expect 2 columns in the df
@@ -84,7 +84,7 @@ test_that("Getting coreness values is possible", {
   coreness_vals_all <- get_coreness(graph)
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     coreness_vals_all, "data.frame")
 
   # Expect 2 columns in the df
@@ -101,9 +101,9 @@ test_that("Getting coreness values is possible", {
     as.integer(1:10))
 
   # Expect numeric values in the second column
-  expect_is(
+  expect_type(
     coreness_vals_all[, 2],
-    "numeric")
+    "double")
 
   # Get coreness values in the `in` direction
   coreness_vals_in <-
@@ -112,7 +112,7 @@ test_that("Getting coreness values is possible", {
       direction = "in")
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     coreness_vals_in, "data.frame")
 
   # Expect 2 columns in the df
@@ -129,9 +129,9 @@ test_that("Getting coreness values is possible", {
     as.integer(1:10))
 
   # Expect numeric values in the second column
-  expect_is(
+  expect_type(
     coreness_vals_in[, 2],
-    "numeric")
+    "double")
 
   # Get coreness values in the `out` direction
   coreness_vals_out <-
@@ -140,7 +140,7 @@ test_that("Getting coreness values is possible", {
       direction = "out")
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     coreness_vals_out, "data.frame")
 
   # Expect 2 columns in the df
@@ -154,12 +154,12 @@ test_that("Getting coreness values is possible", {
   # Expect node ID values in the first column
   expect_identical(
     coreness_vals_out[, 1],
-    as.integer(1:10))
+    1:10)
 
   # Expect numeric values in the second column
-  expect_is(
+  expect_type(
     coreness_vals_out[, 2],
-    "numeric")
+    "double")
 
   # Expect an error if value for `direction`
   # is not any of `all`, `in`, or `out`
@@ -183,7 +183,7 @@ test_that("Getting closeness vitality is possible", {
   closeness_vitality_vals <- get_closeness_vitality(graph)
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     closeness_vitality_vals, "data.frame")
 
   # Expect 2 columns in the df
@@ -197,12 +197,12 @@ test_that("Getting closeness vitality is possible", {
   # Expect node ID values in the first column
   expect_identical(
     closeness_vitality_vals[, 1],
-    as.integer(1:10))
+    1:10)
 
   # Expect numeric values in the second column
-  expect_is(
+  expect_type(
     closeness_vitality_vals[, 2],
-    "numeric")
+    "double")
 })
 
 test_that("Getting alpha centrality is possible", {
@@ -219,7 +219,7 @@ test_that("Getting alpha centrality is possible", {
     get_alpha_centrality(graph)
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     alpha_central_vals, "data.frame")
 
   # Expect 2 columns in the df
@@ -237,9 +237,9 @@ test_that("Getting alpha centrality is possible", {
 
   # Expect numerical values in the
   # second column
-  expect_is(
+  expect_type(
     alpha_central_vals[, 2],
-    "numeric")
+    "double")
 })
 
 test_that("Getting leverage centrality is possible", {
@@ -256,7 +256,7 @@ test_that("Getting leverage centrality is possible", {
     get_leverage_centrality(graph)
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     leverage_central_vals, "data.frame")
 
   # Expect 2 columns in the df
@@ -270,13 +270,13 @@ test_that("Getting leverage centrality is possible", {
   # Expect node ID values in the first column
   expect_identical(
     leverage_central_vals[,1],
-    as.integer(1:10))
+    1:10)
 
   # Expect numerical values in the
   # second column
-  expect_is(
+  expect_type(
     leverage_central_vals[, 2],
-    "numeric")
+    "double")
 })
 
 test_that("Getting authority centrality is possible", {
@@ -355,13 +355,13 @@ test_that("Getting authority centrality is possible", {
     get_authority_centrality(graph = graph_2)
 
   # Expect a data frame as output for all
-  expect_is(
+  expect_s3_class(
     auth_central_vals, "data.frame")
 
-  expect_is(
+  expect_s3_class(
     auth_central_vals_weight_1, "data.frame")
 
-  expect_is(
+  expect_s3_class(
     auth_central_vals_weight_2, "data.frame")
 
   # Expect 2 columns in the df
@@ -387,29 +387,29 @@ test_that("Getting authority centrality is possible", {
   # Expect node ID values in the first column
   expect_identical(
     auth_central_vals[, 1],
-    as.integer(1:10))
+    1:10)
 
   expect_identical(
     auth_central_vals_weight_1[, 1],
-    as.integer(1:10))
+    1:10)
 
   expect_identical(
     auth_central_vals_weight_1[, 1],
-    as.integer(1:10))
+    1:10)
 
   # Expect numerical values in the
   # second column
-  expect_is(
+  expect_type(
     auth_central_vals[, 2],
-    "numeric")
+    "double")
 
-  expect_is(
+  expect_type(
     auth_central_vals_weight_1[, 2],
-    "numeric")
+    "double")
 
-  expect_is(
+  expect_type(
     auth_central_vals_weight_2[, 2],
-    "numeric")
+    "double")
 })
 
 test_that("Getting eigenvector centrality is possible", {
@@ -491,13 +491,13 @@ test_that("Getting eigenvector centrality is possible", {
     get_eigen_centrality(graph = graph_2)
 
   # Expect a data frame as output for all
-  expect_is(
+  expect_s3_class(
     eigen_central_vals, "data.frame")
 
-  expect_is(
+  expect_s3_class(
     eigen_central_vals_weight_1, "data.frame")
 
-  expect_is(
+  expect_s3_class(
     eigen_central_vals_weight_2, "data.frame")
 
   # Expect 2 columns in the df
@@ -523,29 +523,29 @@ test_that("Getting eigenvector centrality is possible", {
   # Expect node ID values in the first column
   expect_identical(
     eigen_central_vals[, 1],
-    as.integer(1:10))
+    1:10)
 
   expect_identical(
     eigen_central_vals_weight_1[, 1],
-    as.integer(1:10))
+    1:10)
 
   expect_identical(
     eigen_central_vals_weight_1[, 1],
-    as.integer(1:10))
+    1:10)
 
   # Expect numerical values in the
   # second column
-  expect_is(
+  expect_type(
     eigen_central_vals[, 2],
-    "numeric")
+    "double")
 
-  expect_is(
+  expect_type(
     eigen_central_vals_weight_1[, 2],
-    "numeric")
+    "double")
 
-  expect_is(
+  expect_type(
     eigen_central_vals_weight_2[, 2],
-    "numeric")
+    "double")
 })
 
 test_that("Getting radiality values is possible", {
@@ -562,7 +562,7 @@ test_that("Getting radiality values is possible", {
   radiality_vals <- get_radiality(graph)
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     radiality_vals, "data.frame")
 
   # Expect 2 columns in the df
@@ -580,9 +580,9 @@ test_that("Getting radiality values is possible", {
 
   # Expect numerical values in the
   # second column
-  expect_is(
+  expect_type(
     radiality_vals[, 2],
-    "numeric")
+    "double")
 
   # Expect certain radiality values depending
   # on the `direction` parameter
@@ -644,7 +644,7 @@ test_that("Getting PageRank values is possible", {
   pagerank_vals <- get_pagerank(graph)
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     pagerank_vals, "data.frame")
 
   # Expect 2 columns in the df
@@ -658,13 +658,13 @@ test_that("Getting PageRank values is possible", {
   # Expect node ID values in the first column
   expect_identical(
     pagerank_vals[, 1],
-    as.integer(1:10))
+    1:10)
 
   # Expect numerical values in the
   # second column
-  expect_is(
+  expect_type(
     pagerank_vals[, 2],
-    "numeric")
+    "double")
 })
 
 test_that("Getting articulation points is possible", {
@@ -682,12 +682,11 @@ test_that("Getting articulation points is possible", {
     get_articulation_points(graph)
 
   # Expect an integer vector as output
-  expect_is(
+  expect_type(
     articulation_points, "integer")
 
-  # Expect 4 values in the vector
-  expect_equal(
-    length(articulation_points), 2)
+  # Expect 2 values in the vector
+  expect_length(articulation_points, 2)
 })
 
 test_that("Getting weakly connected components is possible", {
@@ -705,7 +704,7 @@ test_that("Getting weakly connected components is possible", {
     get_w_connected_cmpts(graph)
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     connected_components, "data.frame")
 
   # Expect 2 columns in the df
@@ -718,9 +717,9 @@ test_that("Getting weakly connected components is possible", {
 
   # Expect numerical values in the
   # second column
-  expect_is(
+  expect_type(
     connected_components[, 2],
-    "numeric")
+    "double")
 })
 
 test_that("Getting strongly connected components is possible", {
@@ -738,7 +737,7 @@ test_that("Getting strongly connected components is possible", {
     get_s_connected_cmpts(graph)
 
   # Expect a data frame as output
-  expect_is(
+  expect_s3_class(
     s_connected_components, "data.frame")
 
   # Expect 2 columns in the df
@@ -751,7 +750,7 @@ test_that("Getting strongly connected components is possible", {
 
   # Expect numerical values in the
   # second column
-  expect_is(
+  expect_type(
     s_connected_components[, 2],
-    "numeric")
+    "double")
 })

--- a/tests/testthat/test-get_nodes_edges.R
+++ b/tests/testthat/test-get_nodes_edges.R
@@ -35,18 +35,19 @@ test_that("getting node IDs from various objects is possible", {
   gotten_nodes <- get_node_ids(graph)
 
   # Expect an `integer` vector object
-  expect_is(
+  expect_type(
     gotten_nodes, "integer")
 
   # Expect that the integer vector object
   # has no names
-  expect_null(
-    names(gotten_nodes))
+  expect_named(gotten_nodes, NULL)
 
   # Expect a vector that is sequence
   # from `1` to `26`
-  expect_true(
-    all(1:26 == gotten_nodes))
+  expect_equal(
+    gotten_nodes,
+    1:26
+  )
 
   # Expect that `get_node_ids()` when
   # used on an empty graph returns NA
@@ -91,17 +92,18 @@ test_that("getting node IDs from various objects is possible", {
         type == "h_to_p")
 
   # Expect an `integer` vector object
-  expect_is(
+  expect_type(
     gotten_nodes_w_condition, "integer")
 
   # Expect that the integer vector object
   # has no names
-  expect_null(
-    names(gotten_nodes_w_condition))
+  expect_named(gotten_nodes_w_condition, NULL)
 
-  # Expect a vector that is sequence from `1` to `26`
-  expect_true(
-    all(8:16 == gotten_nodes_w_condition))
+  # Expect a vector that is sequence from `8` to `16`
+  expect_equal(
+    gotten_nodes_w_condition,
+    8:16
+  )
 })
 
 test_that("getting node IDs associated within a graph's edges is possible", {
@@ -141,25 +143,23 @@ test_that("getting node IDs associated within a graph's edges is possible", {
     get_edges(graph, return_type = "list")
 
   # Expect a list object
-  expect_is(
+  expect_type(
     gotten_edges_list, "list")
 
   # Expect that the list is of length 2
-  expect_true(
-    length(gotten_edges_list) == 2)
+  expect_length(gotten_edges_list, 2)
 
   # Expect integer vectors of length 26
   # in `gotten_edges_list`
-  expect_true(
-    length(gotten_edges_list[[1]]) == 26)
+  expect_length(gotten_edges_list[[1]], 26)
 
-  expect_is(
+  expect_type(
     gotten_edges_list[[1]], "integer")
 
-  expect_true(
-    length(gotten_edges_list[[2]]) == 26)
+  expect_length(
+    gotten_edges_list[[2]], 26)
 
-  expect_is(
+  expect_type(
     gotten_edges_list[[2]], "integer")
 
   # Get the `outgoing` and `incoming` node ID values
@@ -170,23 +170,23 @@ test_that("getting node IDs associated within a graph's edges is possible", {
       return_type = "df")
 
   # Expect a data frame object
-  expect_is(
+  expect_s3_class(
     gotten_edges_df, "data.frame")
 
   # Expect that the data frame has 2 columns
-  expect_true(
-    ncol(gotten_edges_df) == 2)
+  expect_equal(
+    ncol(gotten_edges_df), 2)
 
   # Expect columns of class `integer` and that there
   # are 26 rows in `gotten_edges_df`
-  expect_is(
+  expect_type(
     gotten_edges_df[, 1], "integer")
 
-  expect_is(
+  expect_type(
     gotten_edges_df[, 2], "integer")
 
-  expect_true(
-    nrow(gotten_edges_df) == 26)
+  expect_equal(
+    nrow(gotten_edges_df), 26)
 
   # Get the `outgoing` and `incoming` node ID values
   # in a vector object
@@ -195,28 +195,25 @@ test_that("getting node IDs associated within a graph's edges is possible", {
       graph = graph,
       return_type = "vector")
 
-  # Expect a vector object of class `character`
-  expect_is(
-    gotten_edges_vector, "character")
-
-  # Expect that the vector object is of length 26
-  expect_true(
-    length(gotten_edges_vector) == 26)
+  # Expect a vector object of class `character` of length 26
+  expect_type(gotten_edges_vector, "character")
+  expect_length(gotten_edges_vector, 26)
 
   # Expect that the '->' substring is in
   # each vector component
-  expect_true(
-    all(grepl("->", gotten_edges_vector)))
+  expect_match(
+    gotten_edges_vector,
+    "->"
+  )
 
   # Get the edge df from the graph using `get_edge_df()`
   edge_df_from_graph <- get_edge_df(graph)
 
   # Expect that using `get_edge_df()` on a graph
   # with no edges will return an empty data frame
-  expect_equal(
-    nrow(
-      get_edge_df(
-        create_graph(nodes_df = create_node_df(1)))), 0)
+
+  edge_df <- get_edge_df(create_graph(nodes_df = create_node_df(1)))
+  expect_equal(nrow(edge_df), 0)
 })
 
 test_that("getting edge information from a graph with no edges is possible ", {
@@ -235,7 +232,7 @@ test_that("getting edge information from a graph with no edges is possible ", {
       return_type = "vector")
 
   # Expect a vector object of class `logical`
-  expect_is(
+  expect_type(
     edges_vector_from_graph_no_edges, "logical")
 
   # Expect that an NA is returned

--- a/tests/testthat/test-graph_actions.R
+++ b/tests/testthat/test-graph_actions.R
@@ -21,7 +21,7 @@ test_that("actions can be added to a graph object", {
 
   # Expect a `data.frame` object with in
   # `graph$graph_actions`
-  expect_is(
+  expect_s3_class(
     graph$graph_actions, "data.frame")
 
   # Extract `graph$graph_actions` to a
@@ -250,27 +250,29 @@ test_that("graph actions can be triggered to modify the graph", {
 
   # Expect the `pagerank` column to have
   # numeric values less than 1
-  expect_is(
-    graph$nodes_df$pagerank, "numeric")
+  expect_type(
+    graph$nodes_df$pagerank, "double")
 
   expect_true(
     all(graph$nodes_df$pagerank <= 1))
 
   # Expect the `width` column to have
   # numeric values less than 1
-  expect_is(
-    graph$nodes_df$width, "numeric")
+  expect_type(
+    graph$nodes_df$width, "double")
 
   expect_true(
     all(graph$nodes_df$width <= 1))
 
   # Expect the `fillcolor` column to have
   # character values with color codes
-  expect_is(
+  expect_type(
     graph$nodes_df$fillcolor, "character")
 
-  expect_true(
-    all(grepl("#[A-F0-9]*", graph$nodes_df$fillcolor)))
+  expect_match(
+    graph$nodes_df$fillcolor,
+    "#[A-F0-9]*"
+  )
 
   # Expect a warning if using the
   # `trigger_graph_actions()` function

--- a/tests/testthat/test-graph_series.R
+++ b/tests/testthat/test-graph_series.R
@@ -7,7 +7,7 @@ test_that("creating an empty series is possible", {
     create_graph_series(series_type = "sequential")
 
   # Expect an object of class `dgr_graph_1D`
-  expect_is(
+  expect_s3_class(
     series, "dgr_graph_1D")
 
   # Expect that the series type is `sequential`
@@ -15,14 +15,9 @@ test_that("creating an empty series is possible", {
     series$series_type, "sequential")
 
   # Expect that several series components are `NULL`
-  expect_null(
-    series$graphs)
-
-  expect_null(
-    series$series_name)
-
-  expect_null(
-    series$series_scripts)
+  expect_null(series$graphs)
+  expect_null(series$series_name)
+  expect_null(series$series_scripts)
 
   # Expect that the series is empty
   expect_equal(
@@ -37,17 +32,12 @@ test_that("creating an empty series is possible", {
     count_graphs_in_graph_series(series_temporal), 0)
 
   # Expect that several series components are `NULL`
-  expect_null(
-    series_temporal$graphs)
-
-  expect_null(
-    series_temporal$series_name)
-
-  expect_null(
-    series_temporal$series_scripts)
+  expect_null(series_temporal$graphs)
+  expect_null(series_temporal$series_name)
+  expect_null(series_temporal$series_scripts)
 
   # Expect an object of class `dgr_graph_1D`
-  expect_is(
+  expect_s3_class(
     series_temporal, "dgr_graph_1D")
 
   # Expect that the series type is `sequential`
@@ -85,7 +75,7 @@ test_that("adding graphs to a series is also possible", {
       graph = graph_3)
 
   # Expect an object of class `dgr_graph_1D`
-  expect_is(
+  expect_s3_class(
     series, "dgr_graph_1D")
 
   # Expect that the series type is `sequential`
@@ -97,28 +87,24 @@ test_that("adding graphs to a series is also possible", {
     !is.null(series$graphs))
 
   # Expect that several series components are `NULL`
-  expect_null(
-    series$series_name)
-
-  expect_null(
-    series$series_scripts)
+  expect_null(series$series_name)
+  expect_null(series$series_scripts)
 
   # Expect that the series has a graph count of 3
   expect_equal(
     count_graphs_in_graph_series(series), 3L)
 
-  expect_equal(
-    length(series$graphs), 3L)
+  expect_length(series$graphs, 3)
 
   # Expect that the graphs within the graph series object
   # are indeed graph objects
-  expect_is(
+  expect_s3_class(
     series$graphs[[1]], "dgr_graph")
 
-  expect_is(
+  expect_s3_class(
     series$graphs[[2]], "dgr_graph")
 
-  expect_is(
+  expect_s3_class(
     series$graphs[[3]], "dgr_graph")
 
   # Expect that the graphs within the graph series object
@@ -139,7 +125,7 @@ test_that("adding graphs to a series is also possible", {
       series_type = "sequential")
 
   # Expect an object of class `dgr_graph_1D`
-  expect_is(
+  expect_s3_class(
     series_w_graph, "dgr_graph_1D")
 
   # Expect that the series type is `sequential`
@@ -155,15 +141,12 @@ test_that("adding graphs to a series is also possible", {
     count_graphs_in_graph_series(series_w_graph), 1)
 
   # Expect that several series components are `NULL`
-  expect_null(
-    series_w_graph$series_name)
-
-  expect_null(
-    series_w_graph$series_scripts)
+  expect_null(series_w_graph$series_name)
+  expect_null(series_w_graph$series_scripts)
 
   # Expect that the graphs within the graph series object
   # are indeed graph objects
-  expect_is(
+  expect_s3_class(
     series_w_graph$graphs[[1]], "dgr_graph")
 
   # Expect an error when adding something other
@@ -217,8 +200,7 @@ test_that("removing graphs from a series is possible", {
   expect_equal(
     count_graphs_in_graph_series(series), 3)
 
-  expect_equal(
-    length(series$graphs), 3)
+  expect_length(series$graphs, 3)
 
   # Remove the last graph from the series
   series_2 <-

--- a/tests/testthat/test-htmlwidgets.R
+++ b/tests/testthat/test-htmlwidgets.R
@@ -15,7 +15,7 @@ test_that("htmlwidgets object can be created", {
 
   # Expect that the object inherits
   # from `DiagrammeR` and `htmlwidget`
-  expect_is(
+  expect_s3_class(
     diagrammer_htmlwidget, c("DiagrammeR", "htmlwidget"))
 
   mermaid_htmlwidget <-
@@ -31,6 +31,6 @@ test_that("htmlwidgets object can be created", {
 
   # Expect that the object inherits
   # from `DiagrammeR` and `htmlwidget`
-  expect_is(
+  expect_s3_class(
     mermaid_htmlwidget, c("DiagrammeR", "htmlwidget"))
 })

--- a/tests/testthat/test-is_something_some_thing.R
+++ b/tests/testthat/test-is_something_some_thing.R
@@ -440,7 +440,7 @@ test_that("Identifying the graph as weighted is possible", {
     select_edges() %>%
     set_edge_attrs_ws(
       edge_attr = "weight",
-      value = c(3, 5, as.numeric(NA), 9, as.numeric(NA))) %>%
+      value = c(3, 5, NA_real_, 9, NA_real_)) %>%
     clear_selection()
 
   # Expect that this graph won't be

--- a/tests/testthat/test-join_attrs.R
+++ b/tests/testthat/test-join_attrs.R
@@ -33,8 +33,7 @@ test_that("joining a data frame to an ndf is possible", {
 
   # Expect a column named `values` in the graph's
   # node data frame
-  expect_true(
-    "values" %in% colnames(graph$nodes_df))
+  expect_contains(colnames(graph$nodes_df), "values")
 
   # Expect that the `values` column in the graph's
   # node data frame is equivalent to the first 5 values
@@ -99,8 +98,7 @@ test_that("joining a data frame to an edf is possible", {
 
   # Expect a column named `values` in the graph's
   # edge data frame
-  expect_true(
-    "values" %in% colnames(graph$edges_df))
+  expect_contains(colnames(graph$edges_df), "values")
 
   # Expect that the `values` column in the graph's
   # node data frame is equivalent to the first 5 values

--- a/tests/testthat/test-metagraph.R
+++ b/tests/testthat/test-metagraph.R
@@ -51,6 +51,6 @@ test_that("the display of the metagraph works", {
   metagraph_object <- display_metagraph(property_graph)
 
   # Expect that the object has the classes of `grViz` and `htmlwidget`
-  expect_is(
+  expect_s3_class(
     metagraph_object, c("grViz", "htmlwidget"))
 })

--- a/tests/testthat/test-node_edge_data_aes.R
+++ b/tests/testthat/test-node_edge_data_aes.R
@@ -11,12 +11,12 @@ test_that("creating node data attribute values is possible", {
 
   # Expect that a list object has
   # been generated
-  expect_is(
+  expect_type(
     node_data, "list")
 
   # Expect specific names in the object
-  expect_equal(
-    names(node_data),
+  expect_named(
+    node_data,
     c("values_1", "values_2"))
 
   # Expect specific values in each
@@ -59,12 +59,12 @@ test_that("creating edge data attribute values is possible", {
 
   # Expect that a list object has
   # been generated
-  expect_is(
+  expect_type(
     edge_data, "list")
 
   # Expect specific names in the object
-  expect_equal(
-    names(edge_data),
+  expect_named(
+    edge_data,
     c("values_1", "values_2"))
 
   # Expect specific values in each
@@ -120,7 +120,7 @@ test_that("creating node aesthetic attribute values is possible", {
 
   # Expect that a list object has
   # been generated
-  expect_is(
+  expect_type(
     node_aes, "list")
 
   # Expect specific names in the object
@@ -212,7 +212,7 @@ test_that("creating edge aesthetic attribute values is possible", {
 
   # Expect that a list object has
   # been generated
-  expect_is(edge_aes, "list")
+  expect_type(edge_aes, "list")
 
   # Expect specific values in each
   # of the list components
@@ -413,76 +413,39 @@ test_that("binding data and aesthetic attribute values is always possible", {
       edge_aes = edge_aes_,
       edge_data = edge_data_)
 
-  expect_true("fillcolor" %in% (graph_w_attrs_1$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_2$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_3$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_4$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_5$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_6$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_7$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_8$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_9$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_10$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_11$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_12$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_13$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_14$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_15$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_16$nodes_df %>% names()))
-  expect_true("fillcolor" %in% (graph_w_attrs_17$nodes_df %>% names()))
+  expect_contains(names(graph_w_attrs_1$nodes_df),  c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_2$nodes_df),  c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_3$nodes_df),  c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_4$nodes_df),  c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_5$nodes_df),  c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_6$nodes_df),  c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_7$nodes_df),  c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_8$nodes_df),  c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_9$nodes_df),  c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_10$nodes_df), c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_11$nodes_df), c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_12$nodes_df), c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_13$nodes_df), c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_14$nodes_df), c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_15$nodes_df), c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_16$nodes_df), c("fillcolor", "node_value"))
+  expect_contains(names(graph_w_attrs_17$nodes_df), c("fillcolor", "node_value"))
 
-  expect_true("node_value" %in% (graph_w_attrs_1$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_2$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_3$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_4$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_5$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_6$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_7$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_8$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_9$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_10$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_11$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_12$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_13$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_14$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_15$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_16$nodes_df %>% names()))
-  expect_true("node_value" %in% (graph_w_attrs_17$nodes_df %>% names()))
-
-  expect_true("color" %in% (graph_w_attrs_1$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_2$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_3$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_4$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_5$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_6$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_7$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_8$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_9$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_10$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_11$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_12$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_13$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_14$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_17$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_18$edges_df %>% names()))
-  expect_true("color" %in% (graph_w_attrs_19$edges_df %>% names()))
-
-  expect_true("edge_value" %in% (graph_w_attrs_1$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_2$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_3$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_4$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_5$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_6$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_7$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_8$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_9$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_10$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_11$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_12$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_13$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_14$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_17$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_18$edges_df %>% names()))
-  expect_true("edge_value" %in% (graph_w_attrs_19$edges_df %>% names()))
-
+  expect_contains(names(graph_w_attrs_1$edges_df),  c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_2$edges_df),  c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_3$edges_df),  c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_4$edges_df),  c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_5$edges_df),  c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_6$edges_df),  c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_7$edges_df),  c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_8$edges_df),  c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_9$edges_df),  c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_10$edges_df), c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_11$edges_df), c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_12$edges_df), c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_13$edges_df), c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_14$edges_df), c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_17$edges_df), c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_18$edges_df), c("color", "edge_value"))
+  expect_contains(names(graph_w_attrs_19$edges_df), c("color", "edge_value"))
 })

--- a/tests/testthat/test-node_edge_info.R
+++ b/tests/testthat/test-node_edge_info.R
@@ -34,41 +34,41 @@ test_that("getting info about a graph's nodes is possible", {
   info_nodes <- get_node_info(graph)
 
   # Expect a data frame object
-  expect_is(
+  expect_s3_class(
     info_nodes, "data.frame")
 
   # Expect that the data frame has 7 columns
-  expect_true(
-    ncol(info_nodes) == 7)
+  expect_equal(
+    ncol(info_nodes), 7)
 
   # Expect that the data frame has 26 rows
-  expect_true(
-    nrow(info_nodes) == 26)
+  expect_equal(
+    nrow(info_nodes), 26)
 
   # Expect that certain columns will be classed
   # as `integer` or `character`
-  expect_is(
+  expect_type(
     info_nodes$id, "integer")
 
-  expect_is(
+  expect_type(
     info_nodes$label, "character")
 
-  expect_is(
+  expect_type(
     info_nodes$type, "character")
 
   # Expect that certain columns will be classed
-  # as `numeric`
-  expect_is(
-    info_nodes$deg, "numeric")
+  # as `numeric` double
+  expect_type(
+    info_nodes$deg, "double")
 
-  expect_is(
-    info_nodes$indeg, "numeric")
+  expect_type(
+    info_nodes$indeg, "double")
 
-  expect_is(
-    info_nodes$outdeg, "numeric")
+  expect_type(
+    info_nodes$outdeg, "double")
 
-  expect_is(
-    info_nodes$loops, "numeric")
+  expect_type(
+    info_nodes$loops, "double")
 
   # Create a graph with 4 nodes (with type
   # information) but no edges
@@ -83,34 +83,34 @@ test_that("getting info about a graph's nodes is possible", {
   info_nodes_no_edges <- get_node_info(graph)
 
   # Expect a data frame object
-  expect_is(
+  expect_s3_class(
     info_nodes_no_edges, "data.frame")
 
   # Expect that the data frame has 7 columns
-  expect_true(
-    ncol(info_nodes_no_edges) == 7)
+  expect_equal(
+    ncol(info_nodes_no_edges), 7)
 
   # Expect that the data frame has 4 rows
-  expect_true(
-    nrow(info_nodes_no_edges) == 4)
+  expect_equal(
+    nrow(info_nodes_no_edges), 4)
 
   # Expect that the `deg`, `indeg`, `outdeg`,
   # and `loops` columns have show 0
   expect_equal(
     info_nodes_no_edges$deg %>%
-      unique, 0)
+      unique(), 0)
 
   expect_equal(
     info_nodes_no_edges$indeg %>%
-      unique, 0)
+      unique(), 0)
 
   expect_equal(
     info_nodes_no_edges$outdeg %>%
-      unique, 0)
+      unique(), 0)
 
   expect_equal(
     info_nodes_no_edges$loops %>%
-      unique, 0)
+      unique(), 0)
 
   # Create an empty graph
   graph <- create_graph()
@@ -157,27 +157,22 @@ test_that("getting info about a graph's edges is possible", {
   info_edges <- get_edge_info(graph)
 
   # Expect a data frame object
-  expect_is(
+  expect_s3_class(
     info_edges, "data.frame")
 
   # Expect that the data frame has 4 columns
-  expect_true(
-    ncol(info_edges) == 4)
+  expect_equal(
+    ncol(info_edges), 4)
 
   # Expect that the data frame has 26 rows
-  expect_true(
-    nrow(info_edges) == 26)
+  expect_equal(
+    nrow(info_edges), 26)
 
   # Expect that columns will be classed
   # as either as `integer` or `character`
-  expect_is(
-    info_edges$from, "integer")
-
-  expect_is(
-    info_edges$to, "integer")
-
-  expect_is(
-    info_edges$rel, "character")
+  expect_type(info_edges$from, "integer")
+  expect_type(info_edges$to, "integer")
+  expect_type(info_edges$rel, "character")
 
   # Create a graph with 4 nodes but no edges
   graph <-

--- a/tests/testthat/test-predecessors_successors.R
+++ b/tests/testthat/test-predecessors_successors.R
@@ -31,10 +31,11 @@ test_that("getting a node's predecessors/successors is possible", {
       edges_df = edges)
 
   # Tests for `get_predecessors()`
-  expect_is(
+  expect_type(
     get_predecessors(
       graph = graph,
-      node = 26), "integer")
+      node = 26),
+    "integer")
 
   expect_equal(
     get_predecessors(
@@ -42,10 +43,11 @@ test_that("getting a node's predecessors/successors is possible", {
       node = 26), 1)
 
   # Tests for `get_successors()`
-  expect_is(
+  expect_type(
     get_successors(
       graph = graph,
-      node = 1), "integer")
+      node = 1),
+    "integer")
 
   expect_equal(
     get_successors(

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -327,15 +327,13 @@ test_that("Describing if a graph is a simple graph works", {
     add_edges_w_string(
       edges = "1->2")
 
-  expect_true(
-    stringr::str_detect(
-      graph_simple %>% get_printed_output(2),
-      "simple"))
+  expect_match(
+    graph_simple %>% get_printed_output(2),
+    "simple")
 
-  expect_false(
-    stringr::str_detect(
-      graph_not_simple %>% get_printed_output(2),
-      "simple"))
+  expect_no_match(
+    graph_not_simple %>% get_printed_output(2),
+    "simple")
 })
 
 test_that("Describing if a graph is a connected or not works", {
@@ -349,15 +347,13 @@ test_that("Describing if a graph is a connected or not works", {
     create_graph() %>%
     add_n_nodes(n = 4)
 
-  expect_true(
-    stringr::str_detect(
-      graph_connected %>% get_printed_output(2),
-      " connected "))
+  expect_match(
+    graph_connected %>% get_printed_output(2),
+    " connected ")
 
-  expect_true(
-    stringr::str_detect(
-      graph_not_connected %>% get_printed_output(2),
-      " disconnected "))
+  expect_match(
+    graph_not_connected %>% get_printed_output(2),
+    " disconnected ")
 })
 
 test_that("The number of reported nodes is correct", {

--- a/tests/testthat/test-render_graph_series.R
+++ b/tests/testthat/test-render_graph_series.R
@@ -36,7 +36,7 @@ test_that("rendering a graph is indeed possible", {
 
   # Expect that the `rendered_graph` object inherits
   # from `grViz` & `htmlwidget`
-  expect_is(
+  expect_s3_class(
     rendered_graph, c("grViz", "htmlwidget"))
 })
 

--- a/tests/testthat/test-selections.R
+++ b/tests/testthat/test-selections.R
@@ -251,13 +251,13 @@ test_that("selecting an edge in a graph is possible", {
 
   # Expect that node `2` is part of a selection
   # object in 'edges/from'
-  expect_true(
-    graph_width_eq_2$edge_selection$from == 2)
+  expect_equal(
+    graph_width_eq_2$edge_selection$from, 2)
 
   # Expect that node `3` is part of a selection
   # object in 'edges/to'
-  expect_true(
-    graph_width_eq_2$edge_selection$to == 3)
+  expect_equal(
+    graph_width_eq_2$edge_selection$to, 3)
 
   # Select nodes where `width` != 2
   graph_width_neq_2 <-
@@ -267,11 +267,11 @@ test_that("selecting an edge in a graph is possible", {
 
   # Expect that nodes `1` and `3` are part of a
   # selection object in 'edges/from'
-  expect_true(all(graph_width_neq_2$edge_selection$from == c(1, 3)))
+  expect_equal(graph_width_neq_2$edge_selection$from, c(1, 3))
 
   # Expect that nodes `4` and `1` are part of a
   # selection object in 'edges/to'
-  expect_true(all(graph_width_neq_2$edge_selection$to == c(4, 1)))
+  expect_equal(graph_width_neq_2$edge_selection$to, c(4, 1))
 
   # Select nodes where `rel` is `leading_to`
   graph_val_leading_to <-
@@ -281,15 +281,15 @@ test_that("selecting an edge in a graph is possible", {
 
   # Expect that nodes `1`, `2`, and `3` are part of a
   # selection object in 'edges/from'
-  expect_true(
-    all(
-      graph_val_leading_to$edge_selection$from == c(1, 2, 3)))
+  expect_equal(
+    graph_val_leading_to$edge_selection$from,
+    c(1, 2, 3))
 
   # Expect that nodes `4`, `3`, and `1` are part of a
   # selection object in 'edges/to'
-  expect_true(
-    all(
-      graph_val_leading_to$edge_selection$to == c(4, 3, 1)))
+  expect_equal(
+    graph_val_leading_to$edge_selection$to,
+    c(4, 3, 1))
 
   # Create a union of selections in a magrittr pipeline
   graph_sel_union_ab_bc <-
@@ -303,15 +303,14 @@ test_that("selecting an edge in a graph is possible", {
 
   # Expect that nodes `1` and `2` are part of a
   # selection object in `edges/from`
-  expect_true(
-    all(
-      graph_sel_union_ab_bc$edge_selection$from == c(1, 2)))
+  expect_equal(
+    graph_sel_union_ab_bc$edge_selection$from,
+    c(1, 2))
 
   # Expect that nodes `4` and `3` are part of a
   # selection object in `edges/to`
-  expect_true(
-    all(
-      graph_sel_union_ab_bc$edge_selection$to == c(4, 3)))
+  expect_equal(
+    graph_sel_union_ab_bc$edge_selection$to, c(4, 3))
 
   # Create a intersection of selections in a
   # magrittr pipeline
@@ -327,13 +326,13 @@ test_that("selecting an edge in a graph is possible", {
 
   # Expect that node `2` is part of a selection
   # object in `edges/from`
-  expect_true(
-    graph_sel_intersect_bc$edge_selection$from == 2)
+  expect_equal(
+    graph_sel_intersect_bc$edge_selection$from, 2)
 
   # Expect that node `3` is part of a selection
   # object in `edges/to`
-  expect_true(
-    graph_sel_intersect_bc$edge_selection$to == 3)
+  expect_equal(
+    graph_sel_intersect_bc$edge_selection$to, 3)
 
   # Create a selection that is a difference
   # of selections
@@ -349,13 +348,13 @@ test_that("selecting an edge in a graph is possible", {
 
   # Expect that node `1` is part of a selection
   # object in `edges/from`
-  expect_true(
-    graph_sel_edge_difference_ad$edge_selection$from == 1)
+  expect_equal(
+    graph_sel_edge_difference_ad$edge_selection$from, 1)
 
   # Expect that node `4` is part of a selection
   # object in `edges/to`
-  expect_true(
-    graph_sel_edge_difference_ad$edge_selection$to == 4)
+  expect_equal(
+    graph_sel_edge_difference_ad$edge_selection$to, 4)
 
   # Select edges, specifying only the `from` node
   graph_from_a <-
@@ -364,11 +363,11 @@ test_that("selecting an edge in a graph is possible", {
       from = 1)
 
   # Expect that only the edge `1`->`4` is selected
-  expect_true(
-    graph_from_a$edge_selection$from == 1)
+  expect_equal(
+    graph_from_a$edge_selection$from, 1)
 
-  expect_true(
-    graph_from_a$edge_selection$to == 4)
+  expect_equal(
+    graph_from_a$edge_selection$to, 4)
 
   # Expect an error if when only specifying the
   # `from` node, that node isn't present in the graph
@@ -384,11 +383,11 @@ test_that("selecting an edge in a graph is possible", {
       to = 3)
 
   # Expect that only the edge `2`->`3` is selected
-  expect_true(
-    graph_to_c$edge_selection$from == 2)
+  expect_equal(
+    graph_to_c$edge_selection$from, 2)
 
-  expect_true(
-    graph_to_c$edge_selection$to == 3)
+  expect_equal(
+    graph_to_c$edge_selection$to, 3)
 
   # Expect an error if when only specifying the
   # `to` node, that node isn't present in the graph
@@ -508,13 +507,13 @@ test_that("selecting edges via node IDs is possible", {
 
   # Expect that certain edges with be available
   # in the selection
-  expect_true(
-    all(graph$edge_selection$from %in%
-          c(3, 4, 2)))
+  expect_in(
+    graph$edge_selection$from,
+    c(3, 4, 2))
 
-  expect_true(
-    all(graph$edge_selection$to %in%
-          c(4, 5, 3)))
+  expect_in(
+    graph$edge_selection$to,
+    c(4, 5, 3))
 })
 
 test_that("selecting edges via edge IDs is possible", {
@@ -587,9 +586,9 @@ test_that("selecting nodes in a neighborhood is possible", {
 
   # Expect that specific nodes are part of a selection
   # object in `nodes`
-  expect_true(
-    all(graph_sel_1_sel_4_dist_2_sel_A_dist_3$node_selection$node ==
-          c(4, 3, 2)))
+  expect_equal(
+    graph_sel_1_sel_4_dist_2_sel_A_dist_3$node_selection$node,
+    c(4, 3, 2))
 
   # Create a selection of nodes centered around node
   # `7` and including those nodes a distance of 2
@@ -603,9 +602,9 @@ test_that("selecting nodes in a neighborhood is possible", {
 
   # Expect that specific nodes are part of a selection
   # object in `nodes`
-  expect_true(
-    all(graph_sel_1_sel_4_dist_2_sel_A_dist_3$node_selection$node ==
-          c(4, 3, 2)))
+  expect_equal(
+    graph_sel_1_sel_4_dist_2_sel_A_dist_3$node_selection$node,
+    c(4, 3, 2))
 })
 
 test_that("getting a selection is possible", {
@@ -622,9 +621,9 @@ test_that("getting a selection is possible", {
     get_selection()
 
   # Expect that specific nodes are returned
-  expect_true(
-    all(graph_node_selection_1 ==
-          c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)))
+  expect_equal(
+    graph_node_selection_1,
+    c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
 
   # Select all edges in graph and get selection
   graph_edge_selection_1 <-
@@ -633,9 +632,9 @@ test_that("getting a selection is possible", {
     get_selection()
 
   # Expect that specific nodes are returned
-  expect_true(
-    all(graph_edge_selection_1 ==
-          c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)))
+  expect_equal(
+    graph_edge_selection_1,
+    c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
 })
 
 test_that("inverting a selection is possible", {
@@ -659,9 +658,8 @@ test_that("inverting a selection is possible", {
 
   # Expect that all nodes except `1` and `2` are
   # in the selection
-  expect_true(
-    all(graph_select_1_2_inverted$node_selection$node %in%
-          3:12))
+  expect_in(graph_select_1_2_inverted$node_selection$node,
+          3:12)
 
   # Select edges `1`->`2` and `2`->`3` in the graph
   graph_select_edges_1_2__2_3 <-
@@ -681,15 +679,14 @@ test_that("inverting a selection is possible", {
 
   # Expect that every other edge is now in
   # the selection
-  expect_true(
-    all(
-      graph_select_edges_1_2__2_3_inverted$edge_selection$from %in%
-        c(3, 4, 5, 6, 7, 8, 9, 10, 11)))
+  expect_equal(
+    graph_select_edges_1_2__2_3_inverted$edge_selection$from,
+      c(3, 4, 5, 6, 7, 8, 9, 10, 11))
 
-  expect_true(
-    all(
-      graph_select_edges_1_2__2_3_inverted$edge_selection$to %in%
-        c(4, 5, 6, 7, 8, 9, 10, 11, 12)))
+  expect_equal(
+    graph_select_edges_1_2__2_3_inverted$edge_selection$to,
+    c(4, 5, 6, 7, 8, 9, 10, 11, 12)
+  )
 
   # Expect an error if inverting selection that
   # doesn't exist
@@ -715,9 +712,7 @@ test_that("getting/clearing a selection is possible", {
 
   # Get the selection and expect both nodes to
   # be present
-  expect_true(
-    all(c(1, 2) %in%
-          get_selection(graph_select_all_nodes)))
+  expect_contains(get_selection(graph_select_all_nodes), c(1, 2))
 
   # Clear the selection
   graph_select_all_nodes_cleared <-

--- a/tests/testthat/test-series_info.R
+++ b/tests/testthat/test-series_info.R
@@ -11,7 +11,7 @@ test_that("graph series information can be obtained", {
 
   # Expect that `empty_series_info` is a
   # data frame object
-  expect_is(
+  expect_s3_class(
     empty_series_info, "data.frame")
 
   # Expect that the data frame has no rows
@@ -23,25 +23,25 @@ test_that("graph series information can be obtained", {
     ncol(empty_series_info), 7)
 
   # Expect specific column classes in the data frame
-  expect_is(
+  expect_type(
     empty_series_info[, 1], "integer")
 
-  expect_is(
+  expect_type(
     empty_series_info[, 2], "character")
 
-  expect_is(
+  expect_s3_class(
     empty_series_info[, 3], "POSIXct")
 
-  expect_is(
+  expect_type(
     empty_series_info[, 4], "character")
 
-  expect_is(
+  expect_type(
     empty_series_info[, 5], "integer")
 
-  expect_is(
+  expect_type(
     empty_series_info[, 6], "integer")
 
-  expect_is(
+  expect_type(
     empty_series_info[, 7], "logical")
 
   # Create 3 graph objects
@@ -93,7 +93,7 @@ test_that("graph series information can be obtained", {
     get_graph_series_info()
 
   # Expect that `info_on_series` is a data frame object
-  expect_is(
+  expect_s3_class(
     info_on_series, "data.frame")
 
   # Expect that the data frame has 3 rows
@@ -105,25 +105,25 @@ test_that("graph series information can be obtained", {
     ncol(info_on_series), 7)
 
   # Expect specific column classes in the data frame
-  expect_is(
+  expect_type(
     info_on_series[, 1], "integer")
 
-  expect_is(
+  expect_type(
     info_on_series[, 2], "character")
 
-  expect_is(
+  expect_s3_class(
     info_on_series[, 3], "POSIXct")
 
-  expect_is(
+  expect_type(
     info_on_series[, 4], "character")
 
-  expect_is(
+  expect_type(
     info_on_series[, 5], "integer")
 
-  expect_is(
+  expect_type(
     info_on_series[, 6], "integer")
 
-  expect_is(
+  expect_type(
     info_on_series[, 7], "logical")
 
   # Expect that the values in the `graph`
@@ -160,7 +160,7 @@ test_that("graph series information can be obtained", {
 
   # Expect that `info_on_series_temporal` is
   # a data frame object
-  expect_is(
+  expect_s3_class(
     info_on_series_temporal, "data.frame")
 
   # Expect that the data frame has 1 row
@@ -172,25 +172,25 @@ test_that("graph series information can be obtained", {
     ncol(info_on_series_temporal), 7)
 
   # Expect specific column classes in the data frame
-  expect_is(
+  expect_type(
     info_on_series_temporal[, 1], "integer")
 
-  expect_is(
+  expect_type(
     info_on_series_temporal[, 2], "character")
 
-  expect_is(
+  expect_s3_class(
     info_on_series_temporal[, 3], "POSIXct")
 
-  expect_is(
+  expect_type(
     info_on_series_temporal[, 4], "character")
 
-  expect_is(
+  expect_type(
     info_on_series_temporal[, 5], "integer")
 
-  expect_is(
+  expect_type(
     info_on_series_temporal[, 6], "integer")
 
-  expect_is(
+  expect_type(
     info_on_series_temporal[, 7], "logical")
 
   # Expect that the `name`, `date_time`,
@@ -198,8 +198,8 @@ test_that("graph series information can be obtained", {
   expect_equal(
     info_on_series_temporal[, 2], "graph_no_tz_provided")
 
-  expect_true(
-    !is.na(info_on_series_temporal[, 3]))
+  expect_false(
+    is.na(info_on_series_temporal[, 3]))
 
   expect_equal(
     info_on_series_temporal[, 4], "GMT")

--- a/tests/testthat/test-set_get_graph_attrs.R
+++ b/tests/testthat/test-set_get_graph_attrs.R
@@ -11,8 +11,8 @@ test_that("Setting a graph name can be done", {
     set_graph_name(name = "test_that_name")
 
   # Expect that the name was set
-  expect_true(
-    graph_name$graph_info$graph_name == "test_that_name")
+  expect_equal(
+    graph_name$graph_info$graph_name, "test_that_name")
 
   # Add 2 nodes and an edge and then
   # select a node
@@ -32,8 +32,8 @@ test_that("Setting a graph name can be done", {
       name = "test_that_name_again")
 
   # Expect that the name was set
-  expect_true(
-    graph_name_1$graph_info$graph_name == "test_that_name_again")
+  expect_equal(
+    graph_name_1$graph_info$graph_name, "test_that_name_again")
 })
 
 test_that("Setting a time for the graph can be done", {
@@ -53,8 +53,8 @@ test_that("Setting a time for the graph can be done", {
     graph_1$graph_info$graph_time == "2015-10-25 15:23:00")
 
   # Expect that the time zone is set to `GMT`
-  expect_true(
-    graph_1$graph_info$graph_tz == "GMT")
+  expect_equal(
+    graph_1$graph_info$graph_tz, "GMT")
 
   # Update tz when a timestamp is already present
   graph_2 <-
@@ -63,8 +63,8 @@ test_that("Setting a time for the graph can be done", {
       tz = "America/Los_Angeles")
 
   # Expect that the time zone has been changed
-  expect_true(
-    graph_2$graph_info$graph_tz == "America/Los_Angeles")
+  expect_equal(
+    graph_2$graph_info$graph_tz, "America/Los_Angeles")
 
   # Expect an error when setting a time zone that is
   # not in `OlsonNames()`
@@ -90,7 +90,7 @@ test_that("Getting the graph name is possible", {
 
   # Verify that the graph name returned is a
   # character vector
-  expect_is(
+  expect_type(
     get_graph_name(graph), "character")
 
   # Expect that the returned vector has a length of 1
@@ -111,18 +111,17 @@ test_that("Getting the graph time is possible", {
       time = "2015-10-25 15:23:00")
 
   # Expect a graph time as POSIXct
-  expect_is(
+  expect_s3_class(
     get_graph_time(graph), "POSIXct")
 
   # Expect that the returned vector has a length of 1
-  expect_equal(
-    length(get_graph_time(graph)), 1)
+  expect_length(get_graph_time(graph), 1)
 
   # Create a graph without a time set
   graph <- create_graph()
 
   # Verify that a POSIXct time is returned
-  expect_is(
+  expect_s3_class(
     get_graph_time(graph), "POSIXct")
 })
 

--- a/tests/testthat/test-set_get_node_edge_attrs.R
+++ b/tests/testthat/test-set_get_node_edge_attrs.R
@@ -59,8 +59,7 @@ test_that("setting node attributes is possible", {
       values = 5)
 
   # Expect that all nodes have the attribute set
-  expect_true(
-    all(graph_set_all$nodes_df$value == 5))
+  expect_in(graph_set_all$nodes_df$value, 5)
 
   # Select node `1` and apply a node attribute
   # using that node selection
@@ -150,9 +149,7 @@ test_that("setting edge attributes is possible", {
       values = 5)
 
   # Expect that all edges have the attribute set
-  expect_true(
-    all(
-      graph_set_all$edges_df$value == 5))
+  expect_in(graph_set_all$edges_df$value, 5)
 
   # Select edge `1`->`2` and apply an edge attribute using that
   # edge selection
@@ -191,17 +188,12 @@ test_that("Getting node attributes is possible", {
       graph = graph,
       node_attr = value)
 
-  # Expect a vector of integer values
-  expect_is(
-    all_nodes, "integer")
-
-  # Expect the vector to have length 4
-  expect_equal(
-    length(all_nodes), 4)
-
+  # Expect a vector of integer values (length 4)
+  expect_type(all_nodes, "integer")
+  expect_length(all_nodes, 4)
   # Expect certain names to be in the vector
-  expect_true(
-    all(1:4 %in% names(all_nodes)))
+
+  expect_named(all_nodes, as.character(1:4))
 
   # Expect certain values to be in the vector
   expect_equal(
@@ -223,13 +215,9 @@ test_that("Getting node attributes is possible", {
       node_attr = value,
       nodes = c(1, 3))
 
-  # Expect the vector to have length 2
-  expect_equal(
-    length(nodes_1_3), 2)
-
-  # Expect certain names to be in the vector
-  expect_true(
-    all(c(1, 3) %in% names(nodes_1_3)))
+  # Expect the vector to have length 2 (named 1, 3)
+  expect_length(nodes_1_3, 2)
+  expect_named(nodes_1_3, c("1", "3"))
 
   # Expect certain values to be in the vector
   expect_equal(
@@ -291,17 +279,17 @@ test_that("Getting edge attributes is possible", {
       edge_attr = value)
 
   # Expect a numeric vector
-  expect_is(
-    all_edges, "numeric")
+  expect_type(
+    all_edges, "double")
 
   # Expect the vector to have length 4
-  expect_equal(
-    length(all_edges), 4)
+  expect_length(all_edges, 4)
 
   # Expect certain names to be in the vector
-  expect_true(
-    all(c("1->2", "2->3", "1->4", "4->3") %in%
-          names(all_edges)))
+  expect_contains(
+    names(all_edges),
+    c("1->2", "2->3", "1->4", "4->3")
+    )
 
   # Expect certain values to be in the vector
   expect_equal(
@@ -326,13 +314,13 @@ test_that("Getting edge attributes is possible", {
         to = c(2, 3))
 
   # Expect the vector to have length 2
-  expect_equal(
-    length(some_edges), 2)
+  expect_length(some_edges, 2)
 
   # Expect certain names to be in the vector
-  expect_true(
-    all(c("1->2", "2->3") %in%
-          names(some_edges)))
+  expect_contains(
+    names(some_edges),
+    c("1->2", "2->3")
+  )
 
   # Expect certain values to be in the vector
   expect_equal(
@@ -385,16 +373,16 @@ test_that("Getting node attributes with a selection is possible", {
       node_attr = value)
 
   # Expect a vector of integer values
-  expect_is(
-    nodes_1_3, "integer")
+  expect_type(nodes_1_3, "integer")
 
   # Expect the vector to have length 2
-  expect_equal(
-    length(nodes_1_3), 2)
+  expect_length(nodes_1_3, 2)
 
   # Expect certain names to be in the vector
-  expect_true(
-    all(c(1, 3) %in% names(nodes_1_3)))
+  expect_named(
+    nodes_1_3,
+    c("1", "3")
+  )
 
   # Expect certain values to be in the vector
   expect_equal(
@@ -471,16 +459,19 @@ test_that("Getting edge attributes with a selection is possible", {
       edge_attr = value)
 
   # Expect a numeric vector
-  expect_is(
-    edge_attr_values, "numeric")
+  expect_type(
+    edge_attr_values, "double")
 
   # Expect the vector to have length 2
-  expect_equal(
-    length(edge_attr_values), 2)
+  expect_length(edge_attr_values, 2)
 
   # Expect certain names to be in the vector
-  expect_true(
-    all(c("1->2", "2->3") %in% names(edge_attr_values)))
+  # expect_contains == expect_true(all(expected %in% object))
+  expect_named(
+    edge_attr_values,
+    c("1->2", "2->3"),
+    ignore.order = TRUE
+    )
 
   # Expect certain values to be in the vector
   expect_equal(

--- a/tests/testthat/test-set_node_positions.R
+++ b/tests/testthat/test-set_node_positions.R
@@ -25,8 +25,7 @@ test_that("setting a single node's position is possible", {
 
   # Expect that the `x` and `y` node
   # attributes columns are available
-  expect_true(
-    all(c("x", "y") %in% colnames(graph_1$nodes_df)))
+  expect_contains(colnames(graph_1$nodes_df), c("x", "y"))
 
   # Expect specific values in the `x` column
   expect_equal(
@@ -57,10 +56,9 @@ test_that("setting a single node's position is possible", {
       x = 4, y = 4,
       use_labels = TRUE)
 
-  # Expect that the `x` and `y` node
+  # Expect that both `x` and `y` node
   # attributes columns are available
-  expect_true(
-    all(c("x", "y") %in% colnames(graph_2$nodes_df)))
+  expect_contains(colnames(graph_2$nodes_df), c("x", "y"))
 
   # Expect specific values in the `x` column
   expect_equal(
@@ -179,10 +177,9 @@ test_that("setting positions with a text string is possible", {
                "2" = "label:desc",
                "3" = "label:desc"))
 
-  # Expect that the `x` and `y` node
+  # Expect that both the `x` and `y` node
   # attributes columns are available
-  expect_true(
-    all(c("x", "y") %in% colnames(graph$nodes_df)))
+  expect_contains(colnames(graph$nodes_df), c("x", "y"))
 
   # Expect specific values in the `x` column
   expect_equal(

--- a/tests/testthat/test-similarity_measures.R
+++ b/tests/testthat/test-similarity_measures.R
@@ -35,61 +35,27 @@ test_that("the dice similarity algorithm is functional", {
       direction = "in")
 
   # Expect that a `matrix` object is returned
-  expect_is(
-    dice_all, "matrix")
-
-  expect_is(
-    dice_out, "matrix")
-
-  expect_is(
-    dice_in, "matrix")
+  expect_true(is.matrix(dice_all))
+  expect_true(is.matrix(dice_out))
+  expect_true(is.matrix(dice_in))
 
   # Expect a square matrix of 3 columns and 3 rows
-  expect_equal(
-    ncol(dice_all), 3)
-
-  expect_equal(
-    nrow(dice_all), 3)
-
-  expect_equal(
-    ncol(dice_out), 3)
-
-  expect_equal(
-    nrow(dice_out), 3)
-
-  expect_equal(
-    ncol(dice_in), 3)
-
-  expect_equal(
-    nrow(dice_in), 3)
+  expect_equal(dim(dice_all), c(3, 3))
+  expect_equal(dim(dice_out), c(3, 3))
+  expect_equal(dim(dice_in), c(3, 3))
 
   # Expect all columns to be numeric
-  expect_true(
-    inherits(dice_all[, 1], "numeric"))
+  expect_type(dice_all[, 1], "double")
+  expect_type(dice_all[, 2], "double")
+  expect_type(dice_all[, 3], "double")
 
-  expect_true(
-    inherits(dice_all[, 2], "numeric"))
+  expect_type(dice_out[, 1], "double")
+  expect_type(dice_out[, 2], "double")
+  expect_type(dice_out[, 3], "double")
 
-  expect_true(
-    inherits(dice_all[, 3], "numeric"))
-
-  expect_true(
-    inherits(dice_out[, 1], "numeric"))
-
-  expect_true(
-    inherits(dice_out[, 2], "numeric"))
-
-  expect_true(
-    inherits(dice_out[, 3], "numeric"))
-
-  expect_true(
-    inherits(dice_in[, 1], "numeric"))
-
-  expect_true(
-    inherits(dice_in[, 2], "numeric"))
-
-  expect_true(
-    inherits(dice_in[, 3], "numeric"))
+  expect_type(dice_in[, 1], "double")
+  expect_type(dice_in[, 2], "double")
+  expect_type(dice_in[, 3], "double")
 
   # Expect specific column names in this data frame
   expect_equal(
@@ -190,61 +156,27 @@ test_that("the Jaccard similarity algorithm is functional", {
       direction = "in")
 
   # Expect that a `matrix` object is returned
-  expect_is(
-    jaccard_all, "matrix")
-
-  expect_is(
-    jaccard_out, "matrix")
-
-  expect_is(
-    jaccard_in, "matrix")
+  expect_true(is.matrix(jaccard_all))
+  expect_true(is.matrix(jaccard_out))
+  expect_true(is.matrix(jaccard_in))
 
   # Expect a square matrix of 3 columns and 3 rows
-  expect_equal(
-    ncol(jaccard_all), 3)
-
-  expect_equal(
-    nrow(jaccard_all), 3)
-
-  expect_equal(
-    ncol(jaccard_out), 3)
-
-  expect_equal(
-    nrow(jaccard_out), 3)
-
-  expect_equal(
-    ncol(jaccard_in), 3)
-
-  expect_equal(
-    nrow(jaccard_in), 3)
+  expect_equal(dim(jaccard_all), c(3, 3))
+  expect_equal(dim(jaccard_out), c(3, 3))
+  expect_equal(dim(jaccard_in), c(3, 3))
 
   # Expect all columns to be numeric
-  expect_true(
-    inherits(jaccard_all[, 1], "numeric"))
+  expect_type(jaccard_all[, 1], "double")
+  expect_type(jaccard_all[, 2], "double")
+  expect_type(jaccard_all[, 3], "double")
 
-  expect_true(
-    inherits(jaccard_all[, 2], "numeric"))
+  expect_type(jaccard_out[, 1], "double")
+  expect_type(jaccard_out[, 2], "double")
+  expect_type(jaccard_out[, 3], "double")
 
-  expect_true(
-    inherits(jaccard_all[, 3], "numeric"))
-
-  expect_true(
-    inherits(jaccard_out[, 1], "numeric"))
-
-  expect_true(
-    inherits(jaccard_out[, 2], "numeric"))
-
-  expect_true(
-    inherits(jaccard_out[, 3], "numeric"))
-
-  expect_true(
-    inherits(jaccard_in[, 1], "numeric"))
-
-  expect_true(
-    inherits(jaccard_in[, 2], "numeric"))
-
-  expect_true(
-    inherits(jaccard_in[, 3], "numeric"))
+  expect_type(jaccard_in[, 1], "double")
+  expect_type(jaccard_in[, 2], "double")
+  expect_type(jaccard_in[, 3], "double")
 
   # Expect specific column names in this data frame
   expect_equal(

--- a/tests/testthat/test-spectools.R
+++ b/tests/testthat/test-spectools.R
@@ -14,7 +14,7 @@ test_that("the specification tools are functional", {
   replaced_spec <- grViz(replace_in_spec(spec))
 
   # Expect that the object inherits from 'grViz' and 'htmlwidget'
-  expect_is(
+  expect_s3_class(
     replaced_spec, c("grViz", "htmlwidget"))
 
   # Create a simple Graphviz graph specification and perform
@@ -42,7 +42,7 @@ test_that("the specification tools are functional", {
   replaced_spec <- grViz(replace_in_spec(spec))
 
   # Expect that the object inherits from 'grViz' and 'htmlwidget'
-  expect_is(
+  expect_s3_class(
     replaced_spec, c("grViz", "htmlwidget"))
 })
 

--- a/tests/testthat/test-transform_graph.R
+++ b/tests/testthat/test-transform_graph.R
@@ -16,7 +16,7 @@ test_that("Converting to igraph is possible", {
     to_igraph(graph)
 
   # Expect that the new object is an igraph object
-  expect_is(
+  expect_s3_class(
     igraph_graph, "igraph")
 })
 
@@ -30,9 +30,8 @@ test_that("Changing to undirected mode is possible", {
   undirected_graph <-
     set_graph_undirected(graph)
 
-  # Expect the the graph is undirected
-  expect_true(
-    graph$directed)
+  # Expect the the graph is directed
+  expect_true(graph$directed)
 })
 
 test_that("Changing to directed mode is possible", {

--- a/tests/testthat/test-traversals.R
+++ b/tests/testthat/test-traversals.R
@@ -53,8 +53,7 @@ test_that("simple traversals are possible", {
 
   # Expect that nodes `1` and `3` are in the
   # current selection
-  expect_true(
-    all(c(1, 3) %in% get_selection(graph)))
+  expect_in(get_selection(graph), c(1, 3))
 
   # Traverse by moving from nodes onto edges, then,
   # onto nodes; from `1` to `4`

--- a/tests/testthat/test-x11_hex.R
+++ b/tests/testthat/test-x11_hex.R
@@ -6,20 +6,20 @@ test_that("a data frame X11 color names and hexadecimal values can be made", {
   x11_hex_df <- x11_hex()
 
   # Expect an object of class "data.frame"
-  expect_is(x11_hex_df, "data.frame")
+  expect_s3_class(x11_hex_df, "data.frame")
 
   # Expect that the "x11_hex_df" data frame has 2 columns
-  expect_true(ncol(x11_hex_df) == 2L)
+  expect_equal(ncol(x11_hex_df), 2)
 
   # Expect that the "x11_hex_df" data frame has 655 rows
-  expect_true(nrow(x11_hex_df) == 655L)
+  expect_equal(nrow(x11_hex_df), 655)
 
   # Expect specific column names
-  expect_true(all(colnames(x11_hex_df) == c("x11_name", "hex")))
+  expect_in(colnames(x11_hex_df), c("x11_name", "hex"))
 
   # Expect that both columns are of the "character" class
-  expect_is(x11_hex_df[,1], "character")
-  expect_is(x11_hex_df[,2], "character")
+  expect_type(x11_hex_df[,1], "character")
+  expect_type(x11_hex_df[,2], "character")
 
   # Expect that the color names are lowercased with no spaces
   expect_match(x11_hex_df[,1], "[a-z1-4]")


### PR DESCRIPTION
* use dplyr::all_of() and with igraph, mode instead of neimode. (

Various cleaning in tests to make the potential transition to testthat 3rd edition much easier (as expect_is is deprecated for testthat edition 3)

Edit: I also updated gh actions because they were not testing for r 4.3 and r 4.4
