### PR TITLE
Add display to code when saving `as_svg = TRUE`

### DIFF
--- a/R/render_graph.R
+++ b/R/render_graph.R
@@ -241,6 +241,9 @@ render_graph <- function(
           grViz(diagram = dot_code)), "\n") %>%
         unlist()
 
+      # create display to make return work when `as_svg = TRUE` #482
+      display <- grViz(diagram = dot_code, width = width, height = height)
+
       # Get a tibble of SVG data
       svg_tbl <- get_svg_tbl(svg_vec)
 

--- a/man/DiagrammeR-package.Rd
+++ b/man/DiagrammeR-package.Rd
@@ -20,5 +20,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Richard Iannone \email{riannone@me.com} (\href{https://orcid.org/0000-0003-3925-190X}{ORCID})
 
+Authors:
+\itemize{
+  \item Olivier Roy \email{olivierroy71@hotmail.com}
+}
+
 }
 \keyword{internal}


### PR DESCRIPTION
Fix #492 

Naive fix, (harmless) doesn't change anything ) working on refactoring the `render_graph()` code to silence some tibble related warnings, but thought I'd send this as a separate PR.

I ran into an error that only shows up when dev (with load_all() when testing this. (that I do not understand)

```r
<std::runtime_error> with text:
  ReferenceError: Viz is not defined
Warnings
In file(con, "r") :
  file("") accepts only open = "w+" and open = "w+b" : using the first one
```

If you have an idea what it means, please let me know.

But I was able to test it successfully by installing the dev version of DIagrammeR locally.