### PR TITLE
Use viridisLite instead of viridis + redocument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     stringr (>= 1.4),
     tibble (>= 3.1),
     tidyr (>= 1.1),
-    viridis (>= 0.6.2),
+    viridisLite (>= 0.4.2),
     visNetwork (>= 2.1.0)
 Suggests:
     curl,
@@ -53,4 +53,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # DiagrammeR (development version)
 
+* DiagrammeR now has a dependency on viridisLite instead of viridis (@olivroy, #511)
+
 * DiagrammeR nows uses testthat 3rd edition (@olivroy, #498)
 
 * No longer use deprecated features from tibble, igraph and tidyselect (>= 1.2.0) (@olivroy, #497, #507)

--- a/R/DiagrammeR-package.R
+++ b/R/DiagrammeR-package.R
@@ -1,5 +1,4 @@
 #' @keywords internal
-#' @aliases DiagrammeR-package
 "_PACKAGE"
 
 ## usethis namespace: start

--- a/R/colorize_edge_attrs.R
+++ b/R/colorize_edge_attrs.R
@@ -140,7 +140,7 @@ colorize_edge_attrs <- function(
     if (palette %in% row.names(RColorBrewer::brewer.pal.info)) {
       color_palette <- RColorBrewer::brewer.pal(num_recodings, palette)
     } else if (palette == "viridis") {
-      color_palette <- viridis::viridis(num_recodings)
+      color_palette <- viridisLite::viridis(num_recodings)
       color_palette <- gsub("..$", "", color_palette)
     }
   }

--- a/R/colorize_node_attrs.R
+++ b/R/colorize_node_attrs.R
@@ -185,7 +185,7 @@ colorize_node_attrs <- function(
     if (palette %in% row.names(RColorBrewer::brewer.pal.info)) {
       color_palette <- RColorBrewer::brewer.pal(num_recodings, palette)
     } else if (palette == "viridis") {
-      color_palette <- viridis::viridis(num_recodings)
+      color_palette <- viridisLite::viridis(num_recodings)
       color_palette <- gsub("..$", "", color_palette)
     }
   }

--- a/man/DiagrammeR-package.Rd
+++ b/man/DiagrammeR-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{DiagrammeR-package}
 \alias{DiagrammeR-package}
-\alias{_PACKAGE}
 \title{DiagrammeR: Graph/Network Visualization}
 \description{
 Build graph/network structures using functions for stepwise addition and deletion of nodes and edges. Work with data available in tables for bulk addition of nodes, edges, and associated metadata. Use graph selections and traversals to apply changes to specific nodes or edges. A wide selection of graph algorithms allow for the analysis of graphs. Visualize the graphs and take advantage of any aesthetic properties assigned to nodes and edges.


### PR DESCRIPTION
Makes the package a bit lighter as we only use `viridis::virdis()` which is re-exported from viridisLite anyway. This removes 9 dependencies overall.