### PR TITLE
graphViz - Correctly pass options to `Viz()`

### DIFF
--- a/inst/htmlwidgets/grViz.js
+++ b/inst/htmlwidgets/grViz.js
@@ -34,9 +34,8 @@ HTMLWidgets.widget({
       }
 
       try {
-
-        el.innerHTML = Viz(x.diagram, format="svg", engine=x.config.engine, options=x.config.options);
-
+        el.innerHTML = Viz( x.diagram, { format: "svg", engine: x.config.engine, ...x.config.options });
+        
         makeResponsive(el);
 
         if (HTMLWidgets.shinyMode) {


### PR DESCRIPTION
This also fix conflict with Quarto
https://github.com/quarto-dev/quarto-cli/issues/12513

Looking at how `Viz()` function works 
````js
    function Viz(src) {
        var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
        var format = options.format === undefined ? "svg" : options.format;
        var engine = options.engine === undefined ? "dot" : options.engine;
        var scale = options.scale;
        var totalMemory = options.totalMemory;
        var files = options.files === undefined ? [] : options.files;
        var images = options.images === undefined ? [] : options.images;
````

I think it requires only one argument for the options, and then the different options are taken into this one. 

It also fix the conflict problem with Quarto. 

````markdown
---
format: html
---

```{r}
library(DiagrammeR)
mygraph<- grViz("
digraph transmission {
  graph [layout = dot, rankdir = TB]

  node [shape = box, style = \"rounded,filled\", fillcolor = lightgray, color = gray20, fontname = Helvetica, fontsize = 12]

  D [label = 'Fruit Bat']
  B [label = 'Human', fillcolor = red]  # Red fill for B
  C [label = 'Human']

  D -> B
  B -> C
  C -> B
}
")

```
### Column {.tabset width="30%"}

```{r}
#| title: chain
mygraph
```
````

To be discussed.

closes #519 