### PR TITLE
Update examples in docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.3

--- a/R/add_balanced_tree.R
+++ b/R/add_balanced_tree.R
@@ -25,11 +25,11 @@
 #' # 2 (branching twice) and
 #' # different branching ratios
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
 #'     k = 2,
 #'     h = 2,
-#'     type = "binary") %>%
+#'     type = "binary") |>
 #'   add_balanced_tree(
 #'     k = 3,
 #'     h = 2,
@@ -37,8 +37,8 @@
 #'
 #' # Get some node information
 #' # from this graph
-#' graph %>%
-#'   get_node_info() %>%
+#' graph |>
+#'   get_node_info() |>
 #'   head(5)
 #'
 #' # Node and edge aesthetic and data
@@ -47,7 +47,7 @@
 #' # `node_data`, and `edge_data`
 #' # arguments
 #' graph_w_attrs <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
 #'     k = 2,
 #'     h = 2,
@@ -71,14 +71,14 @@
 #'
 #' # Get the first three rows of
 #' # the graph's node data frame
-#' graph_w_attrs %>%
-#'   get_node_df() %>%
+#' graph_w_attrs |>
+#'   get_node_df() |>
 #'   head(3)
 #'
 #' # Get the first three rows of
 #' # the graph's edge data frame
-#' graph_w_attrs %>%
-#'   get_edge_df() %>%
+#' graph_w_attrs |>
+#'   get_edge_df() |>
 #'   head(3)
 #'
 #' @export
@@ -165,7 +165,7 @@ add_balanced_tree <- function(
       node_aes$index__ <- seq_len(n_nodes_tree)
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -184,7 +184,7 @@ add_balanced_tree <- function(
       node_data$index__ <- seq_len(n_nodes_tree)
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -203,7 +203,7 @@ add_balanced_tree <- function(
       edge_aes$index__ <- seq_len(n_edges_tree)
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -222,7 +222,7 @@ add_balanced_tree <- function(
       edge_data$index__ <- seq_len(n_edges_tree)
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -235,7 +235,7 @@ add_balanced_tree <- function(
   if (exists("node_aes_tbl")) {
 
     tree_nodes <-
-      tree_nodes %>%
+      tree_nodes |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -243,7 +243,7 @@ add_balanced_tree <- function(
   if (exists("node_data_tbl")) {
 
     tree_nodes <-
-      tree_nodes %>%
+      tree_nodes |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -251,7 +251,7 @@ add_balanced_tree <- function(
   if (exists("edge_aes_tbl")) {
 
     tree_edges <-
-      tree_edges %>%
+      tree_edges |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -259,7 +259,7 @@ add_balanced_tree <- function(
   if (exists("edge_data_tbl")) {
 
     tree_edges <-
-      tree_edges %>%
+      tree_edges |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_cycle.R
+++ b/R/add_cycle.R
@@ -21,12 +21,12 @@
 #' # Create a new graph and
 #' # add a cycle of nodes to it
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 6)
 #'
 #' # Get node information
 #' # from this graph
-#' graph %>%
+#' graph |>
 #'   get_node_info()
 #'
 #' # Node and edge aesthetic and data
@@ -39,7 +39,7 @@
 #' set.seed(23)
 #'
 #' graph_w_attrs <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(
 #'     n = 3,
 #'     label = c(
@@ -63,10 +63,10 @@
 #'           sd = 1.0)))
 #'
 #' # Get the graph's node data frame
-#' graph_w_attrs %>% get_node_df()
+#' graph_w_attrs |> get_node_df()
 #'
 #' # Get the graph's edge data frame
-#' graph_w_attrs %>% get_edge_df()
+#' graph_w_attrs |> get_edge_df()
 #'
 #' @export
 add_cycle <- function(
@@ -124,7 +124,7 @@ add_cycle <- function(
       node_aes$index__ <- seq_len(n)
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -143,7 +143,7 @@ add_cycle <- function(
       edge_aes$index__ <- seq_len(n)
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -162,7 +162,7 @@ add_cycle <- function(
       node_data$index__ <- seq_len(n)
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -181,7 +181,7 @@ add_cycle <- function(
       edge_data$index__ <- seq_len(n)
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -201,7 +201,7 @@ add_cycle <- function(
   if (exists("node_aes_tbl")) {
 
     cycle_nodes <-
-      cycle_nodes %>%
+      cycle_nodes |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -209,7 +209,7 @@ add_cycle <- function(
   if (exists("node_data_tbl")) {
 
     cycle_nodes <-
-      cycle_nodes %>%
+      cycle_nodes |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -224,7 +224,7 @@ add_cycle <- function(
   if (exists("edge_aes_tbl")) {
 
     cycle_edges <-
-      cycle_edges %>%
+      cycle_edges |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -232,7 +232,7 @@ add_cycle <- function(
   if (exists("edge_data_tbl")) {
 
     cycle_edges <-
-      cycle_edges %>%
+      cycle_edges |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_edge.R
+++ b/R/add_edge.R
@@ -25,10 +25,10 @@
 #' @examples
 #' # Create a graph with 4 nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_node(label = "one") %>%
-#'   add_node(label = "two") %>%
-#'   add_node(label = "three") %>%
+#'   create_graph() |>
+#'   add_node(label = "one") |>
+#'   add_node(label = "two") |>
+#'   add_node(label = "three") |>
 #'   add_node(label = "four")
 #'
 #' # Add an edge between those
@@ -44,13 +44,13 @@
 #' # Use the `get_edge_info()`
 #' # function to verify that
 #' # the edge has been created
-#' graph %>%
+#' graph |>
 #'   get_edge_info()
 #'
 #' # Add another node and
 #' # edge to the graph
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_edge(
 #'     from = 3,
 #'     to = 2,
@@ -59,7 +59,7 @@
 #' # Verify that the edge
 #' # has been created by
 #' # counting graph edges
-#' graph %>% count_edges()
+#' graph |> count_edges()
 #'
 #' # Add edges by specifying
 #' # node `label` values; note
@@ -67,11 +67,11 @@
 #' # unique `label` values to
 #' # use this option
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_edge(
 #'     from = "three",
 #'     to = "four",
-#'     rel = "L") %>%
+#'     rel = "L") |>
 #'   add_edge(
 #'     from = "four",
 #'     to = "one",
@@ -79,13 +79,13 @@
 #'
 #' # Use `get_edges()` to verify
 #' # that the edges were added
-#' graph %>% get_edges()
+#' graph |> get_edges()
 #'
 #' # Add edge aesthetic and data
 #' # attributes during edge creation
 #' graph_2 <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 2) %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 2) |>
 #'   add_edge(
 #'     from = 1,
 #'     to = 2,
@@ -100,7 +100,7 @@
 #' # to verify that the attribute
 #' # values were bound to the
 #' # newly created edge
-#' graph_2 %>% get_edge_df()
+#' graph_2 |> get_edge_df()
 #'
 #'
 #' @family edge creation and removal
@@ -146,7 +146,7 @@ add_edge <- function(
       edge_aes$index__ <- 1
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -165,7 +165,7 @@ add_edge <- function(
       edge_data$index__ <- 1
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -189,9 +189,9 @@ add_edge <- function(
 
     # Stop function if the label for
     # `from` is not distinct in the graph
-    if (graph$nodes_df %>%
-        dplyr::select("label") %>%
-        dplyr::filter(label == from) %>%
+    if (graph$nodes_df |>
+        dplyr::select("label") |>
+        dplyr::filter(label == from) |>
         nrow() > 1) {
 
       rlang::abort(
@@ -208,9 +208,9 @@ add_edge <- function(
 
     # Stop function if the label for
     # `to` is not distinct in the graph
-    if (graph$nodes_df %>%
-        dplyr::select("label") %>%
-        dplyr::filter(label == to) %>%
+    if (graph$nodes_df |>
+        dplyr::select("label") |>
+        dplyr::filter(label == to) |>
         nrow() > 1) {
 
       rlang::abort(
@@ -253,16 +253,16 @@ add_edge <- function(
       # those to the new edge
       graph <-
         suppressMessages(
-          graph %>%
+          graph |>
             select_edges_by_edge_id(
-              edges = graph$edges_df$id %>% max())
+              edges = graph$edges_df$id |> max())
         )
 
       # Iteratively set edge attribute values for
       # the new edge in the graph
       for (i in seq_len(ncol(edge_aes_tbl))) {
         graph <-
-          graph %>%
+          graph |>
           set_edge_attrs_ws(
             edge_attr = !!colnames(edge_aes_tbl)[i],
             value = edge_aes_tbl[1, i][[1]]
@@ -281,7 +281,7 @@ add_edge <- function(
       # those to the new edge
       graph <-
         suppressMessages(
-          graph %>%
+          graph |>
             select_edges_by_edge_id(
               edges = max(graph$edges_df$id))
         )
@@ -290,7 +290,7 @@ add_edge <- function(
       # the new edge in the graph
       for (i in seq_len(ncol(edge_data_tbl))) {
         graph <-
-          graph %>%
+          graph |>
           set_edge_attrs_ws(
             edge_attr = !!colnames(edge_data_tbl)[i],
             value = edge_data_tbl[1, i][[1]]
@@ -308,7 +308,7 @@ add_edge <- function(
 
     # Remove extra items from the `graph_log`
     graph$graph_log <-
-      graph$graph_log %>%
+      graph$graph_log |>
       dplyr::filter(version_id <= current_graph_log_version_id)
 
     # Get the name of the function

--- a/R/add_edge_clone.R
+++ b/R/add_edge_clone.R
@@ -19,19 +19,19 @@
 #' # in this path and then add a
 #' # `color` edge attribute
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 2,
-#'     rel = "a") %>%
-#'   select_last_edges_created() %>%
+#'     rel = "a") |>
+#'   select_last_edges_created() |>
 #'   set_edge_attrs(
 #'     edge_attr = color,
-#'     values = "steelblue") %>%
+#'     values = "steelblue") |>
 #'   clear_selection()
 #'
 #' # Display the graph's internal
 #' # edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Create a new node (will have
 #' # node ID of `3`) and then
@@ -40,8 +40,8 @@
 #' # attributes of edge `1` -> `2`
 #' # (edge ID `1`)
 #' graph_2 <-
-#'   graph %>%
-#'   add_node() %>%
+#'   graph |>
+#'   add_node() |>
 #'   add_edge_clone(
 #'     edge = 1,
 #'     from = 3,
@@ -49,22 +49,25 @@
 #'
 #' # Display the graph's internal
 #' # edge data frame
-#' graph_2 %>% get_edge_df()
+#' graph_2 |> get_edge_df()
 #'
 #' # The same change can be performed
 #' # with some helper functions in the
 #' # `add_edge_clone()` function call
 #' graph_3 <-
-#'   graph %>%
-#'     add_node() %>%
+#'   graph |>
+#'     add_node()
+#'
+#' graph_3 <-
+#'   graph_3 |>
 #'     add_edge_clone(
-#'       edge = get_last_edges_created(.),
-#'       from = get_last_nodes_created(.),
+#'       edge = get_last_edges_created(graph_3),
+#'       from = get_last_nodes_created(graph_3),
 #'       to = 1)
 #'
 #' # Display the graph's internal
 #' # edge data frame
-#' graph_3 %>% get_edge_df()
+#' graph_3 |> get_edge_df()
 #'
 #' @family edge creation and removal
 #' @export
@@ -103,21 +106,21 @@ add_edge_clone <- function(
   # Get the number of columns in the graph's
   # internal edge data frame
   n_col_edf <-
-    graph %>%
-    get_edge_df() %>%
+    graph |>
+    get_edge_df() |>
     ncol()
 
   # Extract all of the edge attributes
   # (`rel` and additional edge attrs)
   edge_attr_vals <-
-    graph %>%
-    get_edge_df() %>%
-    dplyr::filter(id == edge) %>%
+    graph |>
+    get_edge_df() |>
+    dplyr::filter(id == edge) |>
     dplyr::select(4:dplyr::all_of(n_col_edf))
 
   # Create the requested edge
   graph <-
-    graph %>%
+    graph |>
     add_edge(
       from = from,
       to = to)
@@ -144,7 +147,7 @@ add_edge_clone <- function(
 
   # Remove extra items from the `graph_log`
   graph$graph_log <-
-    graph$graph_log %>%
+    graph$graph_log |>
     dplyr::filter(version_id <= current_graph_log_version_id)
 
   # Get the name of the function

--- a/R/add_edge_df.R
+++ b/R/add_edge_df.R
@@ -14,7 +14,7 @@
 #' # Create a graph with 4 nodes
 #' # and no edges
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(n = 4)
 #'
 #' # Create an edge data frame (edf)
@@ -28,14 +28,14 @@
 #' # a graph with both nodes
 #' # and edges
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_edge_df(
 #'     edge_df = edf)
 #'
 #' # Get the graph's edges to
 #' # verify that the edf had
 #' # been added
-#' graph %>%
+#' graph |>
 #'   get_edges(
 #'     return_type = "vector")
 #'
@@ -61,7 +61,7 @@ add_edge_df <- function(
   edges_created <- graph$last_edge
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Combine the incoming edge data frame
   # with those in the graph
@@ -76,7 +76,7 @@ add_edge_df <- function(
   graph$edges_df <- combined_edges
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/add_edges_from_table.R
+++ b/R/add_edges_from_table.R
@@ -31,7 +31,7 @@
 #' # `currencies` dataset available
 #' # in the package
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_nodes_from_table(
 #'     table = currencies)
 #'
@@ -47,7 +47,7 @@
 #' # `iso_4217_code` column of the
 #' # graph's internal node data frame
 #' graph_1 <-
-#'   graph %>%
+#'   graph |>
 #'     add_edges_from_table(
 #'       table = usd_exchange_rates,
 #'       from_col = from_currency,
@@ -56,8 +56,8 @@
 #'
 #' # View part of the graph's
 #' # internal edge data frame
-#' graph_1 %>%
-#'   get_edge_df() %>%
+#' graph_1 |>
+#'   get_edge_df() |>
 #'   head()
 #'
 #' # If you would like to assign
@@ -67,7 +67,7 @@
 #' # set a static `rel` attribute for
 #' # all edges created, use `set_rel`
 #' graph_2 <-
-#'   graph %>%
+#'   graph |>
 #'     add_edges_from_table(
 #'       table = usd_exchange_rates,
 #'       from_col = from_currency,
@@ -77,8 +77,8 @@
 #'
 #' # View part of the graph's internal
 #' # edge data frame (edf)
-#' graph_2 %>%
-#'   get_edge_df() %>%
+#' graph_2 |>
+#'   get_edge_df() |>
 #'   head()
 #'
 #' @family edge creation and removal
@@ -106,26 +106,26 @@ add_edges_from_table <- function(
 
   # Get the requested `from_col`
   from_col <-
-    rlang::ensym(from_col) %>% rlang::as_string()
+    rlang::ensym(from_col) |> rlang::as_string()
 
   # Get the requested `to_col`
   to_col <-
-    rlang::ensym(to_col) %>% rlang::as_string()
+    rlang::ensym(to_col) |> rlang::as_string()
 
   # Get the requested `from_to_map`
   from_to_map <-
-    rlang::ensym(from_to_map) %>% rlang::as_string()
+    rlang::ensym(from_to_map) |> rlang::as_string()
 
   # Get the requested `rel_col`
   if (!rlang::quo_is_null(rlang::enquo(rel_col))) {
     rel_col <-
-      rlang::ensym(rel_col) %>% rlang::as_string()
+      rlang::ensym(rel_col) |> rlang::as_string()
   }
 
   # Get the requested `drop_cols`
   if (!rlang::quo_is_null(rlang::enquo(drop_cols))) {
     drop_cols <-
-      rlang::ensym(drop_cols) %>% rlang::as_string()
+      rlang::ensym(drop_cols) |> rlang::as_string()
   }
 
   # Determine whether the table is a file connection
@@ -177,35 +177,35 @@ add_edges_from_table <- function(
   # Exclude the `from` and `to` columns
   # from the `csv` table
   csv_data_excluding_from_to <-
-    csv %>%
+    csv |>
     dplyr::select(setdiff(colnames(csv), c(from_col, to_col)))
 
   # Get the `from` col
   col_from <-
-    dplyr::as_tibble(csv) %>%
-    dplyr::select(!!from_col) %>%
+    dplyr::as_tibble(csv) |>
+    dplyr::select(!!from_col) |>
     dplyr::left_join(
-      ndf %>% dplyr::select("id", !!from_to_map),
-      by = stats::setNames(from_to_map, from_col)) %>%
-    dplyr::select(from = "id") %>%
+      ndf |> dplyr::select("id", !!from_to_map),
+      by = stats::setNames(from_to_map, from_col)) |>
+    dplyr::select(from = "id") |>
     dplyr::mutate(from = as.integer(from))
 
   # Get the `to` col
   col_to <-
-    dplyr::as_tibble(csv) %>%
-    dplyr::select(!!to_col) %>%
+    dplyr::as_tibble(csv) |>
+    dplyr::select(!!to_col) |>
     dplyr::left_join(
-      ndf %>% dplyr::select("id", !!from_to_map),
-      by = stats::setNames(from_to_map, to_col)) %>%
-    dplyr::select(to = "id") %>%
+      ndf |> dplyr::select("id", !!from_to_map),
+      by = stats::setNames(from_to_map, to_col)) |>
+    dplyr::select(to = "id") |>
     dplyr::mutate(to = as.integer(to))
 
   # Combine the `from` and `to` columns together along
   # with a new `rel` column (filled with NAs) and additional
   # columns from the CSV
   edf <-
-    col_from %>%
-    dplyr::bind_cols(col_to) %>%
+    col_from |>
+    dplyr::bind_cols(col_to) |>
     dplyr::bind_cols(csv_data_excluding_from_to)
 
   # Add in a `rel` column (filled with NAs) if it's not
@@ -217,8 +217,8 @@ add_edges_from_table <- function(
   # Use the `select()` function to arrange the
   # column rows and then convert to a data frame
   edf <-
-    edf %>%
-    dplyr::relocate("from", "to", "rel") %>%
+    edf |>
+    dplyr::relocate("from", "to", "rel") |>
     as.data.frame(stringsAsFactors = FALSE)
 
   # Remove any rows where there is an NA in either
@@ -248,13 +248,13 @@ add_edges_from_table <- function(
       col_index_1 <- which(colnames(edf) == col_selection[["column_selection"]][1])
       col_index_2 <- which(colnames(edf) == col_selection[["column_selection"]][2])
 
-      col_indices <- col_index_1:col_index_2 %>% sort()
+      col_indices <- col_index_1:col_index_2 |> sort()
 
       columns_retained <- base::setdiff(colnames(edf), colnames(edf)[col_indices])
 
     } else if (col_selection[["selection_type"]] == "column_index_range") {
 
-      col_indices <- col_selection[["column_selection"]] %>% sort()
+      col_indices <- col_selection[["column_selection"]] |> sort()
 
       columns_retained <- base::setdiff(colnames(edf), colnames(edf)[col_indices])
 
@@ -271,7 +271,7 @@ add_edges_from_table <- function(
   }
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Add the edf to the graph object
   if (is.null(graph$edges_df)) {
@@ -281,7 +281,7 @@ add_edges_from_table <- function(
   }
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/add_edges_w_string.R
+++ b/R/add_edges_w_string.R
@@ -22,23 +22,23 @@
 #' @examples
 #' # Create a graph with 4 nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_node(label = "one") %>%
-#'   add_node(label = "two") %>%
-#'   add_node(label = "three") %>%
+#'   create_graph() |>
+#'   add_node(label = "one") |>
+#'   add_node(label = "two") |>
+#'   add_node(label = "three") |>
 #'   add_node(label = "four")
 #'
 #' # Add edges between nodes using
 #' # a character string with node
 #' # ID values
 #' graph_node_id <-
-#'   graph %>%
+#'   graph |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->3")
 #'
 #' # Show the graph's internal
 #' # edge data frame
-#' graph_node_id %>% get_edge_df()
+#' graph_node_id |> get_edge_df()
 #'
 #' # Add edges between nodes using
 #' # a character string with node
@@ -47,7 +47,7 @@
 #' # all nodes must have unique
 #' # `label` values to use this
 #' graph_node_label <-
-#'   graph %>%
+#'   graph |>
 #'   add_edges_w_string(
 #'     edges =
 #'       "one->two one->three
@@ -57,7 +57,7 @@
 #' # Show the graph's internal
 #' # edge data frame (it's the
 #' # same as before)
-#' graph_node_label %>% get_edge_df()
+#' graph_node_label |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -150,13 +150,13 @@ add_edges_w_string <- function(
   }
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Add the new edges to the graph
   graph <- add_edge_df(graph, new_edges)
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph
@@ -165,12 +165,12 @@ add_edges_w_string <- function(
   # Clear the graph's active selection
   graph <-
     suppressMessages(
-      graph %>%
+      graph |>
         clear_selection())
 
   # Remove extra items from the `graph_log`
   graph$graph_log <-
-    graph$graph_log %>%
+    graph$graph_log |>
     dplyr::filter(version_id <= current_graph_log_version_id)
 
   # Get the name of the function

--- a/R/add_forward_edges_ws.R
+++ b/R/add_forward_edges_ws.R
@@ -30,30 +30,30 @@
 #' # Create an empty graph, add 2 nodes
 #' # to it, and create the edge `1->2`
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "type_a",
-#'     label = c("a_1", "a_2")) %>%
+#'     label = c("a_1", "a_2")) |>
 #'   add_edge(
 #'     from = 1, to = 2, rel = "a")
 #'
 #' # Get the graph's edges
-#' graph %>% get_edge_ids()
+#' graph |> get_edge_ids()
 #'
 #' # Select the edge and create 2
 #' # additional edges with the same
 #' # definition (`1->2`) but with
 #' # different `rel` values (`b` and `c`)
 #' graph <-
-#'   graph %>%
-#'   select_edges() %>%
-#'   add_forward_edges_ws(rel = "b") %>%
-#'   add_forward_edges_ws(rel = "c") %>%
+#'   graph |>
+#'   select_edges() |>
+#'   add_forward_edges_ws(rel = "b") |>
+#'   add_forward_edges_ws(rel = "c") |>
 #'   clear_selection()
 #'
 #' # Get the graph's edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -81,7 +81,7 @@ add_forward_edges_ws <- function(
   # Get a vector of edges available in the
   # graph's selection
   edges_in_selection <-
-    graph$edge_selection %>%
+    graph$edge_selection |>
     dplyr::select("from", "to")
 
   # Get the number of edges in the graph
@@ -105,7 +105,7 @@ add_forward_edges_ws <- function(
   }
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/add_full_graph.R
+++ b/R/add_full_graph.R
@@ -36,27 +36,27 @@
 #' # will also have edges from
 #' # and to themselves
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_full_graph(
 #'     n = 3, keep_loops = TRUE
 #'   )
 #'
 #' # Get node information
 #' # from this graph
-#' graph %>% get_node_info()
+#' graph |> get_node_info()
 #'
 #' # Using `keep_loops = FALSE`
 #' # (the default) will remove
 #' # the loops
-#' create_graph() %>%
-#'   add_full_graph(n = 3) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 3) |>
 #'   get_node_info()
 #'
 #' # Values can be set for
 #' # the node `label`, node
 #' # `type`, and edge `rel`
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_full_graph(
 #'     n = 3,
 #'     type = "connected",
@@ -66,11 +66,11 @@
 #'
 #' # Show the graph's node
 #' # data frame (ndf)
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's edge
 #' # data frame (edf)
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Create a fully-connected and
 #' # directed graph with 3 nodes,
@@ -82,9 +82,9 @@
 #' set.seed(23)
 #'
 #' edge_wt_matrix <-
-#'   rnorm(100, 5, 2) %>%
-#'   sample(9, FALSE) %>%
-#'   round(2) %>%
+#'   rnorm(100, 5, 2) |>
+#'   sample(9, FALSE) |>
+#'   round(2) |>
 #'   matrix(
 #'     ncol = 3,
 #'     nrow = 3,
@@ -94,7 +94,7 @@
 #' # Create the fully-connected
 #' # graph (without loops however)
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_full_graph(
 #'     n = 3,
 #'     type = "weighted",
@@ -106,18 +106,18 @@
 #'
 #' # Show the graph's node
 #' # data frame (ndf)
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's edge
 #' # data frame (edf)
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # An undirected graph can
 #' # also use a matrix with
 #' # edge weights, but only
 #' # the lower triangle of
 #' # that matrix will be used
-#' create_graph(directed = FALSE) %>%
+#' create_graph(directed = FALSE) |>
 #'   add_full_graph(
 #'     n = 3,
 #'     type = "weighted",
@@ -125,7 +125,7 @@
 #'     rel = "related_to",
 #'     edge_wt_matrix = edge_wt_matrix,
 #'     keep_loops = FALSE
-#'   ) %>%
+#'   ) |>
 #'   get_edge_df()
 #'
 #' @export
@@ -167,10 +167,10 @@ add_full_graph <- function(
   graph_info <- graph$graph_info
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Create initial adjacency matrix
   adj_matrix <- matrix(1, nrow = n, ncol = n)
@@ -279,7 +279,7 @@ add_full_graph <- function(
       node_aes$index__ <- seq_len(nrow(new_graph$nodes_df))
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -298,7 +298,7 @@ add_full_graph <- function(
       node_data$index__ <- seq_len(nrow(new_graph$nodes_df))
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-index__)
     }
 
@@ -317,7 +317,7 @@ add_full_graph <- function(
       edge_aes$index__ <- seq_len(nrow(new_graph$edges_df))
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -336,7 +336,7 @@ add_full_graph <- function(
       edge_data$index__ <- seq_len(nrow(new_graph$edges_df))
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -349,7 +349,7 @@ add_full_graph <- function(
   if (exists("node_aes_tbl")) {
 
     new_graph$nodes_df <-
-      new_graph$nodes_df %>%
+      new_graph$nodes_df |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -357,7 +357,7 @@ add_full_graph <- function(
   if (exists("node_data_tbl")) {
 
     new_graph$nodes_df <-
-      new_graph$nodes_df %>%
+      new_graph$nodes_df |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -365,7 +365,7 @@ add_full_graph <- function(
   if (exists("edge_aes_tbl")) {
 
     new_graph$edges_df <-
-      new_graph$edges_df %>%
+      new_graph$edges_df |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -373,7 +373,7 @@ add_full_graph <- function(
   if (exists("edge_data_tbl")) {
 
     new_graph$edges_df <-
-      new_graph$edges_df %>%
+      new_graph$edges_df |>
       dplyr::bind_cols(edge_data_tbl)
   }
 
@@ -387,14 +387,14 @@ add_full_graph <- function(
     combined_graph$last_node <- nodes_created + n
 
     # Get the updated number of nodes in the graph
-    nodes_graph_2 <- combined_graph %>% count_nodes()
+    nodes_graph_2 <- combined_graph |> count_nodes()
 
     # Get the number of nodes added to
     # the graph
     nodes_added <- nodes_graph_2 - nodes_graph_1
 
     # Get the updated number of edges in the graph
-    edges_graph_2 <- combined_graph %>% count_edges()
+    edges_graph_2 <- combined_graph |> count_edges()
 
     # Get the number of edges added to
     # the graph
@@ -429,14 +429,14 @@ add_full_graph <- function(
   } else {
 
     # Get the updated number of nodes in the graph
-    nodes_graph_2 <- new_graph %>% count_nodes()
+    nodes_graph_2 <- new_graph |> count_nodes()
 
     # Get the number of nodes added to
     # the graph
     nodes_added <- nodes_graph_2 - nodes_graph_1
 
     # Get the updated number of edges in the graph
-    edges_graph_2 <- new_graph %>% count_edges()
+    edges_graph_2 <- new_graph |> count_edges()
 
     # Get the number of edges added to
     # the graph

--- a/R/add_global_graph_attrs.R
+++ b/R/add_global_graph_attrs.R
@@ -21,7 +21,7 @@
 #' # add a global graph attribute
 #' graph <-
 #'   create_graph(
-#'     attr_theme = NULL) %>%
+#'     attr_theme = NULL) |>
 #'   add_global_graph_attrs(
 #'     attr = "overlap",
 #'     value = "true",
@@ -29,13 +29,13 @@
 #'
 #' # Verify that the attribute
 #' # addition has been made
-#' graph %>%
+#' graph |>
 #'   get_global_graph_attr_info()
 #'
 #' # Add another attribute with
 #' # `add_global_graph_attrs()`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_global_graph_attrs(
 #'     attr = "penwidth",
 #'     value = 12,
@@ -43,18 +43,18 @@
 #'
 #' # Verify that the attribute
 #' # addition has been made
-#' graph %>%
+#' graph |>
 #'   get_global_graph_attr_info()
 #'
 #' # When adding an attribute where
 #' # `attr` and `attr_type` already
 #' # exists, the value provided will
 #' # serve as an update
-#' graph %>%
+#' graph |>
 #'   add_global_graph_attrs(
 #'     attr = "penwidth",
 #'     value = 15,
-#'     attr_type = "node") %>%
+#'     attr_type = "node") |>
 #'   get_global_graph_attr_info()
 #'
 #' @export
@@ -93,14 +93,14 @@ add_global_graph_attrs <- function(
   # Join the new attributes to those available
   # on the `attr` and `attr_type` columns
   global_attrs_joined <-
-    global_attrs_available %>%
+    global_attrs_available |>
     dplyr::full_join(
       global_attrs_to_add,
-      by = c("attr", "attr_type")) %>%
+      by = c("attr", "attr_type")) |>
     dplyr::mutate(
       attr, attr_type,
       value = dplyr::coalesce(value.y, value.x),
-      .keep = "none") %>%
+      .keep = "none") |>
     dplyr::select("attr", "value", "attr_type")
 
   # Replace the graph's global attributes with

--- a/R/add_gnm_graph.R
+++ b/R/add_gnm_graph.R
@@ -31,16 +31,16 @@
 #' # 120 edges
 #' gnm_graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 100,
 #'     m = 120)
 #'
 #' # Get a count of nodes
-#' gnm_graph %>% count_nodes()
+#' gnm_graph |> count_nodes()
 #'
 #' # Get a count of edges
-#' gnm_graph %>% count_edges()
+#' gnm_graph |> count_edges()
 #'
 #' @export
 add_gnm_graph <- function(
@@ -117,7 +117,7 @@ add_gnm_graph <- function(
   # create a unique label for all new nodes
   if (label) {
     sample_gnm_graph$nodes_df$label <-
-      sample_gnm_graph$nodes_df$id %>% as.character()
+      sample_gnm_graph$nodes_df$id |> as.character()
   }
 
   n_nodes <- nrow(sample_gnm_graph$nodes_df)
@@ -134,7 +134,7 @@ add_gnm_graph <- function(
       node_aes$index__ <- seq_len(nrow(sample_gnm_graph$nodes_df))
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -153,7 +153,7 @@ add_gnm_graph <- function(
       node_data$index__ <- seq_len(nrow(sample_gnm_graph$nodes_df))
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -172,7 +172,7 @@ add_gnm_graph <- function(
       edge_aes$index__ <- seq_len(nrow(sample_gnm_graph$edges_df))
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -191,7 +191,7 @@ add_gnm_graph <- function(
       edge_data$index__ <- seq_len(nrow(sample_gnm_graph$edges_df))
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -204,7 +204,7 @@ add_gnm_graph <- function(
   if (exists("node_aes_tbl")) {
 
     sample_gnm_graph$nodes_df <-
-      sample_gnm_graph$nodes_df %>%
+      sample_gnm_graph$nodes_df |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -212,7 +212,7 @@ add_gnm_graph <- function(
   if (exists("node_data_tbl")) {
 
     sample_gnm_graph$nodes_df <-
-      sample_gnm_graph$nodes_df %>%
+      sample_gnm_graph$nodes_df |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -220,7 +220,7 @@ add_gnm_graph <- function(
   if (exists("edge_aes_tbl")) {
 
     sample_gnm_graph$edges_df <-
-      sample_gnm_graph$edges_df %>%
+      sample_gnm_graph$edges_df |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -228,7 +228,7 @@ add_gnm_graph <- function(
   if (exists("edge_data_tbl")) {
 
     sample_gnm_graph$edges_df <-
-      sample_gnm_graph$edges_df %>%
+      sample_gnm_graph$edges_df |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_gnp_graph.R
+++ b/R/add_gnp_graph.R
@@ -28,16 +28,16 @@
 #' # a probability value of 0.05
 #' gnp_graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnp_graph(
 #'     n = 100,
 #'     p = 0.05)
 #'
 #' # Get a count of nodes
-#' gnp_graph %>% count_nodes()
+#' gnp_graph |> count_nodes()
 #'
 #' # Get a count of edges
-#' gnp_graph %>% count_edges()
+#' gnp_graph |> count_edges()
 #'
 #' @export
 add_gnp_graph <- function(
@@ -114,7 +114,7 @@ add_gnp_graph <- function(
   # create a unique label for all new nodes
   if (label) {
     sample_gnp_graph$nodes_df$label <-
-      sample_gnp_graph$nodes_df$id %>% as.character()
+      sample_gnp_graph$nodes_df$id |> as.character()
   }
 
   n_nodes <- nrow(sample_gnp_graph$nodes_df)
@@ -131,7 +131,7 @@ add_gnp_graph <- function(
       node_aes$index__ <- seq_len(nrow(sample_gnp_graph$nodes_df))
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -150,7 +150,7 @@ add_gnp_graph <- function(
       node_data$index__ <- seq_len(nrow(sample_gnp_graph$nodes_df))
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -169,7 +169,7 @@ add_gnp_graph <- function(
       edge_aes$index__ <- seq_len(nrow(sample_gnp_graph$edges_df))
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -188,7 +188,7 @@ add_gnp_graph <- function(
       edge_data$index__ <- seq_len(nrow(sample_gnp_graph$edges_df))
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -201,7 +201,7 @@ add_gnp_graph <- function(
   if (exists("node_aes_tbl")) {
 
     sample_gnp_graph$nodes_df <-
-      sample_gnp_graph$nodes_df %>%
+      sample_gnp_graph$nodes_df |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -209,7 +209,7 @@ add_gnp_graph <- function(
   if (exists("node_data_tbl")) {
 
     sample_gnp_graph$nodes_df <-
-      sample_gnp_graph$nodes_df %>%
+      sample_gnp_graph$nodes_df |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -217,7 +217,7 @@ add_gnp_graph <- function(
   if (exists("edge_aes_tbl")) {
 
     sample_gnp_graph$edges_df <-
-      sample_gnp_graph$edges_df %>%
+      sample_gnp_graph$edges_df |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -225,7 +225,7 @@ add_gnp_graph <- function(
   if (exists("edge_data_tbl")) {
 
     sample_gnp_graph$edges_df <-
-      sample_gnp_graph$edges_df %>%
+      sample_gnp_graph$edges_df |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_graph_action.R
+++ b/R/add_graph_action.R
@@ -17,7 +17,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 22,
@@ -33,7 +33,7 @@
 #' # called on the graph that modifies it
 #' # (e.g., `add_n_nodes()`)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_graph_action(
 #'     fcn = "set_node_attr_w_fcn",
 #'     node_attr_fcn = "get_betweenness",
@@ -43,7 +43,7 @@
 #' # To ensure that the action is
 #' # available in the graph, use the
 #' # `get_graph_actions()` function
-#' graph %>% get_graph_actions()
+#' graph |> get_graph_actions()
 #'
 #' @export
 add_graph_action <- function(

--- a/R/add_graph_to_graph_series.R
+++ b/R/add_graph_to_graph_series.R
@@ -14,31 +14,31 @@
 #' @examples
 #' # Create three graphs
 #' graph_1 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 4)
 #'
 #' graph_2 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' graph_3 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_star(n = 6)
 #'
 #' # Create an empty graph series
 #' # and add the graphs
 #' series <-
-#'   create_graph_series() %>%
+#'   create_graph_series() |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_1) %>%
+#'     graph = graph_1) |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_2) %>%
+#'     graph = graph_2) |>
 #'   add_graph_to_graph_series(
 #'     graph = graph_3)
 #'
 #' # Count the number of graphs
 #' # in the graph series
-#' series %>%
+#' series |>
 #'   count_graphs_in_graph_series()
 #'
 #' @export

--- a/R/add_grid_2d.R
+++ b/R/add_grid_2d.R
@@ -23,14 +23,14 @@
 #' # Create a new graph and add
 #' # a 3 x 3 grid
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_grid_2d(
 #'     x = 3, y = 3,
 #'     type = "grid")
 #'
 #' # Get node information
 #' # from this graph
-#' graph %>%
+#' graph |>
 #'   get_node_info()
 #'
 #' # Attributes can be specified
@@ -42,7 +42,7 @@
 #' # attribute will apply to the
 #' # edges
 #' graph_w_attrs <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_grid_2d(
 #'     x = 3, y = 2,
 #'     label = c("one", "two",
@@ -58,10 +58,10 @@
 #'         5.2, 6.1, 2.6)))
 #'
 #' # Get the graph's node data frame
-#' graph_w_attrs %>% get_node_df()
+#' graph_w_attrs |> get_node_df()
 #'
 #' # Get the graph's edge data frame
-#' graph_w_attrs %>% get_edge_df()
+#' graph_w_attrs |> get_edge_df()
 #'
 #' @export
 add_grid_2d <- function(
@@ -111,12 +111,12 @@ add_grid_2d <- function(
   grid <-
     igraph::make_lattice(
       dimvector = c(x, y, 1),
-      directed = graph_directed) %>%
+      directed = graph_directed) |>
     from_igraph()
 
-  n_nodes <- grid %>% count_nodes()
+  n_nodes <- grid |> count_nodes()
 
-  n_edges <- grid %>% count_edges()
+  n_edges <- grid |> count_edges()
 
   # Create a node data frame for the grid graph
   grid_nodes <-
@@ -128,11 +128,11 @@ add_grid_2d <- function(
   # Create an edge data frame for the grid graph
   grid_edges <-
     create_edge_df(
-      from = grid %>%
-        get_edge_df() %>%
+      from = grid |>
+        get_edge_df() |>
         dplyr::pull("from"),
-      to = grid %>%
-        get_edge_df() %>%
+      to = grid |>
+        get_edge_df() |>
         dplyr::pull("to"),
       rel = rel)
 
@@ -153,7 +153,7 @@ add_grid_2d <- function(
       node_aes$index__ <- seq_len(nrow(grid_graph$nodes_df))
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -172,7 +172,7 @@ add_grid_2d <- function(
       node_data$index__ <- seq_len(nrow(grid_graph$nodes_df))
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -191,7 +191,7 @@ add_grid_2d <- function(
       edge_aes$index__ <- seq_len(nrow(grid_graph$edges_df))
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -210,7 +210,7 @@ add_grid_2d <- function(
       edge_data$index__ <- seq_len(nrow(grid_graph$edges_df))
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -223,7 +223,7 @@ add_grid_2d <- function(
   if (exists("node_aes_tbl")) {
 
     grid_graph$nodes_df <-
-      grid_graph$nodes_df %>%
+      grid_graph$nodes_df |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -231,7 +231,7 @@ add_grid_2d <- function(
   if (exists("node_data_tbl")) {
 
     grid_graph$nodes_df <-
-      grid_graph$nodes_df %>%
+      grid_graph$nodes_df |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -239,7 +239,7 @@ add_grid_2d <- function(
   if (exists("edge_aes_tbl")) {
 
     grid_graph$edges_df <-
-      grid_graph$edges_df %>%
+      grid_graph$edges_df |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -247,7 +247,7 @@ add_grid_2d <- function(
   if (exists("edge_data_tbl")) {
 
     grid_graph$edges_df <-
-      grid_graph$edges_df %>%
+      grid_graph$edges_df |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_grid_3d.R
+++ b/R/add_grid_3d.R
@@ -19,14 +19,14 @@
 #' # Create a new graph and add
 #' # a 2 x 2 x 2 grid
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_grid_3d(
 #'     x = 2, y = 2, z = 2,
 #'     type = "grid")
 #'
 #' # Get node information
 #' # from this graph
-#' graph %>%
+#' graph |>
 #'   get_node_info()
 #'
 #' # Attributes can be specified
@@ -38,7 +38,7 @@
 #' # attribute will apply to the
 #' # edges
 #' graph_w_attrs <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_grid_3d(
 #'     x = 2, y = 2, z = 2,
 #'     label = c(
@@ -57,10 +57,10 @@
 #'         6.3, 9.3)))
 #'
 #' # Get the graph's node data frame
-#' graph_w_attrs %>% get_node_df()
+#' graph_w_attrs |> get_node_df()
 #'
 #' # Get the graph's edge data frame
-#' graph_w_attrs %>% get_edge_df()
+#' graph_w_attrs |> get_edge_df()
 #'
 #' @export
 add_grid_3d <- function(
@@ -112,12 +112,12 @@ add_grid_3d <- function(
   grid <-
     igraph::make_lattice(
       dimvector = c(x, y, z),
-      directed = graph_directed) %>%
+      directed = graph_directed) |>
     from_igraph()
 
-  n_nodes <- grid %>% count_nodes()
+  n_nodes <- grid |> count_nodes()
 
-  n_edges <- grid %>% count_edges()
+  n_edges <- grid |> count_edges()
 
   # Create a node data frame for the grid graph
   grid_nodes <-
@@ -150,7 +150,7 @@ add_grid_3d <- function(
       node_aes$index__ <- seq_len(nrow(grid_graph$nodes_df))
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -169,7 +169,7 @@ add_grid_3d <- function(
       node_data$index__ <- seq_len(nrow(grid_graph$nodes_df))
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -188,7 +188,7 @@ add_grid_3d <- function(
       edge_aes$index__ <- seq_len(nrow(grid_graph$edges_df))
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -207,7 +207,7 @@ add_grid_3d <- function(
       edge_data$index__ <- seq_len(nrow(grid_graph$edges_df))
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -220,7 +220,7 @@ add_grid_3d <- function(
   if (exists("node_aes_tbl")) {
 
     grid_graph$nodes_df <-
-      grid_graph$nodes_df %>%
+      grid_graph$nodes_df |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -228,7 +228,7 @@ add_grid_3d <- function(
   if (exists("node_data_tbl")) {
 
     grid_graph$nodes_df <-
-      grid_graph$nodes_df %>%
+      grid_graph$nodes_df |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -236,7 +236,7 @@ add_grid_3d <- function(
   if (exists("edge_aes_tbl")) {
 
     grid_graph$edges_df <-
-      grid_graph$edges_df %>%
+      grid_graph$edges_df |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -244,7 +244,7 @@ add_grid_3d <- function(
   if (exists("edge_data_tbl")) {
 
     grid_graph$edges_df <-
-      grid_graph$edges_df %>%
+      grid_graph$edges_df |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_growing_graph.R
+++ b/R/add_growing_graph.R
@@ -26,7 +26,7 @@
 #' # nodes, adding an edge after
 #' # each node addition
 #' growing_graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_growing_graph(
 #'     n = 100,
 #'     m = 1,
@@ -34,10 +34,10 @@
 #'     set_seed = 23)
 #'
 #' # Get a count of nodes
-#' growing_graph %>% count_nodes()
+#' growing_graph |> count_nodes()
 #'
 #' # Get a count of edges
-#' growing_graph %>% count_edges()
+#' growing_graph |> count_edges()
 #'
 #' @export
 add_growing_graph <- function(
@@ -114,7 +114,7 @@ add_growing_graph <- function(
   # create a unique label for all new nodes
   if (label) {
     sample_growing_graph$nodes_df$label <-
-      sample_growing_graph$nodes_df$id %>% as.character()
+      sample_growing_graph$nodes_df$id |> as.character()
   }
 
   n_nodes <- nrow(sample_growing_graph$nodes_df)
@@ -131,7 +131,7 @@ add_growing_graph <- function(
       node_aes$index__ <- seq_len(nrow(sample_growing_graph$nodes_df))
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -150,7 +150,7 @@ add_growing_graph <- function(
       node_data$index__ <- seq_len(nrow(sample_growing_graph$nodes_df))
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -169,7 +169,7 @@ add_growing_graph <- function(
       edge_aes$index__ <- seq_len(nrow(sample_growing_graph$edges_df))
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -188,7 +188,7 @@ add_growing_graph <- function(
       edge_data$index__ <- seq_len(nrow(sample_growing_graph$edges_df))
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -201,7 +201,7 @@ add_growing_graph <- function(
   if (exists("node_aes_tbl")) {
 
     sample_growing_graph$nodes_df <-
-      sample_growing_graph$nodes_df %>%
+      sample_growing_graph$nodes_df |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -209,7 +209,7 @@ add_growing_graph <- function(
   if (exists("node_data_tbl")) {
 
     sample_growing_graph$nodes_df <-
-      sample_growing_graph$nodes_df %>%
+      sample_growing_graph$nodes_df |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -217,7 +217,7 @@ add_growing_graph <- function(
   if (exists("edge_aes_tbl")) {
 
     sample_growing_graph$edges_df <-
-      sample_growing_graph$edges_df %>%
+      sample_growing_graph$edges_df |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -225,7 +225,7 @@ add_growing_graph <- function(
   if (exists("edge_data_tbl")) {
 
     sample_growing_graph$edges_df <-
-      sample_growing_graph$edges_df %>%
+      sample_growing_graph$edges_df |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_islands_graph.R
+++ b/R/add_islands_graph.R
@@ -24,7 +24,7 @@
 #' @examples
 #' # Create a graph of islands
 #' islands_graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_islands_graph(
 #'     n_islands = 4,
 #'     island_size = 10,
@@ -33,10 +33,10 @@
 #'     set_seed = 23)
 #'
 #' # Get a count of nodes
-#' islands_graph %>% count_nodes()
+#' islands_graph |> count_nodes()
 #'
 #' # Get a count of edges
-#' islands_graph %>% count_edges()
+#' islands_graph |> count_edges()
 #'
 #' @export
 add_islands_graph <- function(
@@ -107,7 +107,7 @@ add_islands_graph <- function(
   # create a unique label for all new nodes
   if (label) {
     sample_islands_graph$nodes_df$label <-
-      sample_islands_graph$nodes_df$id %>% as.character()
+      sample_islands_graph$nodes_df$id |> as.character()
   }
 
   n_nodes <- nrow(sample_islands_graph$nodes_df)
@@ -124,7 +124,7 @@ add_islands_graph <- function(
       node_aes$index__ <- seq_len(nrow(sample_islands_graph$nodes_df))
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -143,7 +143,7 @@ add_islands_graph <- function(
       node_data$index__ <- seq_len(nrow(sample_islands_graph$nodes_df))
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -162,7 +162,7 @@ add_islands_graph <- function(
       edge_aes$index__ <- seq_len(nrow(sample_islands_graph$edges_df))
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -181,7 +181,7 @@ add_islands_graph <- function(
       edge_data$index__ <- seq_len(nrow(sample_islands_graph$edges_df))
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -194,7 +194,7 @@ add_islands_graph <- function(
   if (exists("node_aes_tbl")) {
 
     sample_islands_graph$nodes_df <-
-      sample_islands_graph$nodes_df %>%
+      sample_islands_graph$nodes_df |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -202,7 +202,7 @@ add_islands_graph <- function(
   if (exists("node_data_tbl")) {
 
     sample_islands_graph$nodes_df <-
-      sample_islands_graph$nodes_df %>%
+      sample_islands_graph$nodes_df |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -210,7 +210,7 @@ add_islands_graph <- function(
   if (exists("edge_aes_tbl")) {
 
     sample_islands_graph$edges_df <-
-      sample_islands_graph$edges_df %>%
+      sample_islands_graph$edges_df |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -218,7 +218,7 @@ add_islands_graph <- function(
   if (exists("edge_data_tbl")) {
 
     sample_islands_graph$edges_df <-
-      sample_islands_graph$edges_df %>%
+      sample_islands_graph$edges_df |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_n_node_clones.R
+++ b/R/add_n_node_clones.R
@@ -21,7 +21,7 @@
 #' # nodes; supply `label`, `type`,
 #' # and `value` node attributes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 3,
 #'     label = c("d", "g", "r"),
@@ -29,14 +29,14 @@
 #'
 #' # Display the graph's internal
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create 3 clones of node `1`
 #' # but assign new node label
 #' # values (leaving `label` as
 #' # NULL yields NA values)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_n_node_clones(
 #'     n = 3,
 #'     node = 1,
@@ -45,7 +45,7 @@
 #' # Display the graph's internal
 #' # node data frame: nodes `4`,
 #' # `5`, and `6` are clones of `1`
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -96,8 +96,8 @@ add_n_node_clones <- function(
   # Get the number of columns in the graph's
   # internal node data frame
   n_col_ndf <-
-    graph %>%
-    get_node_df() %>%
+    graph |>
+    get_node_df() |>
     ncol()
 
   # Extract all of the node attributes
@@ -105,9 +105,9 @@ add_n_node_clones <- function(
   if (n_col_ndf >= 4) {
 
     node_attr_vals <-
-      graph %>%
-      get_node_df() %>%
-      dplyr::filter(id == node) %>%
+      graph |>
+      get_node_df() |>
+      dplyr::filter(id == node) |>
       dplyr::select("type", 4:dplyr::all_of(n_col_ndf))
   }
 
@@ -117,7 +117,7 @@ add_n_node_clones <- function(
     get_node_attrs(graph = graph, node_attr = type, nodes = node))
 
   graph <-
-    graph %>%
+    graph |>
     add_n_nodes(
       n = n,
       type = group_id,
@@ -127,14 +127,14 @@ add_n_node_clones <- function(
   # the new nodes
   new_node_ids <-
     suppressMessages(
-      graph %>%
-        select_last_nodes_created() %>%
+      graph |>
+        select_last_nodes_created() |>
         get_selection())
 
   # Create a node selection for the
   # new nodes in the graph
   graph <-
-    graph %>%
+    graph |>
     select_nodes_by_id(
       nodes = new_node_ids)
 
@@ -161,7 +161,7 @@ add_n_node_clones <- function(
 
   # Remove extra items from the `graph_log`
   graph$graph_log <-
-    graph$graph_log %>%
+    graph$graph_log |>
     dplyr::filter(version_id <= current_graph_log_version_id)
 
   # Get the name of the function

--- a/R/add_n_nodes.R
+++ b/R/add_n_nodes.R
@@ -21,11 +21,11 @@
 #' # will be assigned ID values
 #' # from `1` to `5`
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(n = 5)
 #'
 #' # Get the graph's node IDs
-#' graph %>% get_node_ids()
+#' graph |> get_node_ids()
 #'
 #' @family node creation and removal
 #'
@@ -59,7 +59,7 @@ add_n_nodes <- function(
       node_aes$index__ <- seq_len(n)
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -78,7 +78,7 @@ add_n_nodes <- function(
       node_data$index__ <- seq_len(n)
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -98,7 +98,7 @@ add_n_nodes <- function(
   if (exists("node_aes_tbl")) {
 
     new_nodes <-
-      new_nodes %>%
+      new_nodes |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -106,7 +106,7 @@ add_n_nodes <- function(
   if (exists("node_data_tbl")) {
 
     new_nodes <-
-      new_nodes %>%
+      new_nodes |>
       dplyr::bind_cols(node_data_tbl)
   }
 

--- a/R/add_n_nodes_ws.R
+++ b/R/add_n_nodes_ws.R
@@ -44,36 +44,36 @@
 #' # with edges from the original node to all of the
 #' # new nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 1) %>%
-#'   select_last_nodes_created() %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 1) |>
+#'   select_last_nodes_created() |>
 #'   add_n_nodes_ws(
 #'     n = 5,
 #'     direction = "from")
 #'
 #' # Get the graph's nodes
-#' graph %>% get_node_ids()
+#' graph |> get_node_ids()
 #'
 #' # Get the graph's edges
-#' graph %>% get_edges()
+#' graph |> get_edges()
 #'
 #' # Create an empty graph, add a node to it, select
 #' # that node, and then add 5 more nodes to the graph
 #' # with edges toward the original node from all of
 #' # the new nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 1) %>%
-#'   select_last_nodes_created() %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 1) |>
+#'   select_last_nodes_created() |>
 #'   add_n_nodes_ws(
 #'     n = 5,
 #'     direction = "to")
 #'
 #' # Get the graph's nodes
-#' graph %>% get_node_ids()
+#' graph |> get_node_ids()
 #'
 #' # Get the graph's edges
-#' graph %>% get_edges()
+#' graph |> get_edges()
 #'
 #' @family node creation and removal
 #'
@@ -122,10 +122,10 @@ add_n_nodes_ws <- function(
   rel   <-   rel %||% NA_character_
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Get a vector of nodes available in the
   # graph's selection
@@ -197,14 +197,14 @@ add_n_nodes_ws <- function(
   graph$directed <- is_graph_directed(graph)
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- graph %>% count_nodes()
+  nodes_graph_2 <- graph |> count_nodes()
 
   # Get the number of nodes added to
   # the graph
   nodes_added <- nodes_graph_2 - nodes_graph_1
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph
@@ -213,17 +213,17 @@ add_n_nodes_ws <- function(
   # Get the edge ID values for the
   # last edges created
   new_edge_id <-
-    graph %>%
-    get_edge_df() %>%
-    utils::tail(edges_added) %>%
+    graph |>
+    get_edge_df() |>
+    utils::tail(edges_added) |>
     dplyr::pull("id")
 
   # Get the node ID values for the
   # last nodes created
   new_node_id <-
-    graph %>%
-    get_node_df() %>%
-    utils::tail(nodes_added) %>%
+    graph |>
+    get_node_df() |>
+    utils::tail(nodes_added) |>
     dplyr::pull("id")
 
   # Collect node aesthetic attributes
@@ -236,7 +236,7 @@ add_n_nodes_ws <- function(
       node_aes$index__ <- seq_len(nodes_added)
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -255,7 +255,7 @@ add_n_nodes_ws <- function(
       node_data$index__ <- seq_len(nodes_added)
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -274,7 +274,7 @@ add_n_nodes_ws <- function(
       edge_aes$index__ <- seq_len(edges_added)
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -293,7 +293,7 @@ add_n_nodes_ws <- function(
       edge_data$index__ <- seq_len(edges_added)
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -306,7 +306,7 @@ add_n_nodes_ws <- function(
   if (exists("node_aes_tbl")) {
 
     node_aes_tbl <-
-      node_aes_tbl %>%
+      node_aes_tbl |>
       dplyr::mutate(id = new_node_id, .before = 0)
 
     columns_to_select <-
@@ -314,11 +314,11 @@ add_n_nodes_ws <- function(
 
     graph$nodes_df <-
       dplyr::bind_rows(
-        graph$nodes_df %>%
+        graph$nodes_df |>
           dplyr::filter(!(id %in% new_node_id)),
-        graph$nodes_df %>%
-          dplyr::filter(id %in% new_node_id) %>%
-          dplyr::select(dplyr::all_of(columns_to_select)) %>%
+        graph$nodes_df |>
+          dplyr::filter(id %in% new_node_id) |>
+          dplyr::select(dplyr::all_of(columns_to_select)) |>
           dplyr::left_join(node_aes_tbl, by = "id"))
   }
 
@@ -326,7 +326,7 @@ add_n_nodes_ws <- function(
   if (exists("node_data_tbl")) {
 
     node_data_tbl <-
-      node_data_tbl %>%
+      node_data_tbl |>
       dplyr::mutate(id = new_node_id, .before = 0)
 
     columns_to_select <-
@@ -334,11 +334,11 @@ add_n_nodes_ws <- function(
 
     graph$nodes_df <-
       dplyr::bind_rows(
-        graph$nodes_df %>%
+        graph$nodes_df |>
           dplyr::filter(!(id %in% new_node_id)),
-        graph$nodes_df %>%
-          dplyr::filter(id %in% new_node_id) %>%
-          dplyr::select(dplyr::all_of(columns_to_select)) %>%
+        graph$nodes_df |>
+          dplyr::filter(id %in% new_node_id) |>
+          dplyr::select(dplyr::all_of(columns_to_select)) |>
           dplyr::left_join(node_data_tbl, by = "id"))
   }
 
@@ -346,7 +346,7 @@ add_n_nodes_ws <- function(
   if (exists("edge_aes_tbl")) {
 
     edge_aes_tbl <-
-      edge_aes_tbl %>%
+      edge_aes_tbl |>
       dplyr::mutate(id = new_edge_id, .before = 0)
 
     columns_to_select <-
@@ -354,11 +354,11 @@ add_n_nodes_ws <- function(
 
     graph$edges_df <-
       dplyr::bind_rows(
-        graph$edges_df %>%
+        graph$edges_df |>
           dplyr::filter(!(id %in% new_edge_id)),
-        graph$edges_df %>%
-          dplyr::filter(id %in% new_edge_id) %>%
-          dplyr::select(dplyr::all_of(columns_to_select)) %>%
+        graph$edges_df |>
+          dplyr::filter(id %in% new_edge_id) |>
+          dplyr::select(dplyr::all_of(columns_to_select)) |>
           dplyr::left_join(edge_aes_tbl, by = "id"))
   }
 
@@ -366,7 +366,7 @@ add_n_nodes_ws <- function(
   if (exists("edge_data_tbl")) {
 
     edge_data_tbl <-
-      edge_data_tbl %>%
+      edge_data_tbl |>
       dplyr::mutate(id = new_edge_id, .before = 0)
 
     columns_to_select <-
@@ -374,11 +374,11 @@ add_n_nodes_ws <- function(
 
     graph$edges_df <-
       dplyr::bind_rows(
-        graph$edges_df %>%
+        graph$edges_df |>
           dplyr::filter(!(id %in% new_edge_id)),
-        graph$edges_df %>%
-          dplyr::filter(id %in% new_edge_id) %>%
-          dplyr::select(dplyr::all_of(columns_to_select)) %>%
+        graph$edges_df |>
+          dplyr::filter(id %in% new_edge_id) |>
+          dplyr::select(dplyr::all_of(columns_to_select)) |>
           dplyr::left_join(edge_data_tbl, by = "id"))
   }
 

--- a/R/add_node.R
+++ b/R/add_node.R
@@ -24,28 +24,28 @@
 #' # Create an empty graph and add 2 nodes by using
 #' # the `add_node()` function twice
 #' graph <-
-#'   create_graph() %>%
-#'   add_node() %>%
+#'   create_graph() |>
+#'   add_node() |>
 #'   add_node()
 #'
 #' # Get a count of all nodes
 #' # in the graph
-#' graph %>% count_nodes()
+#' graph |> count_nodes()
 #'
 #' # The nodes added were given
 #' # ID values `1` and `2`; obtain
 #' # the graph's node IDs
-#' graph %>% get_node_ids()
+#' graph |> get_node_ids()
 #'
 #' # Add a node with a `type`
 #' # value defined
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_node(type = "person")
 #'
 #' # View the graph's internal
 #' # node data frame (ndf)
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -92,7 +92,7 @@ add_node <- function(
       node_aes$index__ <- 1
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -111,7 +111,7 @@ add_node <- function(
       node_data$index__ <- 1
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -136,7 +136,7 @@ add_node <- function(
     if (exists("node_aes_tbl")) {
 
       new_node <-
-        new_node %>%
+        new_node |>
         dplyr::bind_cols(node_aes_tbl)
     }
 
@@ -144,7 +144,7 @@ add_node <- function(
     if (exists("node_data_tbl")) {
 
       new_node <-
-        new_node %>%
+        new_node |>
         dplyr::bind_cols(node_data_tbl)
     }
 
@@ -206,14 +206,14 @@ add_node <- function(
     # Add node aesthetics if available
     if (exists("node_aes_tbl")) {
       new_node <-
-        new_node %>%
+        new_node |>
         dplyr::bind_cols(node_aes_tbl)
     }
 
     # Add node data if available
     if (exists("node_data_tbl")) {
       new_node <-
-        new_node %>%
+        new_node |>
         dplyr::bind_cols(node_data_tbl)
     }
 
@@ -230,7 +230,7 @@ add_node <- function(
         edge_aes$index__ <- seq_along(from)
 
         edge_aes_tbl <-
-          dplyr::as_tibble(edge_aes) %>%
+          dplyr::as_tibble(edge_aes) |>
           dplyr::select(-"index__")
       }
 
@@ -247,7 +247,7 @@ add_node <- function(
         edge_data$index__ <- seq_along(from)
 
         edge_data_tbl <-
-          dplyr::as_tibble(edge_data) %>%
+          dplyr::as_tibble(edge_data) |>
           dplyr::select(-"index__")
       }
 
@@ -268,14 +268,14 @@ add_node <- function(
     # Add edge aesthetics if available
     if (exists("edge_aes_tbl")) {
       new_edges <-
-        new_edges %>%
+        new_edges |>
         dplyr::bind_cols(edge_aes_tbl)
     }
 
     # Add edge data if available
     if (exists("edge_data_tbl")) {
       new_edges <-
-        new_edges %>%
+        new_edges |>
         dplyr::bind_cols(edge_data_tbl)
     }
 
@@ -344,7 +344,7 @@ add_node <- function(
     if (exists("node_aes_tbl")) {
 
       new_node <-
-        new_node %>%
+        new_node |>
         dplyr::bind_cols(node_aes_tbl)
     }
 
@@ -352,7 +352,7 @@ add_node <- function(
     if (exists("node_data_tbl")) {
 
       new_node <-
-        new_node %>%
+        new_node |>
         dplyr::bind_cols(node_data_tbl)
     }
 
@@ -368,7 +368,7 @@ add_node <- function(
         edge_aes$index__ <- seq_along(from)
 
         edge_aes_tbl <-
-          dplyr::as_tibble(edge_aes) %>%
+          dplyr::as_tibble(edge_aes) |>
           dplyr::select(-"index__")
       }
 
@@ -386,7 +386,7 @@ add_node <- function(
         edge_data$index__ <- seq_along(from)
 
         edge_data_tbl <-
-          dplyr::as_tibble(edge_data) %>%
+          dplyr::as_tibble(edge_data) |>
           dplyr::select(-"index__")
       }
 
@@ -407,14 +407,14 @@ add_node <- function(
     if (exists("edge_aes_tbl")) {
 
       new_edges <-
-        new_edges %>%
+        new_edges |>
         dplyr::bind_cols(edge_aes_tbl)
     }
 
     # Add edge data if available
     if (exists("edge_data_tbl")) {
       new_edges <-
-        new_edges %>%
+        new_edges |>
         dplyr::bind_cols(edge_data_tbl)
     }
 
@@ -492,7 +492,7 @@ add_node <- function(
       # Add node aesthetics if available
       if (exists("node_aes_tbl")) {
         new_node <-
-          new_node %>%
+          new_node |>
           dplyr::bind_cols(node_aes_tbl)
       }
 
@@ -500,7 +500,7 @@ add_node <- function(
       if (exists("node_data_tbl")) {
 
         new_node <-
-          new_node %>%
+          new_node |>
           dplyr::bind_cols(node_data_tbl)
       }
 
@@ -529,7 +529,7 @@ add_node <- function(
           edge_aes$index__ <- seq_len(length(from) + length(to))
 
           edge_aes_tbl <-
-            dplyr::as_tibble(edge_aes) %>%
+            dplyr::as_tibble(edge_aes) |>
             dplyr::select(-"index__")
         }
 
@@ -548,7 +548,7 @@ add_node <- function(
           edge_data$index__ <- seq_len(length(from) + length(to))
 
           edge_data_tbl <-
-            dplyr::as_tibble(edge_data) %>%
+            dplyr::as_tibble(edge_data) |>
             dplyr::select(-"index__")
         }
 
@@ -561,7 +561,7 @@ add_node <- function(
       if (exists("edge_aes_tbl")) {
 
         new_edges <-
-          new_edges %>%
+          new_edges |>
           dplyr::bind_cols(edge_aes_tbl)
       }
 
@@ -569,7 +569,7 @@ add_node <- function(
       if (exists("edge_data_tbl")) {
 
         new_edges <-
-          new_edges %>%
+          new_edges |>
           dplyr::bind_cols(edge_data_tbl)
       }
 

--- a/R/add_node_clones_ws.R
+++ b/R/add_node_clones_ws.R
@@ -38,16 +38,16 @@
 #' # and `value` node attributes,
 #' # and select the created nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 3,
 #'     label = c("d", "g", "r"),
-#'     type = c("a", "b", "c")) %>%
+#'     type = c("a", "b", "c")) |>
 #'   select_last_nodes_created()
 #'
 #' # Display the graph's internal
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create clones of all nodes
 #' # in the selection but assign
@@ -55,7 +55,7 @@
 #' # (leaving `label` as NULL
 #' # yields NA values)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_node_clones_ws(
 #'     label = c("a", "b", "v"))
 #'
@@ -63,7 +63,7 @@
 #' # node data frame: nodes `4`,
 #' # `5`, and `6` are clones of
 #' # `1`, `2`, and `3`
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Select the last nodes
 #' # created (`4`, `5`, and `6`)
@@ -72,8 +72,8 @@
 #' # creating new edges between
 #' # the new and existing nodes
 #' graph <-
-#'   graph %>%
-#'   select_last_nodes_created() %>%
+#'   graph |>
+#'   select_last_nodes_created() |>
 #'   add_node_clones_ws(
 #'     add_edges = TRUE,
 #'     direction = "to",
@@ -83,7 +83,7 @@
 #' # edge data frame; there are
 #' # edges between the selected
 #' # nodes and their clones
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family node creation and removal
 #'
@@ -125,8 +125,8 @@ add_node_clones_ws <- function(
   # Get the number of columns in the graph's
   # internal node data frame
   n_col_ndf <-
-    graph %>%
-    get_node_df() %>%
+    graph |>
+    get_node_df() |>
     ncol()
 
   # Get the node ID values for
@@ -139,10 +139,10 @@ add_node_clones_ws <- function(
       clear_selection(graph))
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   node_id_value <- graph$last_node
 
@@ -151,15 +151,15 @@ add_node_clones_ws <- function(
     # Extract all of the node attributes
     # (`type` and additional node attrs)
     node_attr_vals <-
-      graph %>%
-      get_node_df() %>%
-      dplyr::filter(id %in% selected_nodes[i]) %>%
+      graph |>
+      get_node_df() |>
+      dplyr::filter(id %in% selected_nodes[i]) |>
       dplyr::select(-"id", -"label")
 
     # Create a clone of the selected
     # node in the graph
     graph <-
-      graph %>%
+      graph |>
       add_node(
         label = label[i])
 
@@ -171,7 +171,7 @@ add_node_clones_ws <- function(
     # Create a node selection for the
     # new nodes in the graph
     graph <-
-      graph %>%
+      graph |>
       select_nodes_by_id(
         nodes = new_node_id)
 
@@ -192,13 +192,13 @@ add_node_clones_ws <- function(
 
       if (direction == "from") {
         graph <-
-          graph %>%
+          graph |>
           add_edge(
             from = new_node_id,
             to = selected_nodes[i])
       } else {
         graph <-
-          graph %>%
+          graph |>
           add_edge(
             from = selected_nodes[i],
             to = new_node_id)
@@ -216,18 +216,18 @@ add_node_clones_ws <- function(
 
   # Remove extra items from the `graph_log`
   graph$graph_log <-
-    graph$graph_log %>%
+    graph$graph_log |>
     dplyr::filter(version_id <= current_graph_log_version_id)
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- graph %>% count_nodes()
+  nodes_graph_2 <- graph |> count_nodes()
 
   # Get the number of nodes added to
   # the graph
   nodes_added <- nodes_graph_2 - nodes_graph_1
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/add_node_df.R
+++ b/R/add_node_df.R
@@ -22,12 +22,12 @@
 #' # the graph object to create
 #' # a graph with nodes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_node_df(
 #'     node_df = ndf)
 #'
 #' # Inspect the graph's ndf
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create another ndf
 #' ndf_2 <-
@@ -38,14 +38,14 @@
 #' # to add more nodes with
 #' # attributes to the graph
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_node_df(
 #'     node_df = ndf_2)
 #'
 #' # View the graph's internal
 #' # node data frame using the
 #' # `get_node_df()` function
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -66,7 +66,7 @@ add_node_df <- function(
   nodes_created <- graph$last_node
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Combine the incoming node data frame with the
   # existing node definitions in the graph object
@@ -85,7 +85,7 @@ add_node_df <- function(
     nodes_created + nrow(node_df)
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- graph %>% count_nodes()
+  nodes_graph_2 <- graph |> count_nodes()
 
   # Get the number of nodes added to
   # the graph

--- a/R/add_nodes_from_df_cols.R
+++ b/R/add_nodes_from_df_cols.R
@@ -40,7 +40,7 @@
 #' # and `col_2` from the data frame
 #' # to the graph object
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_nodes_from_df_cols(
 #'     df = df,
 #'     columns = c("col_1", "col_2"))
@@ -49,13 +49,13 @@
 #' # frame; duplicate labels are
 #' # prevented with `keep_duplicates =
 #' # FALSE`)
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Add new nodes from columns 3 and 4;
 #' # We can specify the columns by their
 #' # numbers as well
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_nodes_from_df_cols(
 #'     df = df,
 #'     columns = 3:4)
@@ -64,7 +64,7 @@
 #' # frame; note that nodes didn't
 #' # get made with columns that
 #' # are not character class columns
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -105,12 +105,12 @@ add_nodes_from_df_cols <- function(
   }
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Isolate the relevant columns in the data frame;
   # Exclude any columns that are not character class
   df <-
-    dplyr::as_tibble(df) %>%
+    dplyr::as_tibble(df) |>
     dplyr::select(dplyr::all_of(columns) & dplyr::where(is.character))
 
   # Create an empty `nodes` vector
@@ -121,14 +121,14 @@ add_nodes_from_df_cols <- function(
   for (i in seq_len(ncol(df))) {
     nodes <-
       c(nodes,
-        df[, i] %>%
-          purrr::flatten_chr() %>%
-          trimws() %>%
-          stringr::str_split(" ") %>%
-          purrr::flatten_chr() %>%
-          tibble::enframe(name = NULL) %>%
-          tidyr::drop_na() %>%
-          dplyr::distinct() %>%
+        df[, i] |>
+          purrr::flatten_chr() |>
+          trimws() |>
+          stringr::str_split(" ") |>
+          purrr::flatten_chr() |>
+          tibble::enframe(name = NULL) |>
+          tidyr::drop_na() |>
+          dplyr::distinct() |>
           purrr::flatten_chr())
   }
 
@@ -175,7 +175,7 @@ add_nodes_from_df_cols <- function(
   }
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- graph %>% count_nodes()
+  nodes_graph_2 <- graph |> count_nodes()
 
   # Get the number of nodes added to
   # the graph

--- a/R/add_nodes_from_table.R
+++ b/R/add_nodes_from_table.R
@@ -31,16 +31,15 @@
 #' # node ID values will be created as
 #' # monotonically-increasing values
 #' graph_1 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_nodes_from_table(
 #'     table = currencies)
 #'
 #' # View part of the graph's internal
 #' # node data frame (ndf)
-#' graph_1 %>%
-#'   get_node_df() %>%
-#'   .[, 1:5] %>%
-#'   head()
+#' ndf_1 <- graph_1 |> get_node_df()
+#'
+#' ndf_1[, 1:5] |> head()
 #'
 #' # If you would like to assign
 #' # any of the table's columns as
@@ -50,17 +49,16 @@
 #' # a static `type` attribute for all
 #' # of the table records, use `set_type`
 #' graph_2 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_nodes_from_table(
 #'     table = currencies,
 #'     label_col = iso_4217_code,
 #'     set_type = currency)
 #'
 #' # View part of the graph's internal ndf
-#' graph_2 %>%
-#'   get_node_df() %>%
-#'   .[, 1:5] %>%
-#'   head()
+#' ndf_2 <- graph_2 |> get_node_df()
+#'
+#' ndf_2[, 1:5] |> head()
 #'
 #' # Suppose we would like to not
 #' # include certain columns from the
@@ -69,7 +67,7 @@
 #' # argument to choose which columns
 #' # to not include as attributes
 #' graph_3 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_nodes_from_table(
 #'     table = currencies,
 #'     label_col = iso_4217_code,
@@ -81,8 +79,8 @@
 #' # `exponent` and `currency_name`
 #' # columns are not attributes in the
 #' # graph's internal node data frame
-#' graph_3 %>%
-#'   get_node_df() %>%
+#' graph_3 |>
+#'   get_node_df() |>
 #'   colnames()
 #'
 #' @family node creation and removal
@@ -105,19 +103,19 @@ add_nodes_from_table <- function(
   # TODO use new technique to convert to string.
   # Get the requested `label_col`
   label_col <-
-    rlang::enquo(label_col) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(label_col) |> rlang::get_expr() |> as.character()
 
   # Get the requested `type_col`
   type_col <-
-    rlang::enquo(type_col) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(type_col) |> rlang::get_expr() |> as.character()
 
   # Get the requested `set_type`
   set_type <-
-    rlang::enquo(set_type) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(set_type) |> rlang::get_expr() |> as.character()
 
   # Get the requested `drop_cols`
   drop_cols <-
-    rlang::enquo(drop_cols) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(drop_cols) |> rlang::get_expr() |> as.character()
 
   if (length(label_col) == 0) {
     label_col <- NULL
@@ -211,13 +209,13 @@ add_nodes_from_table <- function(
       col_index_1 <- which(colnames(csv) == col_selection[["column_selection"]][1])
       col_index_2 <- which(colnames(csv) == col_selection[["column_selection"]][2])
 
-      col_indices <- col_index_1:col_index_2 %>% sort()
+      col_indices <- col_index_1:col_index_2 |> sort()
 
       columns_to_add <- base::setdiff(columns_to_add, colnames(csv)[col_indices])
 
     } else if (col_selection[["selection_type"]] == "column_index_range") {
 
-      col_indices <- col_selection[["column_selection"]] %>% sort()
+      col_indices <- col_selection[["column_selection"]] |> sort()
 
       columns_to_add <- base::setdiff(columns_to_add, colnames(csv)[col_indices])
 
@@ -240,7 +238,7 @@ add_nodes_from_table <- function(
       )
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Add node data frame `ndf` to the graph
   graph <- add_node_df(graph, ndf)
@@ -250,7 +248,7 @@ add_nodes_from_table <- function(
     graph$graph_log[-nrow(graph$graph_log), ]
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- graph %>% count_nodes()
+  nodes_graph_2 <- graph |> count_nodes()
 
   # Get the number of nodes added to
   # the graph
@@ -277,7 +275,7 @@ add_nodes_from_table <- function(
   # Perform graph actions, if any are available
   if (nrow(graph$graph_actions) > 0) {
     graph <-
-      graph %>%
+      graph |>
       trigger_graph_actions()
   }
 

--- a/R/add_pa_graph.R
+++ b/R/add_pa_graph.R
@@ -44,16 +44,16 @@
 #' # 2 edges at every time step
 #' pa_graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_pa_graph(
 #'     n = 100,
 #'     m = 1)
 #'
 #' # Get a count of nodes
-#' pa_graph %>% count_nodes()
+#' pa_graph |> count_nodes()
 #'
 #' # Get a count of edges
-#' pa_graph %>% count_edges()
+#' pa_graph |> count_edges()
 #'
 #' @export
 add_pa_graph <- function(
@@ -149,7 +149,7 @@ add_pa_graph <- function(
   # create a unique label for all new nodes
   if (label) {
     sample_pa_graph$nodes_df$label <-
-      sample_pa_graph$nodes_df$id %>% as.character()
+      sample_pa_graph$nodes_df$id |> as.character()
   }
 
   n_nodes <- nrow(sample_pa_graph$nodes_df)
@@ -166,7 +166,7 @@ add_pa_graph <- function(
       node_aes$index__ <- seq_len(nrow(sample_pa_graph$nodes_df))
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -185,7 +185,7 @@ add_pa_graph <- function(
       node_data$index__ <- seq_len(nrow(sample_pa_graph$nodes_df))
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -204,7 +204,7 @@ add_pa_graph <- function(
       edge_aes$index__ <- seq_len(nrow(sample_pa_graph$edges_df))
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -223,7 +223,7 @@ add_pa_graph <- function(
       edge_data$index__ <- seq_len(nrow(sample_pa_graph$edges_df))
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -236,7 +236,7 @@ add_pa_graph <- function(
   if (exists("node_aes_tbl")) {
 
     sample_pa_graph$nodes_df <-
-      sample_pa_graph$nodes_df %>%
+      sample_pa_graph$nodes_df |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -244,7 +244,7 @@ add_pa_graph <- function(
   if (exists("node_data_tbl")) {
 
     sample_pa_graph$nodes_df <-
-      sample_pa_graph$nodes_df %>%
+      sample_pa_graph$nodes_df |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -252,7 +252,7 @@ add_pa_graph <- function(
   if (exists("edge_aes_tbl")) {
 
     sample_pa_graph$edges_df <-
-      sample_pa_graph$edges_df %>%
+      sample_pa_graph$edges_df |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -260,7 +260,7 @@ add_pa_graph <- function(
   if (exists("edge_data_tbl")) {
 
     sample_pa_graph$edges_df <-
-      sample_pa_graph$edges_df %>%
+      sample_pa_graph$edges_df |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_path.R
+++ b/R/add_path.R
@@ -19,17 +19,17 @@
 #' # Create a new graph and add
 #' # 2 paths of varying lengths
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 4,
-#'     type = "path") %>%
+#'     type = "path") |>
 #'   add_path(
 #'     n = 5,
 #'     type = "path")
 #'
 #' # Get node information
 #' # from this graph
-#' graph %>% get_node_info()
+#' graph |> get_node_info()
 #'
 #' # Node and edge aesthetic and data
 #' # attributes can be specified in
@@ -41,7 +41,7 @@
 #' set.seed(23)
 #'
 #' graph_w_attrs <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 3,
 #'     label = c(
@@ -65,10 +65,10 @@
 #'           sd = 1.0)))
 #'
 #' # Get the graph's node data frame
-#' graph_w_attrs %>% get_node_df()
+#' graph_w_attrs |> get_node_df()
 #'
 #' # Get the graph's edge data frame
-#' graph_w_attrs %>% get_edge_df()
+#' graph_w_attrs |> get_edge_df()
 #'
 #' @export
 add_path <- function(graph,
@@ -124,7 +124,7 @@ add_path <- function(graph,
       node_aes$index__ <- seq_len(n)
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -143,7 +143,7 @@ add_path <- function(graph,
       edge_aes$index__ <- seq_len(n - 1)
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -162,7 +162,7 @@ add_path <- function(graph,
       node_data$index__ <- seq_len(n)
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -181,7 +181,7 @@ add_path <- function(graph,
       edge_data$index__ <- seq_len(n - 1)
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -201,7 +201,7 @@ add_path <- function(graph,
   if (exists("node_aes_tbl")) {
 
     path_nodes <-
-      path_nodes %>%
+      path_nodes |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -209,7 +209,7 @@ add_path <- function(graph,
   if (exists("node_data_tbl")) {
 
     path_nodes <-
-      path_nodes %>%
+      path_nodes |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -224,7 +224,7 @@ add_path <- function(graph,
   if (exists("edge_aes_tbl")) {
 
     path_edges <-
-      path_edges %>%
+      path_edges |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -232,7 +232,7 @@ add_path <- function(graph,
   if (exists("edge_data_tbl")) {
 
     path_edges <-
-      path_edges %>%
+      path_edges |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_prism.R
+++ b/R/add_prism.R
@@ -24,18 +24,18 @@
 #' # Create a new graph and
 #' # add 2 prisms
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_prism(
 #'     n = 3,
 #'     type = "prism",
-#'     label = "a") %>%
+#'     label = "a") |>
 #'   add_prism(
 #'     n = 3,
 #'     type = "prism",
 #'     label = "b")
 #'
 #' # Get node information from this graph
-#' graph %>% get_node_info()
+#' graph |> get_node_info()
 #'
 #' # Node and edge aesthetic and data
 #' # attributes can be specified in
@@ -47,7 +47,7 @@
 #' set.seed(23)
 #'
 #' graph_w_attrs <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_prism(
 #'     n = 3,
 #'     label = c(
@@ -76,10 +76,10 @@
 #'           sd = 1.0)))
 #'
 #' # Get the graph's node data frame
-#' graph_w_attrs %>% get_node_df()
+#' graph_w_attrs |> get_node_df()
 #'
 #' # Get the graph's edge data frame
-#' graph_w_attrs %>% get_edge_df()
+#' graph_w_attrs |> get_edge_df()
 #'
 #' @export
 add_prism <- function(
@@ -137,7 +137,7 @@ add_prism <- function(
       node_aes$index__ <- seq_len(2 * n)
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -156,7 +156,7 @@ add_prism <- function(
       edge_aes$index__ <- seq_len(3 * n)
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -175,7 +175,7 @@ add_prism <- function(
       node_data$index__ <- seq_len(2 * n)
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -194,7 +194,7 @@ add_prism <- function(
       edge_data$index__ <- seq_len(3 * n)
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -214,7 +214,7 @@ add_prism <- function(
   if (exists("node_aes_tbl")) {
 
     prism_nodes <-
-      prism_nodes %>%
+      prism_nodes |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -222,7 +222,7 @@ add_prism <- function(
   if (exists("node_data_tbl")) {
 
     prism_nodes <-
-      prism_nodes %>%
+      prism_nodes |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -247,7 +247,7 @@ add_prism <- function(
   if (exists("edge_aes_tbl")) {
 
     prism_edges <-
-      prism_edges %>%
+      prism_edges |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -255,7 +255,7 @@ add_prism <- function(
   if (exists("edge_data_tbl")) {
 
     prism_edges <-
-      prism_edges %>%
+      prism_edges |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_reverse_edges_ws.R
+++ b/R/add_reverse_edges_ws.R
@@ -32,32 +32,32 @@
 #' # Create an empty graph, add 2 nodes to it,
 #' # and create the edge `1->2`
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "type_a",
-#'     label = c("a_1", "a_2")) %>%
+#'     label = c("a_1", "a_2")) |>
 #'   add_edge(
 #'     from = 1,
 #'     to = 2,
 #'     rel = "a")
 #'
 #' # Get the graph's edges
-#' graph %>% get_edge_ids()
+#' graph |> get_edge_ids()
 #'
 #' # Select the edge and create 2 additional edges
 #' # with the opposite definition of `1->2`, which
 #' # is `2->1`; also, apply, different `rel` values
 #' # (`b` and `c`)
 #' graph <-
-#'   graph %>%
-#'   select_edges() %>%
-#'   add_reverse_edges_ws(rel = "b") %>%
-#'   add_reverse_edges_ws(rel = "c") %>%
+#'   graph |>
+#'   select_edges() |>
+#'   add_reverse_edges_ws(rel = "b") |>
+#'   add_reverse_edges_ws(rel = "c") |>
 #'   clear_selection()
 #'
 #' # Get the graph's edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -82,7 +82,7 @@ add_reverse_edges_ws <- function(
   check_graph_contains_edge_selection(graph)
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # If no value(s) provided for `rel`, set to NA
   rel <- rel %||% NA_character_
@@ -90,7 +90,7 @@ add_reverse_edges_ws <- function(
   # Get a vector of edges available in the
   # graph's selection
   edges_in_selection <-
-    graph$edge_selection %>%
+    graph$edge_selection |>
     dplyr::select("to", "from")
 
   # Add new edges to the graph for every edge
@@ -111,7 +111,7 @@ add_reverse_edges_ws <- function(
   }
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph
@@ -127,7 +127,7 @@ add_reverse_edges_ws <- function(
       edge_aes$index__ <- seq_len(edges_added)
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -146,7 +146,7 @@ add_reverse_edges_ws <- function(
       edge_data$index__ <- seq_len(edges_added)
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 

--- a/R/add_smallworld_graph.R
+++ b/R/add_smallworld_graph.R
@@ -34,7 +34,7 @@
 #' # a probability value of 0.05
 #' smallworld_graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_smallworld_graph(
 #'     dimension = 1,
 #'     size = 50,
@@ -43,10 +43,10 @@
 #'     set_seed = 23)
 #'
 #' # Get a count of nodes
-#' smallworld_graph %>% count_nodes()
+#' smallworld_graph |> count_nodes()
 #'
 #' # Get a count of edges
-#' smallworld_graph %>% count_edges()
+#' smallworld_graph |> count_edges()
 #'
 #' @export
 add_smallworld_graph <- function(
@@ -121,12 +121,12 @@ add_smallworld_graph <- function(
   # create a unique label for all new nodes
   if (label) {
     sample_smallworld_graph$nodes_df$label <-
-      sample_smallworld_graph$nodes_df$id %>% as.character()
+      sample_smallworld_graph$nodes_df$id |> as.character()
   }
 
-  n_nodes <- sample_smallworld_graph %>% count_nodes()
+  n_nodes <- sample_smallworld_graph |> count_nodes()
 
-  n_edges <- sample_smallworld_graph %>% count_edges()
+  n_edges <- sample_smallworld_graph |> count_edges()
 
   # Collect node aesthetic attributes
   if (!is.null(node_aes)) {
@@ -138,7 +138,7 @@ add_smallworld_graph <- function(
       node_aes$index__ <- seq_len(nrow(sample_smallworld_graph$nodes_df))
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -157,7 +157,7 @@ add_smallworld_graph <- function(
       node_data$index__ <- seq_len(nrow(sample_smallworld_graph$nodes_df))
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -176,7 +176,7 @@ add_smallworld_graph <- function(
       edge_aes$index__ <- seq_len(nrow(sample_smallworld_graph$edges_df))
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -195,7 +195,7 @@ add_smallworld_graph <- function(
       edge_data$index__ <- seq_len(nrow(sample_smallworld_graph$edges_df))
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -208,7 +208,7 @@ add_smallworld_graph <- function(
   if (exists("node_aes_tbl")) {
 
     sample_smallworld_graph$nodes_df <-
-      sample_smallworld_graph$nodes_df %>%
+      sample_smallworld_graph$nodes_df |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -216,7 +216,7 @@ add_smallworld_graph <- function(
   if (exists("node_data_tbl")) {
 
     sample_smallworld_graph$nodes_df <-
-      sample_smallworld_graph$nodes_df %>%
+      sample_smallworld_graph$nodes_df |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -224,7 +224,7 @@ add_smallworld_graph <- function(
   if (exists("edge_aes_tbl")) {
 
     sample_smallworld_graph$edges_df <-
-      sample_smallworld_graph$edges_df %>%
+      sample_smallworld_graph$edges_df |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -232,7 +232,7 @@ add_smallworld_graph <- function(
   if (exists("edge_data_tbl")) {
 
     sample_smallworld_graph$edges_df <-
-      sample_smallworld_graph$edges_df %>%
+      sample_smallworld_graph$edges_df |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/add_star.R
+++ b/R/add_star.R
@@ -22,16 +22,16 @@
 #' # Create a new graph and add 2
 #' # stars of varying numbers of nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_star(
 #'     n = 4,
-#'     type = "four_star") %>%
+#'     type = "four_star") |>
 #'   add_star(
 #'     n = 5,
 #'     type = "five_star")
 #'
 #' # Get node information from this graph
-#' graph %>% get_node_info()
+#' graph |> get_node_info()
 #'
 #' # Node and edge aesthetic and data
 #' # attributes can be specified in
@@ -43,7 +43,7 @@
 #' set.seed(23)
 #'
 #' graph_w_attrs <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_star(
 #'     n = 4,
 #'     label = c(
@@ -68,10 +68,10 @@
 #'           sd = 1.0)))
 #'
 #' # Get the graph's node data frame
-#' graph_w_attrs %>% get_node_df()
+#' graph_w_attrs |> get_node_df()
 #'
 #' # Get the graph's edge data frame
-#' graph_w_attrs %>% get_edge_df()
+#' graph_w_attrs |> get_edge_df()
 #'
 #' @export
 add_star <- function(
@@ -129,7 +129,7 @@ add_star <- function(
       node_aes$index__ <- seq_len(n)
 
       node_aes_tbl <-
-        dplyr::as_tibble(node_aes) %>%
+        dplyr::as_tibble(node_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -148,7 +148,7 @@ add_star <- function(
       node_data$index__ <- seq_len(n)
 
       node_data_tbl <-
-        dplyr::as_tibble(node_data) %>%
+        dplyr::as_tibble(node_data) |>
         dplyr::select(-"index__")
     }
 
@@ -167,7 +167,7 @@ add_star <- function(
       edge_aes$index__ <- seq_len(n - 1)
 
       edge_aes_tbl <-
-        dplyr::as_tibble(edge_aes) %>%
+        dplyr::as_tibble(edge_aes) |>
         dplyr::select(-"index__")
     }
 
@@ -186,7 +186,7 @@ add_star <- function(
       edge_data$index__ <- seq_len(n - 1)
 
       edge_data_tbl <-
-        dplyr::as_tibble(edge_data) %>%
+        dplyr::as_tibble(edge_data) |>
         dplyr::select(-"index__")
     }
 
@@ -206,7 +206,7 @@ add_star <- function(
   if (exists("node_aes_tbl")) {
 
     star_nodes <-
-      star_nodes %>%
+      star_nodes |>
       dplyr::bind_cols(node_aes_tbl)
   }
 
@@ -214,7 +214,7 @@ add_star <- function(
   if (exists("node_data_tbl")) {
 
     star_nodes <-
-      star_nodes %>%
+      star_nodes |>
       dplyr::bind_cols(node_data_tbl)
   }
 
@@ -229,7 +229,7 @@ add_star <- function(
   if (exists("edge_aes_tbl")) {
 
     star_edges <-
-      star_edges %>%
+      star_edges |>
       dplyr::bind_cols(edge_aes_tbl)
   }
 
@@ -237,7 +237,7 @@ add_star <- function(
   if (exists("edge_data_tbl")) {
 
     star_edges <-
-      star_edges %>%
+      star_edges |>
       dplyr::bind_cols(edge_data_tbl)
   }
 

--- a/R/attr_themes.R
+++ b/R/attr_themes.R
@@ -5,7 +5,7 @@
 #' @param tbl A tibble.
 #' @noRd
 asdf <- function(tbl) {
-  tbl %>% as.data.frame(stringsAsFactors = FALSE)
+  tbl |> as.data.frame(stringsAsFactors = FALSE)
 }
 
 #' The default attribute theme
@@ -32,7 +32,7 @@ attr_theme_default <- function() {
     "len",                  "1.5",                   "edge",
     "color",                "gray80",                "edge",
     "arrowsize",            "0.5",                   "edge"
-  ) %>%
+  ) |>
     asdf()
 }
 
@@ -46,7 +46,7 @@ attr_theme_lr <- function() {
       ~attr,                  ~value,                  ~attr_type,
       "layout",               "dot",                   "graph",
       "rankdir",              "LR",                    "graph"
-    ) %>%
+    ) |>
       asdf(),
     attr_theme_default()[-1, ])
 }
@@ -61,7 +61,7 @@ attr_theme_tb <- function() {
       ~attr,                  ~value,                  ~attr_type,
       "layout",               "dot",                   "graph",
       "rankdir",              "TB",                    "graph"
-    ) %>%
+    ) |>
       asdf(),
     attr_theme_default()[-1, ])
 }
@@ -76,7 +76,7 @@ attr_theme_rl <- function() {
       ~attr,                  ~value,                  ~attr_type,
       "layout",               "dot",                   "graph",
       "rankdir",              "RL",                    "graph"
-    ) %>%
+    ) |>
       asdf(),
     attr_theme_default()[-1, ])
 }
@@ -91,7 +91,7 @@ attr_theme_bt <- function() {
       ~attr,                  ~value,                  ~attr_type,
       "layout",               "dot",                   "graph",
       "rankdir",              "BT",                    "graph"
-    ) %>%
+    ) |>
       asdf(),
     attr_theme_default()[-1, ])
 }
@@ -120,7 +120,7 @@ attr_theme_fdp <- function() {
     "len",                  "1.5",                   "edge",
     "color",                "gray80",                "edge",
     "arrowsize",            "0.5",                   "edge"
-  ) %>%
+  ) |>
     asdf()
 }
 
@@ -134,7 +134,7 @@ attr_theme_kk <- function() {
       ~attr,                  ~value,                  ~attr_type,
       "layout",               "neato",                 "graph",
       "mode",                 "KK",                    "graph"
-    ) %>%
+    ) |>
       asdf(),
     attr_theme_default()[-1, ])
 }

--- a/R/base64.R
+++ b/R/base64.R
@@ -47,8 +47,8 @@ encode_base64 <- function(raw) {
 get_mime_type <- function(file) {
 
   extension <-
-    file %>%
-    get_file_ext() %>%
+    file |>
+    get_file_ext() |>
     tolower()
 
   switch(

--- a/R/clear_selection.R
+++ b/R/clear_selection.R
@@ -12,29 +12,29 @@
 #' # Create a graph with
 #' # a single path
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 5)
 #'
 #' # Select nodes with IDs `1`
 #' # and `3`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes(
 #'     nodes = c(1, 3))
 #'
 #' # Verify that a node selection
 #' # has been made
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Clear the selection with
 #' # `clear_selection()`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   clear_selection()
 #'
 #' # Verify that the node
 #' # selection has been cleared
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 clear_selection <- function(graph) {

--- a/R/colorize_edge_attrs.R
+++ b/R/colorize_edge_attrs.R
@@ -31,8 +31,8 @@
 #' # Create a graph with 5
 #' # nodes and 4 edges
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 5) %>%
+#'   create_graph() |>
+#'   add_path(n = 5) |>
 #'   set_edge_attrs(
 #'     edge_attr = weight,
 #'     values = c(3.7, 6.3, 9.2, 1.6))
@@ -45,7 +45,7 @@
 #' # part of any bucket, a gray color
 #' # is assigned by default)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   colorize_edge_attrs(
 #'     edge_attr_from = weight,
 #'     edge_attr_to = color,
@@ -56,7 +56,7 @@
 #' # edge attribute with distinct
 #' # colors (from the RColorBrewer
 #' # Red-Yellow-Green palette)
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @export
 colorize_edge_attrs <- function(
@@ -78,11 +78,11 @@ colorize_edge_attrs <- function(
 
   # Get the requested `edge_attr_from`
   edge_attr_from <-
-    rlang::enquo(edge_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `edge_attr_to`
   edge_attr_to <-
-    rlang::enquo(edge_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_to) |> rlang::get_expr() |> as.character()
 
   # Extract edf from graph
   edges_df <- graph$edges_df

--- a/R/colorize_node_attrs.R
+++ b/R/colorize_node_attrs.R
@@ -31,8 +31,8 @@
 #' # Create a graph with 8
 #' # nodes and 7 edges
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 8) %>%
+#'   create_graph() |>
+#'   add_path(n = 8) |>
 #'   set_node_attrs(
 #'     node_attr = weight,
 #'     values = c(
@@ -45,15 +45,15 @@
 #' # to the graph's internal node data frame (ndf)
 #' # with the `join_node_attrs()` function
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_cmty_walktrap(.))
+#'     df = get_cmty_walktrap(graph))
 #'
 #' # Inspect the number of distinct communities
-#' graph %>%
+#' graph |>
 #'   get_node_attrs(
-#'     node_attr = walktrap_group) %>%
-#'   unique() %>%
+#'     node_attr = walktrap_group) |>
+#'   unique() |>
 #'   sort()
 #'
 #' # Visually distinguish the nodes in the different
@@ -63,12 +63,12 @@
 #' # value of 90 and apply opaque colors to the node
 #' # border (with the `color` node attribute)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   colorize_node_attrs(
 #'     node_attr_from = walktrap_group,
 #'     node_attr_to = fillcolor,
 #'     palette = "Greens",
-#'     alpha = 90) %>%
+#'     alpha = 90) |>
 #'   colorize_node_attrs(
 #'     node_attr_from = walktrap_group,
 #'     node_attr_to = color,
@@ -76,12 +76,12 @@
 #'     alpha = 80)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create a graph with 8 nodes and 7 edges
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 8) %>%
+#'   create_graph() |>
+#'   add_path(n = 8) |>
 #'   set_node_attrs(
 #'     node_attr = weight,
 #'     values = c(
@@ -93,7 +93,7 @@
 #' # bucketed ranges (for values not part of any
 #' # bucket, a gray color is assigned by default)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   colorize_node_attrs(
 #'     node_attr_from = weight,
 #'     node_attr_to = fillcolor,
@@ -102,7 +102,7 @@
 #' # Now there will be a `fillcolor` node attribute
 #' # with distinct colors (the `#D9D9D9` color is
 #' # the default `gray85` color)
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #' @export
@@ -125,11 +125,11 @@ colorize_node_attrs <- function(
 
   # Get the requested `node_attr_from`
   node_attr_from <-
-    rlang::enquo(node_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `node_attr_to`
   node_attr_to <-
-    rlang::enquo(node_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_to) |> rlang::get_expr() |> as.character()
 
   # Extract ndf from graph
   nodes_df <- graph$nodes_df

--- a/R/combine_graphs.R
+++ b/R/combine_graphs.R
@@ -16,14 +16,14 @@
 #' # Create a graph with a cycle
 #' # containing 6 nodes
 #' graph_cycle <-
-#'  create_graph() %>%
+#'  create_graph() |>
 #'    add_cycle(n = 6)
 #'
 #' # Create a random graph with
 #' # 8 nodes and 15 edges using the
 #' # `add_gnm_graph()` function
 #' graph_random <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 8,
 #'     m = 15,
@@ -38,14 +38,14 @@
 #'
 #' # Get the number of nodes in
 #' # the combined graph
-#' combined_graph %>% count_nodes()
+#' combined_graph |> count_nodes()
 #'
 #' # The `combine_graphs()`
 #' # function will renumber
 #' # node ID values in graph `y`
 #' # during the union; this ensures
 #' # that node ID values are unique
-#' combined_graph %>% get_node_ids()
+#' combined_graph |> get_node_ids()
 #'
 #' @export
 combine_graphs <- function(
@@ -71,14 +71,14 @@ combine_graphs <- function(
   nodes_created <- x$last_node
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- x %>% count_nodes()
+  nodes_graph_1 <- x |> count_nodes()
 
   # Get the number of edges ever created for
   # graph `x`
   edges_created <- x$last_edge
 
   # Get the number of edges in the graph
-  edges_graph_1 <- x %>% count_edges()
+  edges_graph_1 <- x |> count_edges()
 
   # Get the node data frame for graph `x`
   x_nodes_df <- get_node_df(x)
@@ -106,15 +106,15 @@ combine_graphs <- function(
     dplyr::inner_join(
       y_edges_df,
       y_nodes_df,
-      by = c("from" = "id")) %>%
-    dplyr::rename(from_new = "new_node_id") %>%
+      by = c("from" = "id")) |>
+    dplyr::rename(from_new = "new_node_id") |>
     dplyr::select(-"type", -"label")
 
   # Rename `id` if it has a `.x` suffix
   if ("id.x" %in% colnames(y_edges_df)) {
 
     y_edges_df <-
-      y_edges_df %>%
+      y_edges_df |>
       dplyr::rename(id = "id.x")
   }
 
@@ -122,15 +122,15 @@ combine_graphs <- function(
     dplyr::inner_join(
       y_edges_df,
       y_nodes_df,
-      by = c("to" = "id")) %>%
-    dplyr::rename(to_new = "new_node_id") %>%
+      by = c("to" = "id")) |>
+    dplyr::rename(to_new = "new_node_id") |>
     dplyr::select(-"type", -"label")
 
   # Rename `id` if it has a `.x` suffix
   if ("id.x" %in% colnames(y_edges_df)) {
 
     y_edges_df <-
-      y_edges_df %>%
+      y_edges_df |>
       dplyr::rename(id = "id.x")
   }
 
@@ -140,7 +140,7 @@ combine_graphs <- function(
 
   # Remove columns ending with `.x` or `_new`
   y_edges_df <-
-    y_edges_df %>%
+    y_edges_df |>
     dplyr::select(
       !dplyr::ends_with(c(".x", "_new")))
 
@@ -180,14 +180,14 @@ combine_graphs <- function(
   x$last_edge <- nrow(combined_edges)
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- x %>% count_nodes()
+  nodes_graph_2 <- x |> count_nodes()
 
   # Get the number of nodes added to
   # the graph
   nodes_added <- nodes_graph_2 - nodes_graph_1
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- x %>% count_edges()
+  edges_graph_2 <- x |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/copy_edge_attrs.R
+++ b/R/copy_edge_attrs.R
@@ -18,11 +18,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 8,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_edge_attrs(
 #'     edge_attr = color,
 #'     values = "green")
@@ -30,13 +30,13 @@
 #' # Get the graph's internal
 #' # edf to show which edge
 #' # attributes are available
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Make a copy the `color`
 #' # edge attribute as the
 #' # `color_2` edge attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   copy_edge_attrs(
 #'     edge_attr_from = color,
 #'     edge_attr_to = color_2)
@@ -44,7 +44,7 @@
 #' # Get the graph's internal
 #' # edf to show that the edge
 #' # attribute had been copied
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #' @export
@@ -62,11 +62,11 @@ copy_edge_attrs <- function(
 
   # Get the requested `edge_attr_from`
   edge_attr_from <-
-    rlang::enquo(edge_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `edge_attr_to`
   edge_attr_to <-
-    rlang::enquo(edge_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_to) |> rlang::get_expr() |> as.character()
 
   # Stop function if `edge_attr_from` and
   # `edge_attr_to` are identical

--- a/R/copy_node_attrs.R
+++ b/R/copy_node_attrs.R
@@ -18,31 +18,34 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 10,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = shape,
-#'     values = "circle") %>%
+#'     values = "circle")
+#'
+#' graph <-
+#'   graph |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 5,
 #'       mean = 5,
-#'       sd = 1) %>% round(1))
+#'       sd = 1) |> round(1))
 #'
 #' # Get the graph's internal
 #' # ndf to show which node
 #' # attributes are available
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Make a copy the `value`
 #' # node attribute as the
 #' # `width` node attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   copy_node_attrs(
 #'     node_attr_from = value,
 #'     node_attr_to = size)
@@ -50,7 +53,7 @@
 #' # Get the graph's internal
 #' # ndf to show that the node
 #' # attribute had been copied
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -69,11 +72,11 @@ copy_node_attrs <- function(
 
   # Get the requested `node_attr_from`
   node_attr_from <-
-    rlang::enquo(node_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `node_attr_to`
   node_attr_to <-
-    rlang::enquo(node_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_to) |> rlang::get_expr() |> as.character()
 
   # Stop function if `node_attr_from` and
   # `node_attr_to` are identical

--- a/R/count_asymmetric_node_pairs.R
+++ b/R/count_asymmetric_node_pairs.R
@@ -13,19 +13,19 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Get a count of asymmetrically-
 #' # connected node pairs
-#' graph %>%
+#' graph |>
 #'   count_asymmetric_node_pairs()
 #'
 #' # Create a full graph and then
 #' # count the asymmetrically-
 #' # connected node pairs
-#' create_graph() %>%
-#'   add_full_graph(n = 10) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 10) |>
 #'   count_asymmetric_node_pairs()
 #'
 #' @export

--- a/R/count_automorphisms.R
+++ b/R/count_automorphisms.R
@@ -14,17 +14,17 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Get a count of automorphisms
-#' graph %>%
+#' graph |>
 #'   count_automorphisms()
 #'
 #' # Create a full graph and then
 #' # count the automorphisms
-#' create_graph() %>%
-#'   add_full_graph(n = 10) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 10) |>
 #'   count_automorphisms()
 #'
 #' @export

--- a/R/count_edges.R
+++ b/R/count_edges.R
@@ -13,13 +13,13 @@
 #' # path of nodes and 3
 #' # unconnected nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 3) %>%
+#'   create_graph() |>
+#'   add_path(n = 3) |>
 #'   add_n_nodes(n = 3)
 #'
 #' # Get a count of all edges
 #' # in the graph
-#' graph %>%
+#' graph |>
 #'   count_edges()
 #'
 #' @export

--- a/R/count_graphs_in_graph_series.R
+++ b/R/count_graphs_in_graph_series.R
@@ -12,31 +12,31 @@
 #' @examples
 #' # Create three graphs
 #' graph_1 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 4)
 #'
 #' graph_2 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' graph_3 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_star(n = 6)
 #'
 #' # Create an empty graph series
 #' # and add the graphs
 #' series <-
-#'   create_graph_series() %>%
+#'   create_graph_series() |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_1) %>%
+#'     graph = graph_1) |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_2) %>%
+#'     graph = graph_2) |>
 #'   add_graph_to_graph_series(
 #'     graph = graph_3)
 #'
 #' # Count the number of graphs
 #' # in the graph series
-#' series %>%
+#' series |>
 #'   count_graphs_in_graph_series()
 #'
 #' @export

--- a/R/count_loop_edges.R
+++ b/R/count_loop_edges.R
@@ -15,14 +15,14 @@
 #' # edges, including loop edges
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_full_graph(
 #'     n = 3,
 #'     keep_loops = TRUE)
 #'
 #' # Get a count of all loop edges
 #' # in the graph
-#' graph %>% count_loop_edges()
+#' graph |> count_loop_edges()
 #'
 #' @export
 count_loop_edges <- function(graph) {

--- a/R/count_mutual_node_pairs.R
+++ b/R/count_mutual_node_pairs.R
@@ -13,18 +13,18 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Get a count of mutually-connected
 #' # node pairs
-#' graph %>% count_mutual_node_pairs()
+#' graph |> count_mutual_node_pairs()
 #'
 #' # Create a full graph and then
 #' # count the mutually-connected
 #' # node pairs
-#' create_graph() %>%
-#'   add_full_graph(n = 10) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 10) |>
 #'   count_mutual_node_pairs()
 #'
 #' @export

--- a/R/count_nodes.R
+++ b/R/count_nodes.R
@@ -13,13 +13,13 @@
 #' # path of nodes and 3
 #' # unconnected nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 3) %>%
+#'   create_graph() |>
+#'   add_path(n = 3) |>
 #'   add_n_nodes(n = 3)
 #'
 #' # Get a count of all nodes
 #' # in the graph
-#' graph %>%
+#' graph |>
 #'   count_nodes()
 #'
 #' @export

--- a/R/count_s_connected_cmpts.R
+++ b/R/count_s_connected_cmpts.R
@@ -13,7 +13,7 @@
 #' # Create a graph and add
 #' # several graph islands
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_islands_graph(
 #'     n_islands = 4,
 #'     island_size = 10,
@@ -23,7 +23,7 @@
 #'
 #' # Get a count of strongly-connected
 #' # components in the graph
-#' graph %>% count_s_connected_cmpts()
+#' graph |> count_s_connected_cmpts()
 #'
 #' @export
 count_s_connected_cmpts <- function(graph) {

--- a/R/count_unconnected_node_pairs.R
+++ b/R/count_unconnected_node_pairs.R
@@ -12,18 +12,18 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Get a count of unconnected node
 #' # pairs in the graph
-#' graph %>%
+#' graph |>
 #'   count_unconnected_node_pairs()
 #'
 #' # Create a full graph and then
 #' # count all unconnected node pairs
-#' create_graph() %>%
-#'   add_full_graph(n = 10) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 10) |>
 #'   count_unconnected_node_pairs()
 #'
 #' @export

--- a/R/count_unconnected_nodes.R
+++ b/R/count_unconnected_nodes.R
@@ -12,18 +12,18 @@
 #' # path of nodes and 3
 #' # unconnected nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 3) %>%
+#'   create_graph() |>
+#'   add_path(n = 3) |>
 #'   add_n_nodes(n = 3)
 #'
 #' # Get a count of all nodes
 #' # in the graph
-#' graph %>% count_nodes()
+#' graph |> count_nodes()
 #'
 #' # Get a count of all
 #' # unconnected nodes in the
 #' # graph
-#' graph %>%
+#' graph |>
 #'   count_unconnected_nodes()
 #'
 #' @export
@@ -41,22 +41,22 @@ count_unconnected_nodes <- function(graph) {
   # of edges
   nodes_in_edf <-
     dplyr::bind_rows(
-      graph$edges_df %>% dplyr::select(node_id = "from"),
-      graph$edges_df %>% dplyr::select(node_id = "to")
-      ) %>%
+      graph$edges_df |> dplyr::select(node_id = "from"),
+      graph$edges_df |> dplyr::select(node_id = "to")
+      ) |>
     dplyr::distinct()
 
   # Get tbl with all nodes that are
   # in the node data frame
   nodes_in_ndf <-
-    graph$nodes_df %>%
+    graph$nodes_df |>
     dplyr::select(node_id = "id")
 
   # Get nodes not in edge definitions
   nodes_not_in_edf <-
     dplyr::setdiff(
       nodes_in_ndf,
-      nodes_in_edf) %>%
+      nodes_in_edf) |>
     dplyr::pull("node_id")
 
   if (length(nodes_in_edf > 0)) {

--- a/R/count_w_connected_cmpts.R
+++ b/R/count_w_connected_cmpts.R
@@ -12,13 +12,13 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
-#'   add_cycle(n = 5) %>%
+#'   create_graph() |>
+#'   add_cycle(n = 5) |>
 #'   add_cycle(n = 5)
 #'
 #' # Get a count of weakly-connected
 #' # components in the graph
-#' graph %>% count_w_connected_cmpts()
+#' graph |> count_w_connected_cmpts()
 #'
 #' @export
 count_w_connected_cmpts <- function(graph) {

--- a/R/create_graph.R
+++ b/R/create_graph.R
@@ -53,7 +53,7 @@
 #'     nodes_df = ndf)
 #'
 #' # Get information on the graph's nodes
-#' graph %>%
+#' graph |>
 #'   get_node_info()
 #'
 #' # You can create a similar graph with
@@ -76,7 +76,7 @@
 #'
 #' # Get information on the graph's
 #' # internal node data frame (ndf)
-#' graph %>%
+#' graph |>
 #'   get_node_df()
 #'
 #' # A graph can also be created by
@@ -101,11 +101,11 @@
 #'
 #' # Get information on the graph's
 #' # internal edge data frame (edf)
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Get information on the graph's
 #' # internal node data frame (ndf)
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 create_graph <- function(
@@ -129,7 +129,7 @@ create_graph <- function(
   # Generate a random 8-character, alphanumeric
   # string to use as a graph ID
   graph_id <-
-    replicate(8, sample(c(LETTERS, letters, 0:9), 1)) %>%
+    replicate(8, sample(c(LETTERS, letters, 0:9), 1)) |>
     paste(collapse = "")
 
   # Create the `graph_info` data frame

--- a/R/create_graph_series.R
+++ b/R/create_graph_series.R
@@ -15,31 +15,31 @@
 #' @examples
 #' # Create three graphs
 #' graph_1 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 4)
 #'
 #' graph_2 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' graph_3 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_star(n = 6)
 #'
 #' # Create an empty graph series
 #' # and add the graphs
 #' series <-
-#'   create_graph_series() %>%
+#'   create_graph_series() |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_1) %>%
+#'     graph = graph_1) |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_2) %>%
+#'     graph = graph_2) |>
 #'   add_graph_to_graph_series(
 #'     graph = graph_3)
 #'
 #' # Count the number of graphs
 #' # in the graph series
-#' series %>%
+#' series |>
 #'   count_graphs_in_graph_series()
 #'
 #' @export

--- a/R/delete_cache.R
+++ b/R/delete_cache.R
@@ -18,25 +18,25 @@
 #' # Cache 3 different vectors inside
 #' # the graph object
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_cache(
 #'     name = "a",
-#'     to_cache = 1:4) %>%
+#'     to_cache = 1:4) |>
 #'   set_cache(
 #'     name = "b",
-#'     to_cache = 5:9) %>%
+#'     to_cache = 5:9) |>
 #'   set_cache(
 #'     name = "c",
 #'     to_cache = 10:14)
 #'
 #' # Delete cache `b`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   delete_cache(name = "b")
 #'
 #' # Delete remaining cached vectors
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   delete_cache()
 #'
 #' @export

--- a/R/delete_edge.R
+++ b/R/delete_edge.R
@@ -27,31 +27,31 @@
 #' @examples
 #' # Create a graph with 2 nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(n = 2)
 #'
 #' # Add an edge
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_edge(
 #'     from = 1,
 #'     to = 2)
 #'
 #' # Delete the edge
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   delete_edge(
 #'     from = 1,
 #'     to = 2)
 #'
 #' # Get the count of edges in the graph
-#' graph %>% count_edges()
+#' graph |> count_edges()
 #'
 #' # Create an undirected graph with
 #' # 2 nodes and an edge
 #' graph_undirected <-
-#'   create_graph(directed = FALSE) %>%
-#'   add_n_nodes(n = 2) %>%
+#'   create_graph(directed = FALSE) |>
+#'   add_n_nodes(n = 2) |>
 #'   add_edge(
 #'     from = 1,
 #'     to = 2)
@@ -59,26 +59,26 @@
 #' # Delete the edge; the order of node ID
 #' # values provided in `from` and `to`
 #' # don't matter for the undirected case
-#' graph_undirected %>%
+#' graph_undirected |>
 #'   delete_edge(
 #'     from = 2,
-#'     to = 1) %>%
+#'     to = 1) |>
 #'   count_edges()
 #'
 #' # The undirected graph has a single
 #' # edge with ID `1`; it can be
 #' # deleted by specifying `id`
-#' graph_undirected %>%
-#'   delete_edge(id = 1) %>%
+#' graph_undirected |>
+#'   delete_edge(id = 1) |>
 #'   count_edges()
 #'
 #' # Create a directed graph with 2
 #' # labeled nodes and an edge
 #' graph_labeled_nodes <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
-#'     label = c("one", "two")) %>%
+#'     label = c("one", "two")) |>
 #'   add_edge(
 #'     from = "one",
 #'     to = "two")
@@ -87,10 +87,10 @@
 #' # labels in `from` and `to`; this
 #' # is analogous to creating the
 #' # edge using node labels
-#' graph_labeled_nodes %>%
+#' graph_labeled_nodes |>
 #'   delete_edge(
 #'     from = "one",
-#'     to = "two") %>%
+#'     to = "two") |>
 #'   count_edges()
 #'
 #' @family edge creation and removal
@@ -160,9 +160,9 @@ delete_edge <- function(
       }
 
       # Stop function if the label for `from` is not distinct in the graph
-      if (graph$nodes_df %>%
-          dplyr::select("label") %>%
-          dplyr::filter(label == from) %>%
+      if (graph$nodes_df |>
+          dplyr::select("label") |>
+          dplyr::filter(label == from) |>
           nrow() > 1) {
 
         cli::cli_abort(
@@ -177,9 +177,9 @@ delete_edge <- function(
       }
 
       # Stop function if the label for `to` is not distinct in the graph
-      if (graph$nodes_df %>%
-          dplyr::select("label") %>%
-          dplyr::filter(label == to) %>%
+      if (graph$nodes_df |>
+          dplyr::select("label") |>
+          dplyr::filter(label == to) |>
           nrow() > 1) {
 
         cli::cli_abort(
@@ -224,8 +224,8 @@ delete_edge <- function(
 
     # Stop function if the edge provided is not
     # in the edge data frame
-    if (edf %>%
-        dplyr::filter(from == from_id, to == to_id) %>%
+    if (edf |>
+        dplyr::filter(from == from_id, to == to_id) |>
         nrow() == 0) {
 
       cli::cli_abort(
@@ -234,7 +234,7 @@ delete_edge <- function(
 
     # Filter out relevant rows from `edf`
     edf <-
-      edf %>%
+      edf |>
       dplyr::filter(!(from == from_id & to == to_id))
 
     # Reset the row names in the edf
@@ -249,9 +249,9 @@ delete_edge <- function(
 
     # Stop function if the edge provided is not
     # in the edge data frame
-    if (edf %>%
+    if (edf |>
         dplyr::filter((from == from_id & to == to_id) |
-                      (from == to_id & to == from_id)) %>%
+                      (from == to_id & to == from_id)) |>
         nrow() == 0) {
 
       cli::cli_abort(
@@ -260,7 +260,7 @@ delete_edge <- function(
 
     # Filter out relevant rows from `edf`
     edf <-
-      edf %>%
+      edf |>
       dplyr::filter(!((from == from_id & to == to_id) |
                         (from == to_id & to == from_id)))
 

--- a/R/delete_edges_ws.R
+++ b/R/delete_edges_ws.R
@@ -23,8 +23,8 @@
 #' @examples
 #' # Create a graph
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 3) %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 3) |>
 #'   add_edges_w_string(
 #'     edges = "1->3 1->2 2->3")
 #'
@@ -32,16 +32,16 @@
 #' # node with ID `3` (these are
 #' # `1`->`3` and `2`->`3`)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges_by_node_id(nodes = 3)
 #'
 #' # Delete edges in selection
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   delete_edges_ws()
 #'
 #' # Get a count of edges in the graph
-#' graph %>% count_edges()
+#' graph |> count_edges()
 #'
 #' @family edge creation and removal
 #'
@@ -71,7 +71,7 @@ delete_edges_ws <- function(graph) {
   to_delete <- graph$edge_selection$to
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Delete all edges in selection
   for (i in seq_along(from_delete)) {
@@ -97,7 +97,7 @@ delete_edges_ws <- function(graph) {
     remove_linked_dfs(graph)
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/delete_global_graph_attrs.R
+++ b/R/delete_global_graph_attrs.R
@@ -17,15 +17,15 @@
 #' # Create a new graph and add
 #' # some extra global graph attrs
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_global_graph_attrs(
 #'     attr = "overlap",
 #'     value = "true",
-#'     attr_type = "graph") %>%
+#'     attr_type = "graph") |>
 #'   add_global_graph_attrs(
 #'     attr = "penwidth",
 #'     value = 3,
-#'     attr_type = "node") %>%
+#'     attr_type = "node") |>
 #'   add_global_graph_attrs(
 #'     attr = "penwidth",
 #'     value = 3,
@@ -33,21 +33,21 @@
 #'
 #' # Inspect the graph's global
 #' # attributes
-#' graph %>%
+#' graph |>
 #'   get_global_graph_attr_info()
 #'
 #' # Delete the `penwidth` attribute
 #' # for the graph's nodes using the
 #' # `delete_global_graph_attrs()` fcn
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   delete_global_graph_attrs(
 #'     attr = "penwidth",
 #'     attr_type = "node")
 #'
 #' # View the remaining set of global
 #' # attributes for the graph
-#' graph %>%
+#' graph |>
 #'   get_global_graph_attr_info()
 #'
 #' @export
@@ -88,7 +88,7 @@ delete_global_graph_attrs <- function(
     attr <- rlang::enquo(attr)
 
     graph$global_attrs <-
-      graph$global_attrs %>%
+      graph$global_attrs |>
       dplyr::filter(!(attr %in% !!attr))
   }
 
@@ -105,7 +105,7 @@ delete_global_graph_attrs <- function(
     attr_type <- rlang::enquo(attr_type)
 
     graph$global_attrs <-
-      graph$global_attrs %>%
+      graph$global_attrs |>
       dplyr::filter(!(attr_type %in% !!attr_type))
   }
 
@@ -125,13 +125,13 @@ delete_global_graph_attrs <- function(
       dplyr::tibble(
         attr = as.character(attr),
         value = NA_character_,
-        attr_type = as.character(attr_type)) %>%
+        attr_type = as.character(attr_type)) |>
       as.data.frame(stringsAsFactors = FALSE)
 
     # Use the `anti_join()` to remove global attribute
     # rows from the graph
     global_attrs_joined <-
-      global_attrs_available %>%
+      global_attrs_available |>
       dplyr::anti_join(
         global_attrs_to_remove,
         by = c("attr", "attr_type"))

--- a/R/delete_graph_actions.R
+++ b/R/delete_graph_actions.R
@@ -16,7 +16,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 8,
@@ -25,17 +25,17 @@
 #' # Add three graph actions to the
 #' # graph
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_graph_action(
 #'     fcn = "set_node_attr_w_fcn",
 #'     node_attr_fcn = "get_pagerank",
 #'     column_name = "pagerank",
-#'     action_name = "get_pagerank") %>%
+#'     action_name = "get_pagerank") |>
 #'   add_graph_action(
 #'     fcn = "rescale_node_attrs",
 #'     node_attr_from = "pagerank",
 #'     node_attr_to = "width",
-#'     action_name = "pagerank_to_width") %>%
+#'     action_name = "pagerank_to_width") |>
 #'   add_graph_action(
 #'     fcn = "colorize_node_attrs",
 #'     node_attr_from = "width",
@@ -45,19 +45,19 @@
 #' # View the graph actions for the graph
 #' # object by using the `get_graph_actions()`
 #' # function
-#' graph %>% get_graph_actions()
+#' graph |> get_graph_actions()
 #'
 #' # Delete the second and third graph
 #' # actions using `delete_graph_actions()`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   delete_graph_actions(
 #'     actions = c(2, 3))
 #'
 #' # Verify that these last two graph
 #' # actions were deleted by again using
 #' # the `get_graph_actions()` function
-#' graph %>% get_graph_actions()
+#' graph |> get_graph_actions()
 #'
 #' @export
 delete_graph_actions <- function(
@@ -81,8 +81,8 @@ delete_graph_actions <- function(
   if (inherits(actions, "character")) {
 
     graph_action_names <-
-      graph %>%
-      get_graph_actions() %>%
+      graph |>
+      get_graph_actions() |>
       dplyr::pull("action_name")
 
     if (!any(actions %in% graph_action_names)) {
@@ -93,17 +93,17 @@ delete_graph_actions <- function(
 
     # Get a revised data frame with graph actions
     revised_graph_actions <-
-      graph %>%
-      get_graph_actions() %>%
-      dplyr::filter(!(action_name %in% actions)) %>%
+      graph |>
+      get_graph_actions() |>
+      dplyr::filter(!(action_name %in% actions)) |>
       dplyr::mutate(action_index = dplyr::row_number())
   }
 
   if (inherits(actions, "numeric")) {
 
     graph_action_indices <-
-      graph %>%
-      get_graph_actions() %>%
+      graph |>
+      get_graph_actions() |>
       dplyr::pull(action_index)
 
     if (!any(actions %in% graph_action_indices)) {
@@ -112,9 +112,9 @@ delete_graph_actions <- function(
 
     # Get a revised data frame with graph actions
     revised_graph_actions <-
-      graph %>%
-      get_graph_actions() %>%
-      dplyr::filter(!(action_index %in% actions)) %>%
+      graph |>
+      get_graph_actions() |>
+      dplyr::filter(!(action_index %in% actions)) |>
       dplyr::mutate(action_index = dplyr::row_number())
   }
 

--- a/R/delete_loop_edges_ws.R
+++ b/R/delete_loop_edges_ws.R
@@ -26,7 +26,7 @@
 #' # of 5 nodes with loops retained
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_full_graph(
 #'     n = 5,
 #'     keep_loops = TRUE)
@@ -35,14 +35,14 @@
 #' # and remove the loop edges
 #' # associated with those nodes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_id(
-#'     nodes = 3:4) %>%
+#'     nodes = 3:4) |>
 #'   delete_loop_edges_ws()
 #'
 #' # Count the number of loop
 #' # edges remaining in the graph
-#' graph %>% count_loop_edges()
+#' graph |> count_loop_edges()
 #'
 #' @family edge creation and removal
 #'
@@ -65,7 +65,7 @@ delete_loop_edges_ws <- function(graph) {
   edf <- graph$edges_df
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Filter edf such that any loop edges
   # associated with the selected nodes
@@ -73,10 +73,10 @@ delete_loop_edges_ws <- function(graph) {
   selected_nodes <- suppressMessages(get_selection(graph))
 
   edges_to_remove <-
-    selected_nodes %>%
+    selected_nodes |>
     purrr::map_df(
       .f = function(x) {
-        edf %>%
+        edf |>
           dplyr::filter(
             (from == x &
                to == x))
@@ -90,11 +90,11 @@ delete_loop_edges_ws <- function(graph) {
 
   # Scavenge any invalid, linked data frames
   graph <-
-    graph %>%
+    graph |>
     remove_linked_dfs()
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/delete_node.R
+++ b/R/delete_node.R
@@ -14,7 +14,7 @@
 #' # Create a graph with 5 nodes and
 #' # edges between each in a path
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 5)
 #'
 #' # Delete node with ID `3`
@@ -22,12 +22,12 @@
 #'
 #' # Verify that the node with ID `3`
 #' # is no longer in the graph
-#' graph %>% get_node_ids()
+#' graph |> get_node_ids()
 #'
 #' # Also note that edges are removed
 #' # since there were edges between the
 #' # removed node to and from other nodes
-#' graph %>% get_edges()
+#' graph |> get_edges()
 #' @family node creation and removal
 #' @export
 delete_node <- function(
@@ -62,10 +62,10 @@ delete_node <- function(
   }
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Get the graph's node data frame
   ndf <- graph$nodes_df
@@ -75,13 +75,13 @@ delete_node <- function(
 
   # Remove node from `ndf`
   ndf <-
-    ndf %>%
+    ndf |>
     dplyr::filter(id != node)
 
   # Remove any edges connected to `node`
   # in the `edf`
   edf <-
-    edf %>%
+    edf |>
     dplyr::filter(!(from == node | to == node))
 
   # Reset the row names in the ndf and the edf
@@ -94,18 +94,18 @@ delete_node <- function(
 
   # Scavenge any invalid, linked data frames
   graph <-
-    graph %>%
+    graph |>
     remove_linked_dfs()
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- graph %>% count_nodes()
+  nodes_graph_2 <- graph |> count_nodes()
 
   # Get the number of nodes added to
   # the graph
   nodes_deleted <- nodes_graph_2 - nodes_graph_1
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/delete_nodes_ws.R
+++ b/R/delete_nodes_ws.R
@@ -25,24 +25,24 @@
 #' @examples
 #' # Create a graph with 3 nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 3) %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 3) |>
 #'   add_edges_w_string(
 #'     edges = "1->3 1->2 2->3")
 #'
 #' # Select node with ID `1`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_id(nodes = 1)
 #'
 #' # Delete node in selection (this
 #' # also deletes any attached edges)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   delete_nodes_ws()
 #'
 #' # Get a count of nodes in the graph
-#' graph %>% count_nodes()
+#' graph |> count_nodes()
 #'
 #' @family node creation and removal
 #'
@@ -62,10 +62,10 @@ delete_nodes_ws <- function(graph) {
   check_graph_contains_node_selection(graph)
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Get a vector of the nodes to be deleted
   nodes_to_delete <- graph$node_selection$node
@@ -91,18 +91,18 @@ delete_nodes_ws <- function(graph) {
 
   # Scavenge any invalid, linked data frames
   graph <-
-    graph %>%
+    graph |>
     remove_linked_dfs()
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- graph %>% count_nodes()
+  nodes_graph_2 <- graph |> count_nodes()
 
   # Get the number of nodes added to
   # the graph
   nodes_deleted <- nodes_graph_2 - nodes_graph_1
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/deselect_edges.R
+++ b/R/deselect_edges.R
@@ -13,32 +13,32 @@
 #' # Create a graph with
 #' # a single path
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 5)
 #'
 #' # Select edges with IDs `1`
 #' # and `3`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges_by_edge_id(
 #'     edges = c(1, 3))
 #'
 #' # Verify that an edge selection
 #' # has been made
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Deselect edge `1`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges_by_edge_id(
-#'     edges = c(1, 3)) %>%
+#'     edges = c(1, 3)) |>
 #'   deselect_edges(edges = 1)
 #'
 #' # Verify that the edge selection
 #' # has been made for edges `1` and
 #' # `3` and that edge `1` has been
 #' # deselected (leaving only `3`)
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 deselect_edges <- function(
@@ -59,7 +59,7 @@ deselect_edges <- function(
 
   # Extract the graph's edge selection
   graph$edge_selection <-
-    graph$edge_selection %>%
+    graph$edge_selection |>
     dplyr::filter(!(edge %in% edges))
 
   # Get the name of the function

--- a/R/deselect_nodes.R
+++ b/R/deselect_nodes.R
@@ -33,15 +33,15 @@
 #'
 #' # Explicitly select nodes `1` and `3`
 #' graph <-
-#'   graph %>%
-#'   select_nodes(nodes = c(1, 3)) %>%
+#'   graph |>
+#'   select_nodes(nodes = c(1, 3)) |>
 #'   deselect_nodes(nodes = 1)
 #'
 #' # Verify that the node selection
 #' # has been made for nodes `1` and
 #' # `3` and that node `1` has been
 #' # deselected (leaving only `3`)
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 deselect_nodes <- function(
@@ -62,7 +62,7 @@ deselect_nodes <- function(
 
   # Extract the graph's node selection
   graph$node_selection <-
-    graph$node_selection %>%
+    graph$node_selection |>
     dplyr::filter(!(node %in% nodes))
 
   # Get the name of the function

--- a/R/display_metagraph.R
+++ b/R/display_metagraph.R
@@ -18,55 +18,61 @@
 #' # Create a randomized property
 #' # graph with 1000 nodes and 1350 edges
 #' property_graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 1000,
 #'     m = 1350,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   select_nodes_by_degree(
-#'     expressions = "deg >= 3") %>%
+#'     expressions = "deg >= 3") |>
 #'   set_node_attrs_ws(
 #'     node_attr = type,
-#'     value = "a") %>%
-#'   clear_selection() %>%
+#'     value = "a") |>
+#'   clear_selection() |>
 #'   select_nodes_by_degree(
-#'     expressions = "deg < 3") %>%
+#'     expressions = "deg < 3") |>
 #'   set_node_attrs_ws(
 #'     node_attr = type,
-#'     value = "b") %>%
-#'   clear_selection() %>%
+#'     value = "b") |>
+#'   clear_selection() |>
 #'   select_nodes_by_degree(
-#'     expressions = "deg == 0") %>%
+#'     expressions = "deg == 0") |>
 #'   set_node_attrs_ws(
 #'     node_attr = type,
-#'     value = "c") %>%
+#'     value = "c") |>
 #'   set_node_attr_to_display(
-#'     attr = type) %>%
+#'     attr = type)
+#'
+#' # Select a random subset of edges
+#' # for setting edge attributes
+#' node_ids <- get_node_ids(property_graph)
+#' sampled_nodes <- sample(
+#'   node_ids,
+#'   size = floor(0.15 * length(node_ids)))
+#'
+#' property_graph <-
+#'   property_graph |>
 #'   select_edges_by_node_id(
-#'     nodes =
-#'       get_node_ids(.) %>%
-#'       sample(
-#'         size = 0.15 * length(.) %>%
-#'           floor())) %>%
+#'     nodes = sampled_nodes) |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = rel,
-#'     value = "r_1") %>%
-#'   invert_selection() %>%
+#'     value = "r_1") |>
+#'   invert_selection() |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = rel,
-#'     value = "r_2") %>%
-#'   clear_selection() %>%
+#'     value = "r_2") |>
+#'   clear_selection() |>
 #'   copy_edge_attrs(
 #'     edge_attr_from = rel,
-#'     edge_attr_to = label) %>%
+#'     edge_attr_to = label) |>
 #'   add_global_graph_attrs(
 #'     attr = "fontname",
 #'     value = "Helvetica",
-#'     attr_type = "edge") %>%
+#'     attr_type = "edge") |>
 #'   add_global_graph_attrs(
 #'     attr = "fontcolor",
 #'     value = "gray50",
-#'     attr_type = "edge") %>%
+#'     attr_type = "edge") |>
 #'   add_global_graph_attrs(
 #'     attr = "fontsize",
 #'     value = 10,
@@ -88,28 +94,28 @@ display_metagraph <- function(graph) {
 
   # Get a distinct list of node `type` values
   unique_node_list <-
-    graph$nodes_df %>%
+    graph$nodes_df |>
     dplyr::distinct(type)
 
   # Get a distinct list of edges between types
   unique_edge_list <-
-    graph$edges_df %>%
+    graph$edges_df |>
     dplyr::inner_join(
-      graph$nodes_df %>%
+      graph$nodes_df |>
         dplyr::select(from = "id", from_type = "type"),
-      by = "from") %>%
+      by = "from") |>
     dplyr::inner_join(
-      graph$nodes_df %>%
+      graph$nodes_df |>
         dplyr::select(to = "id", to_type = "type"),
-      by = "to") %>%
+      by = "to") |>
     dplyr::distinct(rel, from_type, to_type)
 
   # Create the initial metagraph
   metagraph <-
-    create_graph() %>%
+    create_graph() |>
     add_nodes_from_df_cols(
       unique_node_list,
-      columns = "type") %>%
+      columns = "type") |>
     add_edges_from_table(
       unique_edge_list,
       from_to_map = label,
@@ -122,36 +128,36 @@ display_metagraph <- function(graph) {
 
   # Apply coloring and other aesthetics to nodes and edges
   metagraph <-
-    metagraph %>%
+    metagraph |>
     colorize_node_attrs(
       node_attr_from = "type",
-      node_attr_to = "fillcolor") %>%
+      node_attr_to = "fillcolor") |>
     copy_edge_attrs(
       edge_attr_from = "rel",
-      edge_attr_to = "label") %>%
+      edge_attr_to = "label") |>
     add_global_graph_attrs(
       attr = "fontname",
       value = "Helvetica",
-      attr_type = "edge") %>%
+      attr_type = "edge") |>
     add_global_graph_attrs(
       attr = "fontcolor",
       value = "gray50",
-      attr_type = "edge") %>%
+      attr_type = "edge") |>
     add_global_graph_attrs(
       attr = "fontsize",
       value = 10,
-      attr_type = "edge") %>%
+      attr_type = "edge") |>
     colorize_edge_attrs(
       edge_attr_from = "rel",
-      edge_attr_to = "color") %>%
+      edge_attr_to = "color") |>
     add_global_graph_attrs(
       attr = "fontsize",
       value = 6,
-      attr_type = "edge") %>%
+      attr_type = "edge") |>
     add_global_graph_attrs(
       attr = "len",
       value = 3.5,
-      attr_type = "edge") %>%
+      attr_type = "edge") |>
     add_global_graph_attrs(
       attr = "layout",
       value = "dot",

--- a/R/do_bfs.R
+++ b/R/do_bfs.R
@@ -23,9 +23,9 @@
 #' # Create a graph containing
 #' # two balanced trees
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
-#'     k = 2, h = 2) %>%
+#'     k = 2, h = 2) |>
 #'   add_balanced_tree(
 #'     k = 3, h = 2)
 #'
@@ -36,14 +36,14 @@
 #' # `direction = "all"` doesn't
 #' # take edge direction into
 #' # account)
-#' graph %>%
+#' graph |>
 #'   do_bfs(node = 1)
 #'
 #' # If not specifying a
 #' # starting node, the function
 #' # will begin the search from
 #' # a random node
-#' graph %>%
+#' graph |>
 #'   do_bfs()
 #'
 #' # It's also possible to
@@ -52,7 +52,7 @@
 #' # using `direction = "in"`
 #' # causes the bfs routine to
 #' # visit nodes along inward edges
-#' graph %>%
+#' graph |>
 #'   do_bfs(
 #'     node = 1,
 #'     direction = "in")
@@ -60,7 +60,7 @@
 #' # Using `direction = "out"`
 #' # results in the bfs moving
 #' # along solely outward edges
-#' graph %>%
+#' graph |>
 #'   do_bfs(
 #'     node = 1,
 #'     direction = "out")

--- a/R/do_dfs.R
+++ b/R/do_dfs.R
@@ -23,9 +23,9 @@
 #' # Create a graph containing
 #' # two balanced trees
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
-#'     k = 2, h = 2) %>%
+#'     k = 2, h = 2) |>
 #'   add_balanced_tree(
 #'   k = 3, h = 2)
 #'
@@ -36,14 +36,14 @@
 #' # `direction = "all"`
 #' # doesn't take edge
 #' # direction into account)
-#' graph %>%
+#' graph |>
 #'   do_dfs(node = 1)
 #'
 #' # If not specifying a
 #' # starting node, the function
 #' # will begin the search
 #' # from a random node
-#' graph %>%
+#' graph |>
 #'   do_dfs()
 #'
 #' # It's also possible to
@@ -52,7 +52,7 @@
 #' # using `direction = "in"`
 #' # causes the dfs routine to
 #' # visit nodes along inward edges
-#' graph %>%
+#' graph |>
 #'   do_dfs(
 #'     node = 1,
 #'     direction = "in")
@@ -60,7 +60,7 @@
 #' # Using `direction = "out"`
 #' # results in the dfs moving
 #' # along solely outward edges
-#' graph %>%
+#' graph |>
 #'   do_dfs(
 #'     node = 1,
 #'     direction = "out")

--- a/R/drop_edge_attrs.R
+++ b/R/drop_edge_attrs.R
@@ -14,26 +14,26 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 6,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
-#'     values = 3) %>%
+#'     values = 3) |>
 #'   mutate_edge_attrs(
 #'     penwidth = value * 2)
 #'
 #' # Get the graph's internal
 #' # edf to show which edge
 #' # attributes are available
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Drop the `value` edge
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   drop_edge_attrs(
 #'     edge_attr = value)
 #'
@@ -41,7 +41,7 @@
 #' # edf to show that the edge
 #' # attribute `value` had been
 #' # removed
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -59,7 +59,7 @@ drop_edge_attrs <- function(
 
   # Get the requested `edge_attr`
   edge_attr <-
-    rlang::enquo(edge_attr) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr) |> rlang::get_expr() |> as.character()
 
   # Stop function if `edge_attr` is any of
   # `from`, `to`, or `rel`

--- a/R/drop_node_attrs.R
+++ b/R/drop_node_attrs.R
@@ -12,27 +12,30 @@
 #'
 #' @examples
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 10,
-#'     set_seed = 23) %>%
+#'     set_seed = 23)
+#'
+#' graph <-
+#'   graph |>
 #'  set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 5,
 #'       mean = 5,
-#'       sd = 1) %>% round(1))
+#'       sd = 1) |> round(1))
 #'
 #' # Get the graph's internal
 #' # ndf to show which node
 #' # attributes are available
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Drop the `value` node
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   drop_node_attrs(
 #'     node_attr = value)
 #'
@@ -40,7 +43,7 @@
 #' # ndf to show that the node
 #' # attribute `value` had been
 #' # removed
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -58,7 +61,7 @@ drop_node_attrs <- function(
 
   # Get the requested `node_attr`
   node_attr <-
-    rlang::enquo(node_attr) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr) |> rlang::get_expr() |> as.character()
 
   # Stop function if length of `node_attr` is
   # greater than one

--- a/R/edge_aes.R
+++ b/R/edge_aes.R
@@ -106,7 +106,7 @@
 #' # a path with several edge
 #' # aesthetic attributes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 3,
 #'     type = "path",
@@ -118,7 +118,7 @@
 #' # node data frame; the node
 #' # aesthetic attributes have
 #' # been inserted
-#' graph %>%
+#' graph |>
 #'   get_edge_df()
 #'
 #' @family aesthetics
@@ -195,7 +195,7 @@ edge_aes <- function(style = NULL,
       decorate = decorate)
 
   non_null_attrs <-
-    seq_along(attr_values) %>% # 1:length(attr_values)
+    seq_along(attr_values) |> # 1:length(attr_values)
     purrr::map_chr(.f = function(x) {
       if (is.null(attr_values[[x]])) {
         NA_character_

--- a/R/edge_data.R
+++ b/R/edge_data.R
@@ -14,7 +14,7 @@
 #' # a path with several edge
 #' # data attributes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 3,
 #'     type = "path",
@@ -26,7 +26,7 @@
 #' # edge data frame; the edge
 #' # data attributes have
 #' # been inserted
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #' }
 #'
 #' @family edge creation and removal

--- a/R/export_csv.R
+++ b/R/export_csv.R
@@ -44,7 +44,7 @@
 #'
 #' # Create separate `nodes.csv` and
 #' # `edges.csv` files
-#' # graph %>% export_csv()
+#' # graph |> export_csv()
 #'
 #' @export
 export_csv <- function(

--- a/R/export_graph.R
+++ b/R/export_graph.R
@@ -18,7 +18,7 @@
 #' @examples
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'     add_path(
 #'       n = 5,
 #'       edge_aes = edge_aes(
@@ -35,7 +35,7 @@
 #'
 #' # Create a PDF file for
 #' # the graph (`graph.pdf`)
-#' # graph %>%
+#' # graph |>
 #' #   export_graph(
 #' #     file_name = "graph.pdf",
 #' #     title = "Simple Graph"
@@ -43,7 +43,7 @@
 #'
 #' # Create a PNG file for
 #' # the graph (`mypng.png`)
-#' # graph %>%
+#' # graph |>
 #' #   export_graph(
 #' #     file_name = "mypng.png",
 #' #     file_type = "PNG"

--- a/R/filter_graph_series.R
+++ b/R/filter_graph_series.R
@@ -22,21 +22,21 @@
 #' # Create three graphs
 #' graph_time_1 <-
 #'   create_graph(
-#'     graph_name = "graph_with_time_1") %>%
+#'     graph_name = "graph_with_time_1") |>
 #'   set_graph_time(
 #'     time = "2015-03-25 03:00",
 #'     tz = "GMT")
 #'
 #' graph_time_2 <-
 #'   create_graph(
-#'     graph_name = "graph_with_time_2") %>%
+#'     graph_name = "graph_with_time_2") |>
 #'   set_graph_time(
 #'     time = "2015-03-26 03:00",
 #'     tz = "GMT")
 #'
 #' graph_time_3 <-
 #'   create_graph(
-#'     graph_name = "graph_with_time_3") %>%
+#'     graph_name = "graph_with_time_3") |>
 #'   set_graph_time(
 #'     time = "2015-03-27 15:00",
 #'     tz = "GMT")
@@ -45,11 +45,11 @@
 #' # the graphs
 #' series_temporal <-
 #'   create_graph_series(
-#'     series_type = "temporal") %>%
+#'     series_type = "temporal") |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_time_1) %>%
+#'     graph = graph_time_1) |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_time_2) %>%
+#'     graph = graph_time_2) |>
 #'   add_graph_to_graph_series(
 #'     graph = graph_time_3)
 #'
@@ -62,7 +62,7 @@
 #'
 #' # Get a count of graphs in
 #' # the series
-#' series_sequence_subset %>%
+#' series_sequence_subset |>
 #'   count_graphs_in_graph_series()
 #'
 #' # Subset graph series by date-time
@@ -76,7 +76,7 @@
 #'
 #' # Get a count of graphs in
 #' # the series
-#' series_time_subset %>%
+#' series_time_subset |>
 #'   count_graphs_in_graph_series()
 #'
 #' @export

--- a/R/from_adj_matrix.R
+++ b/R/from_adj_matrix.R
@@ -24,7 +24,7 @@
 #'     0:1, 100,
 #'     replace = TRUE,
 #'     prob = c(0.9,0.1)
-#'   ) %>%
+#'   ) |>
 #'   matrix(ncol = 10)
 #'
 #' # Create a graph from the adjacency matrix

--- a/R/from_igraph.R
+++ b/R/from_igraph.R
@@ -10,7 +10,7 @@
 #' @examples
 #' # Create a DiagrammeR graph object
 #' dgr_graph_orig <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 36,
 #'     m = 50,
@@ -19,18 +19,20 @@
 #' # Convert the DiagrammeR
 #' # graph to an igraph object
 #' ig_graph <-
-#'   dgr_graph_orig %>%
+#'   dgr_graph_orig |>
 #'   to_igraph()
 #'
 #' # Convert the igraph graph
 #' # back to a DiagrammeR graph
 #' dgr_graph_new <-
-#'   ig_graph %>%
+#'   ig_graph |>
 #'   from_igraph()
 #'
 #' # Get some graph information
-#' (dgr_graph_new %>%
-#'   get_graph_info())[, 1:6]
+#' graph_info <- dgr_graph_new |>
+#'   get_graph_info()
+#'
+#' graph_info[, 1:6]
 #'
 #' @export
 from_igraph <- function(igraph,

--- a/R/fully_connect_nodes_ws.R
+++ b/R/fully_connect_nodes_ws.R
@@ -27,8 +27,8 @@
 #' # then add a path of 3 nodes
 #' # and two isolated nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 3) %>%
+#'   create_graph() |>
+#'   add_path(n = 3) |>
 #'   add_n_nodes(n = 2)
 #'
 #' # Select a node in the path
@@ -37,21 +37,21 @@
 #' # and `5`); then, and fully
 #' # connect these nodes together
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_id(
-#'     nodes = 3:5) %>%
+#'     nodes = 3:5) |>
 #'   fully_connect_nodes_ws()
 #'
 #' # Get the graph's edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Create an undirected, empty
 #' # graph; add a path of 3 nodes
 #' # and two isolated nodes
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
-#'   add_path(n = 3) %>%
+#'     directed = FALSE) |>
+#'   add_path(n = 3) |>
 #'   add_n_nodes(n = 2)
 #'
 #' # Select a node in the path
@@ -60,16 +60,16 @@
 #' # and `5`); then, and fully
 #' # connect these nodes together
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_id(
-#'     nodes = 3:5) %>%
+#'     nodes = 3:5) |>
 #'   fully_connect_nodes_ws()
 #'
 #' # Get the graph's edge data
 #' # frame; in the undirected
 #' # case, reverse edges aren't
 #' # added
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @export
 fully_connect_nodes_ws <- function(graph) {
@@ -90,16 +90,16 @@ fully_connect_nodes_ws <- function(graph) {
   check_graph_contains_node_selection(graph)
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Get the graph's edf
   edf <- graph$edges_df
 
   # Get the combination of edges
   edge_candidates <-
-    utils::combn(suppressMessages(get_selection(graph = graph)), 2) %>%
-    t() %>%
-    as.data.frame() %>%
+    utils::combn(suppressMessages(get_selection(graph = graph)), 2) |>
+    t() |>
+    as.data.frame() |>
     dplyr::rename(from = "V1", to = "V2")
 
   # Determine the complete set of edges
@@ -111,10 +111,10 @@ fully_connect_nodes_ws <- function(graph) {
       dplyr::setdiff(
         dplyr::bind_rows(
           edge_candidates,
-          edge_candidates %>%
-            dplyr::select(to, from) %>%
+          edge_candidates |>
+            dplyr::select(to, from) |>
             dplyr::rename(from = "to", to = "from")),
-        edf %>%
+        edf |>
           dplyr::select("from", "to"))
 
   } else {
@@ -122,7 +122,7 @@ fully_connect_nodes_ws <- function(graph) {
     edges_to_add <-
       dplyr::setdiff(
         edge_candidates,
-        edf %>%
+        edf |>
           dplyr::select("from", "to"))
   }
 
@@ -145,7 +145,7 @@ fully_connect_nodes_ws <- function(graph) {
   }
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/fully_disconnect_nodes_ws.R
+++ b/R/fully_disconnect_nodes_ws.R
@@ -24,20 +24,20 @@
 #' # Create an empty graph and
 #' # add a path of 6 nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 6)
 #'
 #' # Select nodes `3` and `4`
 #' # and fully disconnect them
 #' # from the graph
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_id(
-#'     nodes = 3:4) %>%
+#'     nodes = 3:4) |>
 #'   fully_disconnect_nodes_ws()
 #'
 #' # Get the graph's edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @export
 fully_disconnect_nodes_ws <- function(graph) {
@@ -61,12 +61,12 @@ fully_disconnect_nodes_ws <- function(graph) {
   edf <- graph$edges_df
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Filter edf such that any edges containing
   # nodes in the node selection are removed
   edf_replacement <-
-    edf %>%
+    edf |>
     dplyr::filter(
       !(from %in% suppressMessages(get_selection(graph)) |
           to %in% suppressMessages(get_selection(graph))))
@@ -75,10 +75,10 @@ fully_disconnect_nodes_ws <- function(graph) {
   graph$edges_df <- edf_replacement
 
   # Scavenge any invalid, linked data frames
-  graph <- graph %>% remove_linked_dfs()
+  graph <- graph |> remove_linked_dfs()
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/generate_dot.R
+++ b/R/generate_dot.R
@@ -23,12 +23,12 @@ generate_dot <- function(graph) {
 
   if ("graph" %in% global_attrs$attr_type) {
     graph_attrs <-
-      global_attrs %>%
-      dplyr::filter(attr_type == "graph") %>%
+      global_attrs |>
+      dplyr::filter(attr_type == "graph") |>
       dplyr::mutate(string = paste0(attr, " = '", value, "'"))
 
     graph_attrs <-
-      graph_attrs %>%
+      graph_attrs |>
       dplyr::pull("string")
 
   } else {
@@ -37,25 +37,26 @@ generate_dot <- function(graph) {
 
   if ("node" %in% global_attrs$attr_type) {
     node_attrs <-
-      global_attrs %>%
-      dplyr::filter(attr_type == "node") %>%
+      global_attrs |>
+      dplyr::filter(attr_type == "node") |>
       dplyr::mutate(string = paste0(attr, " = '", value, "'"))
 
     node_attrs <-
-      node_attrs %>%
+      node_attrs |>
       dplyr::pull("string")
 
     # Fill in NA attribute values with global preset values
-    for (i in seq_len(nrow(global_attrs %>% dplyr::filter(attr_type == "node")))) {
+    node_global_attrs <- global_attrs |> dplyr::filter(attr_type == "node")
+    for (i in seq_len(nrow(node_global_attrs))) {
 
-      node_attr_to_set <- (global_attrs %>% dplyr::filter(attr_type == "node"))[i, 1]
+      node_attr_to_set <- node_global_attrs[i, 1]
 
       if (node_attr_to_set %in% colnames(nodes_df)) {
 
         col_num <- which(colnames(nodes_df) == node_attr_to_set)
 
         nodes_df[which(is.na(nodes_df[, col_num])), col_num] <-
-          (global_attrs %>% dplyr::filter(attr_type == "node"))[i, 2]
+          node_global_attrs[i, 2]
       }
     }
 
@@ -65,25 +66,26 @@ generate_dot <- function(graph) {
 
   if ("edge" %in% global_attrs$attr_type) {
     edge_attrs <-
-      global_attrs %>%
-      dplyr::filter(attr_type == "edge") %>%
+      global_attrs |>
+      dplyr::filter(attr_type == "edge") |>
       dplyr::mutate(string = paste0(attr, " = '", value, "'"))
 
     edge_attrs <-
-      edge_attrs %>%
+      edge_attrs |>
       dplyr::pull("string")
 
     # Fill in NA attribute values with global preset values
-    for (i in 1:nrow(global_attrs %>% dplyr::filter(attr_type == "edge"))) {
+    edge_global_attrs <- global_attrs |> dplyr::filter(attr_type == "edge")
+    for (i in seq_len(nrow(edge_global_attrs))) {
 
-      edge_attr_to_set <- (global_attrs %>% dplyr::filter(attr_type == "edge"))[i, 1]
+      edge_attr_to_set <- edge_global_attrs[i, 1]
 
       if (edge_attr_to_set %in% colnames(edges_df)) {
 
         col_num <- which(colnames(edges_df) == edge_attr_to_set)
 
         edges_df[which(is.na(edges_df[, col_num])), col_num] <-
-          (global_attrs %>% dplyr::filter(attr_type == "edge"))[i, 2]
+          edge_global_attrs[i, 2]
       }
     }
 
@@ -100,7 +102,7 @@ generate_dot <- function(graph) {
       vars <- vars[purrr::map_lgl(nodes_df[vars], is.character)]
 
       nodes_df <-
-        nodes_df %>%
+        nodes_df |>
         dplyr::mutate(
           dplyr::across(
             .cols = dplyr::all_of(vars),
@@ -118,7 +120,7 @@ generate_dot <- function(graph) {
       vars <- vars[purrr::map_lgl(edges_df[vars], is.character)]
 
       edges_df <-
-        edges_df %>%
+        edges_df |>
         dplyr::mutate(
           dplyr::across(
             .cols = dplyr::all_of(vars),
@@ -279,12 +281,12 @@ generate_dot <- function(graph) {
       if (!is.na(column_with_x) && !is.na(column_with_y)) {
         pos <-
           paste0(
-            nodes_df %>% dplyr::pull(column_with_x), ",",
-            nodes_df %>% dplyr::pull(column_with_y), "!"
+            nodes_df |> dplyr::pull(column_with_x), ",",
+            nodes_df |> dplyr::pull(column_with_y), "!"
           )
 
         nodes_df <-
-          nodes_df %>%
+          nodes_df |>
           dplyr::mutate(pos = !!pos)
       }
 

--- a/R/get_adhesion.R
+++ b/R/get_adhesion.R
@@ -14,16 +14,16 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Determine the graph's adhesion
-#' graph %>% get_adhesion()
+#' graph |> get_adhesion()
 #'
 #' # Create a full graph and then
 #' # get the adhesion for that
-#' create_graph() %>%
-#'   add_full_graph(n = 8) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 8) |>
 #'   get_adhesion()
 #'
 #' @export

--- a/R/get_agg_degree_in.R
+++ b/R/get_agg_degree_in.R
@@ -18,21 +18,24 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 20,
 #'     m = 35,
-#'     set_seed = 23) %>%
+#'     set_seed = 23)
+#'
+#' graph <-
+#'   graph |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 20,
 #'       mean = 5,
-#'       sd = 1) %>% round(1))
+#'       sd = 1) |> round(1))
 #'
 #' # Get the mean indegree value
 #' # from all nodes in the graph
-#' graph %>%
+#' graph |>
 #'   get_agg_degree_in(
 #'     agg = "mean")
 #'
@@ -40,7 +43,7 @@
 #' # can be used (`min`, `max`,
 #' # `median`, `sum`); let's get
 #' # the median in this example
-#' graph %>%
+#' graph |>
 #'   get_agg_degree_in(
 #'     agg = "median")
 #'
@@ -49,7 +52,7 @@
 #' # graph nodes and this is made
 #' # possible by specifying
 #' # `conditions` for the nodes
-#' graph %>%
+#' graph |>
 #'   get_agg_degree_in(
 #'     agg = "mean",
 #'     conditions = value > 5.0)
@@ -75,7 +78,7 @@ get_agg_degree_in <- function(
 
     # Get a vector of node ID values
     node_ids <-
-      ndf %>%
+      ndf |>
       dplyr::pull("id")
   }
 
@@ -85,7 +88,7 @@ get_agg_degree_in <- function(
 
   if (exists("node_ids")) {
     indegree_df <-
-      indegree_df %>%
+      indegree_df |>
       dplyr::filter(id %in% node_ids)
   }
 
@@ -98,9 +101,9 @@ get_agg_degree_in <- function(
   fun <- match.fun(agg)
 
   indegree_agg <-
-    indegree_df %>%
-    dplyr::group_by() %>%
-    dplyr::summarize(fun(indegree, na.rm = TRUE), .groups = "drop") %>%
+    indegree_df |>
+    dplyr::group_by() |>
+    dplyr::summarize(fun(indegree, na.rm = TRUE), .groups = "drop") |>
     purrr::flatten_dbl()
 
   indegree_agg

--- a/R/get_agg_degree_out.R
+++ b/R/get_agg_degree_out.R
@@ -18,28 +18,28 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 20,
 #'     m = 35,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 20,
 #'       mean = 5,
-#'       sd = 1) %>% round(1))
+#'       sd = 1) |> round(1))
 #'
 #' # Get the mean outdegree value from all
 #' # nodes in the graph
-#' graph %>%
+#' graph |>
 #'   get_agg_degree_out(
 #'     agg = "mean")
 #'
 #' # Other aggregation functions can be used
 #' # (`min`, `max`, `median`, `sum`); let's
 #' # get the median in this example
-#' graph %>%
+#' graph |>
 #'   get_agg_degree_out(
 #'     agg = "median")
 #'
@@ -47,7 +47,7 @@
 #' # for a subset of the graph nodes and this
 #' # is made possible by specifying `conditions`
 #' # for the nodes
-#' graph %>%
+#' graph |>
 #'   get_agg_degree_out(
 #'     agg = "mean",
 #'     conditions = value < 5.0)
@@ -74,7 +74,7 @@ get_agg_degree_out <- function(
 
     # Get a vector of node ID values
     node_ids <-
-      ndf %>%
+      ndf |>
       dplyr::pull("id")
   }
 
@@ -84,7 +84,7 @@ get_agg_degree_out <- function(
 
   if (exists("node_ids")) {
     outdegree_df <-
-      outdegree_df %>%
+      outdegree_df |>
       dplyr::filter(id %in% node_ids)
   }
 
@@ -97,9 +97,9 @@ get_agg_degree_out <- function(
   fun <- match.fun(agg)
 
   outdegree_agg <-
-    outdegree_df %>%
-    dplyr::group_by() %>%
-    dplyr::summarize(fun(outdegree, na.rm = TRUE), .groups = "drop") %>%
+    outdegree_df |>
+    dplyr::group_by() |>
+    dplyr::summarize(fun(outdegree, na.rm = TRUE), .groups = "drop") |>
     purrr::flatten_dbl()
 
   outdegree_agg

--- a/R/get_agg_degree_total.R
+++ b/R/get_agg_degree_total.R
@@ -18,22 +18,22 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 20,
 #'     m = 35,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 20,
 #'       mean = 5,
-#'       sd = 1) %>% round(1))
+#'       sd = 1) |> round(1))
 #'
 #' # Get the mean total degree
 #' # value from all nodes in
 #' # the graph
-#' graph %>%
+#' graph |>
 #'   get_agg_degree_total(
 #'     agg = "mean")
 #'
@@ -41,7 +41,7 @@
 #' # can be used (`min`, `max`,
 #' # `median`, `sum`); let's get
 #' # the median in this example
-#' graph %>%
+#' graph |>
 #'   get_agg_degree_total(
 #'     agg = "median")
 #'
@@ -51,7 +51,7 @@
 #' # and this is made possible
 #' # by specifying `conditions`
 #' # for the nodes
-#' graph %>%
+#' graph |>
 #'   get_agg_degree_total(
 #'     agg = "mean",
 #'     conditions = value < 5.0)
@@ -78,7 +78,7 @@ get_agg_degree_total <- function(
 
     # Get a vector of node ID values
     node_ids <-
-      ndf %>%
+      ndf |>
       dplyr::pull("id")
   }
 
@@ -88,7 +88,7 @@ get_agg_degree_total <- function(
 
   if (exists("node_ids")) {
     total_degree_df <-
-      total_degree_df %>%
+      total_degree_df |>
       dplyr::filter(id %in% node_ids)
   }
 
@@ -101,9 +101,9 @@ get_agg_degree_total <- function(
   fun <- match.fun(agg)
 
   total_degree_agg <-
-    total_degree_df %>%
-    dplyr::group_by() %>%
-    dplyr::summarize(fun(total_degree, na.rm = TRUE), .groups = "drop") %>%
+    total_degree_df |>
+    dplyr::group_by() |>
+    dplyr::summarize(fun(total_degree, na.rm = TRUE), .groups = "drop") |>
     purrr::flatten_dbl()
 
   total_degree_agg

--- a/R/get_all_connected_nodes.R
+++ b/R/get_all_connected_nodes.R
@@ -15,7 +15,7 @@
 #' # `add_gnm_graph()` function; it
 #' # has an unconnected node (`6`)
 #' graph_1 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 20,
 #'     m = 32,
@@ -25,14 +25,14 @@
 #' # nodes to `6` so when specifying
 #' # this node with `get_all_connected_nodes()`
 #' # we get NA back
-#' graph_1 %>%
+#' graph_1 |>
 #'   get_all_connected_nodes(
 #'     node = 6)
 #'
 #' # Any other node in `graph_1` will
 #' # provide a vector of all the nodes
 #' # other than `6`
-#' graph_1 %>%
+#' graph_1 |>
 #'   get_all_connected_nodes(
 #'     node = 1)
 #'
@@ -40,21 +40,21 @@
 #' # clusters of nodes (i.e., the
 #' # graph has two connected components)
 #' graph_2 <-
-#'   create_graph() %>%
-#'   add_path(n = 6) %>%
+#'   create_graph() |>
+#'   add_path(n = 6) |>
 #'   add_path(n = 4)
 #'
 #' # In `graph_2`, node `1` is in
 #' # the larger of the two
 #' # connected components
-#' graph_2 %>%
+#' graph_2 |>
 #'   get_all_connected_nodes(
 #'     node = 1)
 #'
 #' # Also in `graph_2`, node `8`
 #' # is in the smaller of the two
 #' # connected components
-#' graph_2 %>%
+#' graph_2 |>
 #'   get_all_connected_nodes(
 #'     node = 8)
 #'
@@ -81,7 +81,7 @@ get_all_connected_nodes <- function(
   # Get single-row data frame with the node's
   # `id` and `wc_component` grouping
   wc_component <-
-    wc_components_df %>%
+    wc_components_df |>
     dplyr::filter(id == node)
 
   # Extract the `wc_component` grouping as
@@ -92,8 +92,8 @@ get_all_connected_nodes <- function(
   # components for the nodes in the `wc_component`
   # grouping (and removing the original node as well)
   connected_nodes <-
-    wc_components_df %>%
-    dplyr::filter(id != node) %>%
+    wc_components_df |>
+    dplyr::filter(id != node) |>
     dplyr::filter(wc_component == wc_component_val)
 
   # If the resulting df has rows, get the node ID

--- a/R/get_alpha_centrality.R
+++ b/R/get_alpha_centrality.R
@@ -23,7 +23,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 12,
@@ -31,20 +31,20 @@
 #'
 #' # Get the alpha centrality scores
 #' # for all nodes
-#' graph %>%
+#' graph |>
 #'   get_alpha_centrality()
 #'
 #' # Add the alpha centrality
 #' # scores to the graph as a node
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_alpha_centrality(.))
+#'     df = get_alpha_centrality(graph))
 #'
 #' # Display the graph's node
 #' # data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_alpha_centrality <- function(
@@ -73,8 +73,8 @@ get_alpha_centrality <- function(
 
   # Create df with alpha centrality values
   data.frame(
-    id = alpha_centrality_values %>%
-      names() %>%
+    id = alpha_centrality_values |>
+      names() |>
       as.integer(),
     alpha_centrality = alpha_centrality_values,
     stringsAsFactors = FALSE)

--- a/R/get_articulation_points.R
+++ b/R/get_articulation_points.R
@@ -12,11 +12,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 12,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = shape,
 #'     values = "square")
@@ -26,16 +26,16 @@
 #' # nodes that if any were to be
 #' # removed, the graph would
 #' # become disconnected)
-#' graph %>%
+#' graph |>
 #'   get_articulation_points()
 #'
 #' # For the articulation points,
 #' # change the node shape to
 #' # a `circle`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_id(
-#'     nodes = get_articulation_points(.)) %>%
+#'     nodes = get_articulation_points(graph)) |>
 #'   set_node_attrs_ws(
 #'     node_attr = shape,
 #'     value = "circle")

--- a/R/get_authority_centrality.R
+++ b/R/get_authority_centrality.R
@@ -15,7 +15,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -23,19 +23,19 @@
 #'
 #' # Get the authority centrality scores
 #' # for all nodes in the graph
-#' graph %>%
+#' graph |>
 #'   get_authority_centrality()
 #'
 #' # Add the authority centrality
 #' # scores to the graph as a node
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_authority_centrality(.))
+#'     df = get_authority_centrality(graph))
 #'
 #' # Display the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_authority_centrality <- function(
@@ -78,8 +78,8 @@ get_authority_centrality <- function(
 
   # Create df with authority centrality values
   data.frame(
-    id = authority_centrality_values$vector %>%
-      names() %>%
+    id = authority_centrality_values$vector |>
+      names() |>
       as.integer(),
     authority_centrality = unname(authority_centrality_values$vector),
     stringsAsFactors = FALSE)

--- a/R/get_betweenness.R
+++ b/R/get_betweenness.R
@@ -12,7 +12,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 12,
@@ -20,19 +20,19 @@
 #'
 #' # Get the betweenness scores
 #' # for nodes in the graph
-#' graph %>% get_betweenness()
+#' graph |> get_betweenness()
 #'
 #' # Add the betweenness
 #' # values to the graph
 #' # as a node attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_betweenness(.))
+#'     df = get_betweenness(graph))
 #'
 #' # Display the graph's node
 #' # data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_betweenness <- function(graph) {
@@ -53,8 +53,8 @@ get_betweenness <- function(graph) {
 
   # Create df with betweenness scores
   data.frame(
-    id = betweenness_scores %>%
-      names() %>%
+    id = betweenness_scores |>
+      names() |>
       as.integer(),
     betweenness = betweenness_scores,
     stringsAsFactors = FALSE)

--- a/R/get_cache.R
+++ b/R/get_cache.R
@@ -17,29 +17,29 @@
 #'
 #' # Create a graph with 5 nodes and 5 edges
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 5) %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 5) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 5,
 #'       mean = 8,
-#'       sd = 2)) %>%
+#'       sd = 2)) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->2")
 #'
 #' # Cache all values from the node attribute `value`
 #' # as a numeric vector
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_cache(
 #'     name = "value",
 #'     to_cache = get_node_attrs(
-#'       graph = .,
+#'       graph = graph,
 #'       node_attr = value))
 #'
 #' # Return the cached vector
-#' graph %>% get_cache()
+#' graph |> get_cache()
 #'
 #' @export
 get_cache <- function(

--- a/R/get_closeness.R
+++ b/R/get_closeness.R
@@ -16,7 +16,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 12,
@@ -24,17 +24,17 @@
 #'
 #' # Get closeness values for all nodes
 #' # in the graph
-#' graph %>% get_closeness()
+#' graph |> get_closeness()
 #'
 #' # Add the closeness values to
 #' # the graph as a node attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_closeness(.))
+#'     df = get_closeness(graph))
 #'
 #' # Display the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_closeness <- function(
@@ -72,8 +72,8 @@ get_closeness <- function(
 
   # Create df with betweenness scores
   data.frame(
-    id = closeness_values %>%
-      names() %>%
+    id = closeness_values |>
+      names() |>
       as.integer(),
     closeness = closeness_values,
     stringsAsFactors = FALSE)

--- a/R/get_closeness_vitality.R
+++ b/R/get_closeness_vitality.R
@@ -12,7 +12,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 12,
@@ -20,19 +20,19 @@
 #'
 #' # Get closeness vitality values
 #' # for all nodes in the graph
-#' graph %>% get_closeness_vitality()
+#' graph |> get_closeness_vitality()
 #'
 #' # Add the closeness vitality
 #' # values to the graph as a
 #' # node attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_closeness_vitality(.))
+#'     df = get_closeness_vitality(graph))
 #'
 #' # Display the graph's
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_closeness_vitality <- function(graph) {
@@ -55,7 +55,7 @@ get_closeness_vitality <- function(graph) {
       function(x) {
         distances <- igraph::distances(igraph::delete_vertices(ig_graph, x))
         sum_distances - sum(distances[!is.infinite(distances)])
-      }) %>% unlist()
+      }) |> unlist()
 
   # Create df with closeness vitality values
   data.frame(

--- a/R/get_cmty_edge_btwns.R
+++ b/R/get_cmty_edge_btwns.R
@@ -14,7 +14,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -26,20 +26,20 @@
 #' # the leading non-negative
 #' # eigenvector of the modularity
 #' # matrix of the graph
-#' graph %>%
+#' graph |>
 #'   get_cmty_edge_btwns()
 #'
 #' # Add the group membership
 #' # values to the graph
 #' # as a node attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'      df = get_cmty_edge_btwns(.))
+#'      df = get_cmty_edge_btwns(graph))
 #'
 #' # Display the graph's
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_cmty_edge_btwns <- function(graph) {
@@ -58,7 +58,7 @@ get_cmty_edge_btwns <- function(graph) {
 
   # Create df with node memberships
   data.frame(
-    id = igraph::membership(cmty_edge_btwns_obj) %>% names() %>% as.integer(),
+    id = igraph::membership(cmty_edge_btwns_obj) |> names() |> as.integer(),
     edge_btwns_group = as.vector(igraph::membership(cmty_edge_btwns_obj)),
     stringsAsFactors = FALSE)
 }

--- a/R/get_cmty_fast_greedy.R
+++ b/R/get_cmty_fast_greedy.R
@@ -14,7 +14,7 @@
 #' # Create a graph with a
 #' # balanced tree
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
 #'     k = 2,
 #'     h = 2)
@@ -24,20 +24,20 @@
 #' # the graph through the greedy
 #' # optimization of modularity
 #' # algorithm
-#' graph %>%
+#' graph |>
 #'   get_cmty_fast_greedy()
 #'
 #' # Add the group membership
 #' # values to the graph as a
 #' # node attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_cmty_fast_greedy(.))
+#'     df = get_cmty_fast_greedy(graph))
 #'
 #' # Display the graph's
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_cmty_fast_greedy <- function(graph) {
@@ -58,7 +58,7 @@ get_cmty_fast_greedy <- function(graph) {
 
   # Create df with node memberships
   data.frame(
-    id = igraph::membership(cmty_fast_greedy_obj) %>% names() %>% as.integer(),
+    id = igraph::membership(cmty_fast_greedy_obj) |> names() |> as.integer(),
     f_g_group = as.vector(igraph::membership(cmty_fast_greedy_obj)),
     stringsAsFactors = FALSE)
 }

--- a/R/get_cmty_l_eigenvec.R
+++ b/R/get_cmty_l_eigenvec.R
@@ -15,7 +15,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -27,19 +27,19 @@
 #' # the leading non-negative
 #' # eigenvector of the modularity
 #' # matrix of the graph
-#' graph %>%
+#' graph |>
 #'   get_cmty_l_eigenvec()
 #'
 #' # Add the group membership
 #' # values to the graph as a node
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_cmty_l_eigenvec(.))
+#'     df = get_cmty_l_eigenvec(graph))
 #'
 #' # Display the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_cmty_l_eigenvec <- function(graph) {
@@ -60,7 +60,7 @@ get_cmty_l_eigenvec <- function(graph) {
 
   # Create df with node memberships
   data.frame(
-    id = igraph::membership(cmty_l_eigenvec_obj) %>% names() %>% as.integer(),
+    id = igraph::membership(cmty_l_eigenvec_obj) |> names() |> as.integer(),
     l_eigenvec_group = as.vector(igraph::membership(cmty_l_eigenvec_obj)),
     stringsAsFactors = FALSE)
 }

--- a/R/get_cmty_louvain.R
+++ b/R/get_cmty_louvain.R
@@ -14,7 +14,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -25,20 +25,20 @@
 #' # through the multi-level
 #' # optimization of modularity
 #' # algorithm
-#' graph %>%
+#' graph |>
 #'   get_cmty_louvain()
 #'
 #' # Add the group membership
 #' # values to the graph as a
 #' # node attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_cmty_louvain(.))
+#'     df = get_cmty_louvain(graph))
 #'
 #' # Display the graph's
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_cmty_louvain <- function(graph) {
@@ -59,7 +59,7 @@ get_cmty_louvain <- function(graph) {
 
   # Create df with node memberships
   data.frame(
-    id = igraph::membership(cmty_louvain_obj) %>% names() %>% as.integer(),
+    id = igraph::membership(cmty_louvain_obj) |> names() |> as.integer(),
     louvain_group = as.vector(igraph::membership(cmty_louvain_obj)),
     stringsAsFactors = FALSE)
 }

--- a/R/get_cmty_walktrap.R
+++ b/R/get_cmty_walktrap.R
@@ -15,7 +15,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -25,20 +25,20 @@
 #' # values for all nodes in the
 #' # graph through the Walktrap
 #' # community finding algorithm
-#' graph %>%
+#' graph |>
 #'   get_cmty_walktrap()
 #'
 #' # Add the group membership
 #' # values to the graph as a
 #' # node attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_cmty_walktrap(.))
+#'     df = get_cmty_walktrap(graph))
 #'
 #' # Display the graph's
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_cmty_walktrap <- function(
@@ -59,7 +59,7 @@ get_cmty_walktrap <- function(
 
   # Create df with node memberships
   data.frame(
-    id = igraph::membership(cmty_walktrap_obj) %>% names() %>% as.integer(),
+    id = igraph::membership(cmty_walktrap_obj) |> names() |> as.integer(),
     walktrap_group = as.vector(igraph::membership(cmty_walktrap_obj)),
     stringsAsFactors = FALSE)
 }

--- a/R/get_common_nbrs.R
+++ b/R/get_common_nbrs.R
@@ -12,19 +12,19 @@
 #' @examples
 #' # Create a directed graph with 5 nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 5)
 #'
 #' # Find all common neighbor nodes
 #' # for nodes `1` and `2` (there are no
 #' # common neighbors amongst them)
-#' graph %>%
+#' graph |>
 #'   get_common_nbrs(
 #'     nodes = c(1, 2))
 #'
 #' # Find all common neighbor nodes for
 #' # nodes `1` and `3`
-#' graph %>%
+#' graph |>
 #'   get_common_nbrs(
 #'     nodes = c(1, 3))
 #'

--- a/R/get_coreness.R
+++ b/R/get_coreness.R
@@ -17,7 +17,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -25,18 +25,18 @@
 #'
 #' # Get coreness values for
 #' # all nodes in the graph
-#' graph %>% get_coreness()
+#' graph |> get_coreness()
 #'
 #' # Add the coreness values
 #' # to the graph as a node
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_coreness(.))
+#'     df = get_coreness(graph))
 #'
 #' # Display the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_coreness <- function(
@@ -74,8 +74,8 @@ get_coreness <- function(
 
   # Create df with coreness values
   data.frame(
-    id = coreness_values %>%
-      names() %>%
+    id = coreness_values |>
+      names() |>
       as.integer(),
     coreness = coreness_values,
     stringsAsFactors = FALSE)

--- a/R/get_degree_distribution.R
+++ b/R/get_degree_distribution.R
@@ -17,7 +17,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -25,7 +25,7 @@
 #'
 #' # Get the total degree
 #' # distribution for the graph
-#' graph %>%
+#' graph |>
 #'   get_degree_distribution(
 #'     mode = "total")
 #'

--- a/R/get_degree_histogram.R
+++ b/R/get_degree_histogram.R
@@ -17,7 +17,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -25,7 +25,7 @@
 #'
 #' # Get degree histogram data for
 #' # the graph (reporting total degree)
-#' graph %>%
+#' graph |>
 #'   get_degree_histogram(
 #'     mode = "total")
 #'
@@ -48,8 +48,8 @@ get_degree_histogram <- function(
   if (mode %in% c("all", "total", "both")) {
 
     deg_hist_df <-
-      get_degree_distribution(graph) %>%
-      dplyr::mutate(total_degree_hist = total_degree_dist * count_nodes(graph)) %>%
+      get_degree_distribution(graph) |>
+      dplyr::mutate(total_degree_hist = total_degree_dist * count_nodes(graph)) |>
       dplyr::select("degree", "total_degree_hist")
   }
 
@@ -57,8 +57,8 @@ get_degree_histogram <- function(
   if (mode == "in") {
 
     deg_hist_df <-
-      get_degree_distribution(graph, mode = "in") %>%
-      dplyr::mutate(indegree_hist = indegree_dist * count_nodes(graph)) %>%
+      get_degree_distribution(graph, mode = "in") |>
+      dplyr::mutate(indegree_hist = indegree_dist * count_nodes(graph)) |>
       dplyr::select("degree", "indegree_hist")
   }
 
@@ -66,8 +66,8 @@ get_degree_histogram <- function(
   if (mode == "out") {
 
      deg_hist_df <-
-      get_degree_distribution(graph, mode = "out") %>%
-      dplyr::mutate(outdegree_hist = outdegree_dist * count_nodes(graph)) %>%
+      get_degree_distribution(graph, mode = "out") |>
+      dplyr::mutate(outdegree_hist = outdegree_dist * count_nodes(graph)) |>
       dplyr::select("degree", "outdegree_hist")
   }
 

--- a/R/get_degree_in.R
+++ b/R/get_degree_in.R
@@ -17,7 +17,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -25,20 +25,20 @@
 #'
 #' # Get the indegree values for
 #' # all nodes in the graph
-#' graph %>%
+#' graph |>
 #'   get_degree_in()
 #'
 #' # Add the indegree values
 #' # to the graph as a node
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_degree_in(.))
+#'     df = get_degree_in(graph))
 #'
 #' # Display the graph's
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_degree_in <- function(
@@ -72,8 +72,8 @@ get_degree_in <- function(
 
   # Create df with indegree scores
   data.frame(
-    id = indegree_values %>%
-      names() %>%
+    id = indegree_values |>
+      names() |>
       as.integer(),
     indegree = indegree_values,
     stringsAsFactors = FALSE)

--- a/R/get_degree_out.R
+++ b/R/get_degree_out.R
@@ -17,7 +17,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -25,20 +25,20 @@
 #'
 #' # Get the outdegree values
 #' # for all nodes in the graph
-#' graph %>%
+#' graph |>
 #'   get_degree_out()
 #'
 #' # Add the outdegree values
 #' # to the graph as a node
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_degree_out(.))
+#'     df = get_degree_out(graph))
 #'
 #' # Display the graph's
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_degree_out <- function(
@@ -72,8 +72,8 @@ get_degree_out <- function(
 
   # Create df with outdegree scores
   data.frame(
-    id = outdegree_values %>%
-      names() %>%
+    id = outdegree_values |>
+      names() |>
       as.integer(),
     outdegree = outdegree_values,
     stringsAsFactors = FALSE)

--- a/R/get_degree_total.R
+++ b/R/get_degree_total.R
@@ -17,7 +17,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -25,20 +25,20 @@
 #'
 #' # Get the total degree values
 #' # for all nodes in the graph
-#' graph %>%
+#' graph |>
 #'   get_degree_total()
 #'
 #' # Add the total degree values
 #' # to the graph as a node
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_degree_total(.))
+#'     df = get_degree_total(graph))
 #'
 #' # Display the graph's
 #' # node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_degree_total <- function(
@@ -72,8 +72,8 @@ get_degree_total <- function(
 
   # Create df with total degree scores
   data.frame(
-    id = total_degree_values %>%
-      names() %>%
+    id = total_degree_values |>
+      names() |>
       as.integer(),
     total_degree = total_degree_values,
     stringsAsFactors = FALSE)

--- a/R/get_dice_similarity.R
+++ b/R/get_dice_similarity.R
@@ -23,7 +23,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -32,7 +32,7 @@
 #' # Get the Dice similarity
 #' # values for nodes `5`, `6`,
 #' # and `7`
-#' graph %>%
+#' graph |>
 #'   get_dice_similarity(
 #'     nodes = 5:7)
 #'

--- a/R/get_eccentricity.R
+++ b/R/get_eccentricity.R
@@ -19,7 +19,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -27,7 +27,7 @@
 #'
 #' # Get the eccentricity values for
 #' # all nodes in the graph
-#' graph %>% get_eccentricity()
+#' graph |> get_eccentricity()
 #'
 #' @export
 get_eccentricity <- function(
@@ -53,8 +53,8 @@ get_eccentricity <- function(
   # Create a data frame with node ID values
   # and eccentrity values
   data.frame(
-    id = eccentricity %>%
-      names() %>%
+    id = eccentricity |>
+      names() |>
       as.integer(),
     eccentricity = eccentricity,
     stringsAsFactors = FALSE)

--- a/R/get_edge_attrs.R
+++ b/R/get_edge_attrs.R
@@ -20,33 +20,34 @@
 #' # edges have an edge attribute
 #' # named `value`
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 4) %>%
-#'   {
-#'     edges <-
-#'       create_edge_df(
-#'         from = c(1, 2, 1, 4),
-#'           to = c(2, 3, 4, 3),
-#'          rel = "rel")
-#'     add_edge_df(
-#'       graph = .,
-#'       edge_df = edges)
-#'   } %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 4)
+#'
+#' edges <-
+#'   create_edge_df(
+#'     from = c(1, 2, 1, 4),
+#'       to = c(2, 3, 4, 3),
+#'      rel = "rel")
+#'
+#' graph <-
+#'   add_edge_df(
+#'     graph = graph,
+#'     edge_df = edges) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = 1.6,
 #'     from = 1,
-#'       to = 2) %>%
+#'       to = 2) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = 4.3,
 #'     from = 1,
-#'       to = 4) %>%
+#'       to = 4) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = 2.9,
 #'     from = 2,
-#'       to = 3) %>%
+#'       to = 3) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = 8.4,
@@ -55,14 +56,14 @@
 #'
 #' # Get the values for the
 #' # `value` edge attribute
-#' graph %>%
+#' graph |>
 #'   get_edge_attrs(
 #'     edge_attr = value)
 #'
 #' # To only return edge attribute
 #' # values for specified edges, use
 #' # the `from` and `to` arguments
-#' graph %>%
+#' graph |>
 #'   get_edge_attrs(
 #'     edge_attr = value,
 #'     from = c(1, 2),
@@ -81,7 +82,7 @@ get_edge_attrs <- function(
 
   edge_attr <- rlang::enquo(edge_attr)
 
-  if (rlang::get_expr(edge_attr) %>%
+  if (rlang::get_expr(edge_attr) |>
       as.character() %in% c("id", "from", "to")) {
 
     cli::cli_abort(
@@ -101,7 +102,7 @@ get_edge_attrs <- function(
 
     # Extract the edge attribute values
     edge_attr_vals <-
-      edf %>%
+      edf |>
       dplyr::pull(!!edge_attr)
 
     # Extract the edge names
@@ -121,13 +122,13 @@ get_edge_attrs <- function(
     # Filter the edf by the supplied
     # edge definitions
     edf <-
-      edf %>%
-      dplyr::mutate(from_to = paste(from, to, sep = "->")) %>%
+      edf |>
+      dplyr::mutate(from_to = paste(from, to, sep = "->")) |>
       dplyr::filter(from_to %in% edges)
 
     # Extract the edge attribute values
     edge_attr_vals <-
-      edf %>%
+      edf |>
       dplyr::pull(!!edge_attr)
 
     # Extract the edge names

--- a/R/get_edge_attrs_ws.R
+++ b/R/get_edge_attrs_ws.R
@@ -27,33 +27,34 @@
 #' # edges have an edge attribute
 #' # named `value`
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 4) %>%
-#'   {
-#'     edges <-
-#'       create_edge_df(
-#'         from = c(1, 2, 1, 4),
-#'           to = c(2, 3, 4, 3),
-#'          rel = "rel")
-#'     add_edge_df(
-#'       graph = .,
-#'       edge_df = edges)
-#'   } %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 4)
+#'
+#' edges <-
+#'   create_edge_df(
+#'     from = c(1, 2, 1, 4),
+#'       to = c(2, 3, 4, 3),
+#'      rel = "rel")
+#'
+#' graph <-
+#'   add_edge_df(
+#'     graph = graph,
+#'     edge_df = edges) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = 1.6,
 #'     from = 1,
-#'       to = 2) %>%
+#'       to = 2) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = 4.3,
 #'     from = 1,
-#'       to = 4) %>%
+#'       to = 4) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = 2.9,
 #'     from = 2,
-#'       to = 3) %>%
+#'       to = 3) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = 8.4,
@@ -63,7 +64,7 @@
 #' # Select the edges defined as
 #' # `1`->`3` and `2`->`3`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges(
 #'     from = c(1, 2),
 #'     to = c(2, 3))
@@ -71,7 +72,7 @@
 #' # Get the edge attribute values
 #' # for the `value` attribute, limited
 #' # to the current edge selection
-#' graph %>%
+#' graph |>
 #'   get_edge_attrs_ws(
 #'     edge_attr = value)
 #'
@@ -89,8 +90,8 @@ get_edge_attrs_ws <- function(
 
   edge_attr <- rlang::enquo(edge_attr)
 
-  if (rlang::enquo(edge_attr) %>%
-      rlang::get_expr() %>%
+  if (rlang::enquo(edge_attr) |>
+      rlang::get_expr() |>
       as.character() %in% c("id", "from", "to")) {
 
     cli::cli_abort(
@@ -107,11 +108,11 @@ get_edge_attrs_ws <- function(
   # Filter the edf by the supplied
   # edge ID values
   edf <-
-    edf %>%
+    edf |>
     dplyr::filter(id %in% edges)
 
   # Extract the edge attribute values
-  edge_attr_vals <- edf %>% dplyr::pull(!!edge_attr)
+  edge_attr_vals <- edf |> dplyr::pull(!!edge_attr)
 
   # Extract the edge names
   edge_names <- paste(edf$from, edf$to, sep = "->")

--- a/R/get_edge_count_w_multiedge.R
+++ b/R/get_edge_count_w_multiedge.R
@@ -36,7 +36,7 @@
 #' # there are multiple edges (i.e.,
 #' # distinct edges with separate edge
 #' # ID values)
-#' graph %>% get_edge_count_w_multiedge()
+#' graph |> get_edge_count_w_multiedge()
 #'
 #' @export
 get_edge_count_w_multiedge <- function(graph) {
@@ -51,12 +51,12 @@ get_edge_count_w_multiedge <- function(graph) {
   # regardless of which definitions these
   # edges have
   multiedge_distinct_edge_def_count <-
-    graph$edges_df %>%
-    dplyr::select(from, to) %>%
-    dplyr::mutate(edge_from_to = paste0(from, "_", to), .keep = "none") %>%
-    dplyr::group_by(edge_from_to) %>%
-    dplyr::summarize(n = dplyr::n(), .groups = "drop") %>%
-    dplyr::filter(n > 1) %>%
+    graph$edges_df |>
+    dplyr::select(from, to) |>
+    dplyr::mutate(edge_from_to = paste0(from, "_", to), .keep = "none") |>
+    dplyr::group_by(edge_from_to) |>
+    dplyr::summarize(n = dplyr::n(), .groups = "drop") |>
+    dplyr::filter(n > 1) |>
     nrow()
 
   multiedge_distinct_edge_def_count

--- a/R/get_edge_df.R
+++ b/R/get_edge_df.R
@@ -11,35 +11,35 @@
 #' @examples
 #' # Create a graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 1,
-#'     type = "a") %>%
-#'   select_last_nodes_created() %>%
+#'     type = "a") |>
+#'   select_last_nodes_created() |>
 #'   add_n_nodes_ws(
 #'     n = 5,
 #'     direction = "from",
-#'     type = "b") %>%
+#'     type = "b") |>
 #'   select_edges_by_node_id(
-#'     nodes = 3:5) %>%
+#'     nodes = 3:5) |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = color,
-#'     value = "green") %>%
+#'     value = "green") |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = rel,
-#'     value = "a") %>%
-#'   invert_selection %>%
+#'     value = "a") |>
+#'   invert_selection() |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = color,
-#'     value = "blue") %>%
+#'     value = "blue") |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = rel,
-#'     value = "b") %>%
+#'     value = "b") |>
 #'   clear_selection()
 #'
 #' # Get the graph's internal
 #' # edge data frame (edf)
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @export
 get_edge_df <- function(graph) {

--- a/R/get_edge_df_ws.R
+++ b/R/get_edge_df_ws.R
@@ -24,11 +24,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 4,
 #'     m = 4,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = c(2.5, 8.2, 4.2, 2.4))
@@ -36,14 +36,14 @@
 #' # Select edges with ID values
 #' # `1` and `3`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges_by_edge_id(
 #'     edges = c(1, 3))
 #'
 #' # Get the edge data frame that's
 #' # limited to the rows that correspond
 #' # to the edge selection
-#' graph %>% get_edge_df_ws()
+#' graph |> get_edge_df_ws()
 #'
 #' @export
 get_edge_df_ws <- function(graph) {
@@ -57,6 +57,6 @@ get_edge_df_ws <- function(graph) {
   # Extract the edge data frame (edf)
   # from the graph and get only those edges
   # from the edges selection
-  graph$edges_df %>%
+  graph$edges_df |>
     dplyr::filter(id %in% graph$edge_selection$edge)
 }

--- a/R/get_edge_ids.R
+++ b/R/get_edge_ids.R
@@ -36,7 +36,7 @@
 #'     edges_df = edf)
 #'
 #' # Get a vector of all edges in a graph
-#' graph %>% get_edge_ids()
+#' graph |> get_edge_ids()
 #'
 #' # Get a vector of edge ID values using a
 #' # numeric comparison (i.e., all edges with
@@ -88,5 +88,5 @@ get_edge_ids <- function(
     return(NA)
   }
 
-  edges_df %>% dplyr::pull("id")
+  edges_df |> dplyr::pull("id")
 }

--- a/R/get_edge_info.R
+++ b/R/get_edge_info.R
@@ -13,14 +13,14 @@
 #' @examples
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5, m = 10,
 #'     set_seed = 23)
 #'
 #' # Get information on the
 #' # graph's edges
-#' graph %>% get_edge_info()
+#' graph |> get_edge_info()
 #'
 #' @export
 get_edge_info <- function(graph) {
@@ -35,6 +35,6 @@ get_edge_info <- function(graph) {
 
   # Extract only the first 4 columns of the
   # edge data frame
-  graph$edges_df %>%
+  graph$edges_df |>
     dplyr::select(id, from, to, rel)
 }

--- a/R/get_edges.R
+++ b/R/get_edges.R
@@ -47,18 +47,18 @@
 #'     edges_df = edf)
 #'
 #' # Get all edges within a graph, returned as a list
-#' graph %>%
+#' graph |>
 #'   get_edges(
 #'     return_type = "vector")
 #'
 #' # Get all edges within a graph, returned as a
 #' # data frame
-#' graph %>%
+#' graph |>
 #'   get_edges(
 #'     return_type = "df")
 #'
 #' # Get all edges returned as a list
-#' graph %>%
+#' graph |>
 #'   get_edges(
 #'     return_type = "list")
 #'
@@ -66,14 +66,14 @@
 #' # a numeric comparison (i.e.,
 #' # all edges with a `value`
 #' # attribute greater than 3)
-#' graph %>%
+#' graph |>
 #'   get_edges(
 #'     conditions = value > 3,
 #'     return_type = "vector")
 #'
 #' # Get a vector of edges using
 #' # a matching condition
-#' graph %>%
+#' graph |>
 #'   get_edges(
 #'     conditions = color == "pink",
 #'     return_type = "vector")
@@ -81,7 +81,7 @@
 #' # Use multiple conditions to
 #' # return edges with the
 #' # desired attribute values
-#' graph %>%
+#' graph |>
 #'   get_edges(
 #'     conditions =
 #'       color == "blue" &
@@ -91,7 +91,7 @@
 #' # Use `return_values = "label"`
 #' # to return the labels of the
 #' # connected nodes
-#' graph %>%
+#' graph |>
 #'   get_edges(
 #'     conditions =
 #'       color == "blue" &
@@ -112,9 +112,9 @@ get_edges <- function(
 
   if (return_values == "label") {
     edges_df <-
-      edges_df %>%
-      dplyr::left_join(graph$nodes_df %>% dplyr::select("id", from_label_ = "label"), by = c("from" = "id")) %>%
-      dplyr::left_join(graph$nodes_df %>% dplyr::select("id", to_label_ = "label"), by = c("to" = "id"))
+      edges_df |>
+      dplyr::left_join(graph$nodes_df |> dplyr::select("id", from_label_ = "label"), by = c("from" = "id")) |>
+      dplyr::left_join(graph$nodes_df |> dplyr::select("id", to_label_ = "label"), by = c("to" = "id"))
   }
 
 
@@ -151,11 +151,11 @@ get_edges <- function(
 
     if (return_values == "id") {
       edges_df <-
-        edges_df %>%
+        edges_df |>
         dplyr::select("from", "to")
     } else if (return_values == "label") {
       edges_df <-
-        edges_df %>%
+        edges_df |>
         dplyr::select("from_label_", "to_label_")
     }
 

--- a/R/get_eigen_centrality.R
+++ b/R/get_eigen_centrality.R
@@ -16,14 +16,14 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10, m = 15,
 #'     set_seed = 23)
 #'
 #' # Get the eigen centrality scores
 #' # for nodes in the graph
-#' graph %>% get_eigen_centrality()
+#' graph |> get_eigen_centrality()
 #'
 #' @export
 get_eigen_centrality <- function(
@@ -64,7 +64,7 @@ get_eigen_centrality <- function(
 
   # Create df with eigen centrality values
   data.frame(
-    id = names(eigen_centrality_values$vector) %>% as.integer(),
-    eigen_centrality = unname(eigen_centrality_values$vector) %>% round(4),
+    id = names(eigen_centrality_values$vector) |> as.integer(),
+    eigen_centrality = unname(eigen_centrality_values$vector) |> round(4),
     stringsAsFactors = FALSE)
 }

--- a/R/get_girth.R
+++ b/R/get_girth.R
@@ -14,16 +14,16 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Determine the graph's girth
-#' graph %>% get_girth()
+#' graph |> get_girth()
 #'
 #' # Create a full graph and then
 #' # get the girth for that
-#' create_graph() %>%
-#'   add_full_graph(n = 10) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 10) |>
 #'   get_girth()
 #'
 #' @export

--- a/R/get_global_graph_attr_info.R
+++ b/R/get_global_graph_attr_info.R
@@ -14,7 +14,7 @@
 #'
 #' # View the graph's set of
 #' # global attributes
-#' graph %>%
+#' graph |>
 #'   get_global_graph_attr_info()
 #'
 #' @export

--- a/R/get_graph_actions.R
+++ b/R/get_graph_actions.R
@@ -15,7 +15,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -28,7 +28,7 @@
 #' # to provide betweenness values in the
 #' # `btwns` column
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_graph_action(
 #'     fcn = "set_node_attr_w_fcn",
 #'     node_attr_fcn = "get_betweenness",
@@ -38,7 +38,7 @@
 #' # To ensure that the action is
 #' # available in the graph, use the
 #' # `get_graph_actions()` function
-#' graph %>% get_graph_actions()
+#' graph |> get_graph_actions()
 #'
 #' @export
 get_graph_actions <- function(graph) {

--- a/R/get_graph_from_graph_series.R
+++ b/R/get_graph_from_graph_series.R
@@ -10,31 +10,31 @@
 #' @examples
 #' # Create three graphs
 #' graph_1 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 4)
 #'
 #' graph_2 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' graph_3 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_star(n = 6)
 #'
 #' # Create an empty graph series
 #' # and add the graphs
 #' series <-
-#'   create_graph_series() %>%
+#'   create_graph_series() |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_1) %>%
+#'     graph = graph_1) |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_2) %>%
+#'     graph = graph_2) |>
 #'   add_graph_to_graph_series(
 #'     graph = graph_3)
 #'
 #' # Get the second graph in the series
 #' extracted_graph <-
-#'   series %>%
+#'   series |>
 #'   get_graph_from_graph_series(
 #'     graph_no = 2)
 #'

--- a/R/get_graph_info.R
+++ b/R/get_graph_info.R
@@ -15,13 +15,13 @@
 #' karate_club <-
 #'   system.file(
 #'     "extdata", "karate.gml",
-#'     package = "DiagrammeR") %>%
-#'   import_graph() %>%
+#'     package = "DiagrammeR") |>
+#'   import_graph() |>
 #'   set_graph_name("karate")
 #'
 #' # Display a data frame with
 #' # graph information
-#' karate_club %>%
+#' karate_club |>
 #'   get_graph_info()
 #' }
 #'

--- a/R/get_graph_log.R
+++ b/R/get_graph_log.R
@@ -15,17 +15,17 @@
 #' # delete 2 nodes from the graph
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
-#'     set_seed = 23) %>%
-#'   delete_node(node = 5) %>%
+#'     set_seed = 23) |>
+#'   delete_node(node = 5) |>
 #'   delete_node(node = 7)
 #'
 #' # Get the graph log, which is a
 #' # record of all graph transformations
-#' graph %>% get_graph_log()
+#' graph |> get_graph_log()
 #'
 #' @export
 get_graph_log <- function(graph) {

--- a/R/get_graph_name.R
+++ b/R/get_graph_name.R
@@ -20,7 +20,7 @@
 #'     name = "the_name")
 #'
 #' # Get the graph's name
-#' graph %>% get_graph_name()
+#' graph |> get_graph_name()
 #'
 #' @export
 get_graph_name <- function(graph) {

--- a/R/get_graph_series_info.R
+++ b/R/get_graph_series_info.R
@@ -12,30 +12,30 @@
 #' @examples
 #' # Create three graphs
 #' graph_1 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 4)
 #'
 #' graph_2 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' graph_3 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_star(n = 6)
 #'
 #' # Create an empty graph series
 #' # and add the graphs
 #' series <-
-#'   create_graph_series() %>%
+#'   create_graph_series() |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_1) %>%
+#'     graph = graph_1) |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_2) %>%
+#'     graph = graph_2) |>
 #'   add_graph_to_graph_series(
 #'     graph = graph_3)
 #'
 #' # Get information on the graphs in the series
-#' series %>% get_graph_series_info()
+#' series |> get_graph_series_info()
 #'
 #' @export
 get_graph_series_info <- function(graph_series) {
@@ -52,7 +52,7 @@ get_graph_series_info <- function(graph_series) {
       nodes = integer(),
       edges = integer(),
       directed = logical()
-    ) %>%
+    ) |>
     as.data.frame(stringsAsFactors = FALSE)
 
   if (graphs_in_series == 0) {

--- a/R/get_graph_time.R
+++ b/R/get_graph_time.R
@@ -14,13 +14,13 @@
 #' # is supplied for the `tz` argument,
 #' # `GMT` is used as the time zone
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'     set_graph_time(
 #'       time = "2015-10-25 15:23:00")
 #'
 #' # Get the graph's time as a POSIXct
 #' # object using `get_graph_time()`
-#' graph %>% get_graph_time()
+#' graph |> get_graph_time()
 #'
 #' @export
 get_graph_time <- function(graph) {

--- a/R/get_jaccard_similarity.R
+++ b/R/get_jaccard_similarity.R
@@ -23,7 +23,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -32,7 +32,7 @@
 #' # Get the Jaccard similarity
 #' # values for nodes `5`, `6`,
 #' # and `7`
-#' graph %>%
+#' graph |>
 #'   get_jaccard_similarity(
 #'     nodes = 5:7)
 #'

--- a/R/get_last_edges_created.R
+++ b/R/get_last_edges_created.R
@@ -13,17 +13,17 @@
 #' # Create a graph and add a cycle and then
 #' # a tree in 2 separate function calls
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(
 #'     n = 3,
-#'     rel = "a") %>%
+#'     rel = "a") |>
 #'   add_balanced_tree(
 #'     k = 2, h = 2,
 #'     rel = "b")
 #'
 #' # Get the last edges created (all edges
 #' # from the tree)
-#' graph %>% get_last_edges_created()
+#' graph |> get_last_edges_created()
 #'
 #' @export
 get_last_edges_created <- function(graph) {
@@ -35,25 +35,25 @@ get_last_edges_created <- function(graph) {
   check_graph_contains_edges(graph)
 
   graph_transform_steps <-
-    graph$graph_log %>%
+    graph$graph_log |>
     dplyr::mutate(
       step_created_edges = as.integer(function_used %in% edge_creation_functions()),
       step_deleted_edges = as.integer(function_used %in% edge_deletion_functions()),
       step_init_with_edges = as.integer(function_used %in% graph_init_functions() &
                                           edges > 0)
-    ) %>%
+    ) |>
     dplyr::filter(
       dplyr::if_any(
         .cols = c(step_created_edges, step_deleted_edges, step_init_with_edges),
         .fns = function(x) x == 1
         )
-    ) %>%
+    ) |>
     dplyr::select(-"version_id", -"time_modified", -"duration")
 
   if (nrow(graph_transform_steps) > 0) {
 
-    if (graph_transform_steps %>%
-        utils::tail(1) %>%
+    if (graph_transform_steps |>
+        utils::tail(1) |>
         dplyr::pull(step_deleted_edges) == 1) {
 
       abort("The previous graph transformation function resulted in a removal of edges.")
@@ -61,25 +61,25 @@ get_last_edges_created <- function(graph) {
     } else {
       if (nrow(graph_transform_steps) > 1) {
         number_of_edges_created <-
-          (graph_transform_steps %>%
-             dplyr::select("edges") %>%
-             utils::tail(2) %>%
+          (graph_transform_steps |>
+             dplyr::select("edges") |>
+             utils::tail(2) |>
              dplyr::pull("edges"))[2] -
-          (graph_transform_steps %>%
-             dplyr::select("edges") %>%
-             utils::tail(2) %>%
+          (graph_transform_steps |>
+             dplyr::select("edges") |>
+             utils::tail(2) |>
              dplyr::pull("edges"))[1]
       } else {
         number_of_edges_created <-
-          graph_transform_steps %>%
+          graph_transform_steps |>
           dplyr::pull("edges")
       }
     }
 
     edge_id_values <-
-      graph$edges_df %>%
-      dplyr::select("id") %>%
-      utils::tail(number_of_edges_created) %>%
+      graph$edges_df |>
+      dplyr::select("id") |>
+      utils::tail(number_of_edges_created) |>
       dplyr::pull("id")
   } else {
     edge_id_values <- NA

--- a/R/get_last_nodes_created.R
+++ b/R/get_last_nodes_created.R
@@ -14,11 +14,11 @@
 #' # Create a graph and add 4 nodes
 #' # in 2 separate function calls
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("a_1", "a_2")) %>%
+#'     label = c("a_1", "a_2")) |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "b",
@@ -26,7 +26,7 @@
 #'
 #' # Get the last nodes created (2 nodes
 #' # from the last function call)
-#' graph %>% get_last_nodes_created()
+#' graph |> get_last_nodes_created()
 #'
 #' @export
 get_last_nodes_created <- function(graph) {
@@ -38,26 +38,26 @@ get_last_nodes_created <- function(graph) {
   check_graph_contains_nodes(graph)
 
   graph_transform_steps <-
-    graph$graph_log %>%
+    graph$graph_log |>
     dplyr::mutate(
       step_created_nodes = as.integer(function_used %in% node_creation_functions()),
       step_deleted_nodes = as.integer(function_used %in% node_deletion_functions()),
       step_init_with_nodes = as.integer(function_used %in% graph_init_functions() &
                                           nodes > 0)
-    ) %>%
+    ) |>
     dplyr::filter(
       # if any step is TRUE (1)
       dplyr::if_any(
         .cols = c(step_created_nodes, step_deleted_nodes, step_init_with_nodes),
         .fns = function(x) x == 1
         )
-    ) %>%
+    ) |>
     dplyr::select(-"version_id", -"time_modified", -"duration")
 
   if (nrow(graph_transform_steps) > 0) {
 
-    if (graph_transform_steps %>%
-        utils::tail(1) %>%
+    if (graph_transform_steps |>
+        utils::tail(1) |>
         dplyr::pull(step_deleted_nodes) == 1) {
 
       cli::cli_abort(
@@ -66,25 +66,25 @@ get_last_nodes_created <- function(graph) {
     } else {
       if (nrow(graph_transform_steps) > 1) {
         number_of_nodes_created <-
-          (graph_transform_steps %>%
-             dplyr::select(nodes) %>%
-             utils::tail(2) %>%
+          (graph_transform_steps |>
+             dplyr::select(nodes) |>
+             utils::tail(2) |>
              dplyr::pull(nodes))[2] -
-          (graph_transform_steps %>%
-             dplyr::select(nodes) %>%
-             utils::tail(2) %>%
+          (graph_transform_steps |>
+             dplyr::select(nodes) |>
+             utils::tail(2) |>
              dplyr::pull(nodes))[1]
       } else {
         number_of_nodes_created <-
-          graph_transform_steps %>%
+          graph_transform_steps |>
           dplyr::pull("nodes")
       }
     }
 
     node_id_values <-
-      graph$nodes_df %>%
-      dplyr::select("id") %>%
-      utils::tail(number_of_nodes_created) %>%
+      graph$nodes_df |>
+      dplyr::select("id") |>
+      utils::tail(number_of_nodes_created) |>
       dplyr::pull("id")
   } else {
     node_id_values <- NA

--- a/R/get_leverage_centrality.R
+++ b/R/get_leverage_centrality.R
@@ -19,7 +19,7 @@
 #' # `add_gnm_graph()` function
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -27,19 +27,19 @@
 #'
 #' # Get leverage centrality values
 #' # for all nodes in the graph
-#' graph %>%
+#' graph |>
 #'   get_leverage_centrality()
 #'
 #' # Add the leverage centrality
 #' # values to the graph as a
 #' # node attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_leverage_centrality(.))
+#'     df = get_leverage_centrality(graph))
 #'
 #' # Display the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 get_leverage_centrality <- function(graph) {
@@ -62,14 +62,14 @@ get_leverage_centrality <- function(graph) {
         mean(
           (degree_vals[x] - degree_vals[igraph::neighbors(ig_graph, degree_vals)]) /
             (degree_vals[x] + degree_vals[igraph::neighbors(ig_graph, degree_vals)]))
-      }) %>%
+      }) |>
     unlist()
 
   # Create df with leverage centrality values
   data.frame(
-    id = degree_vals %>%
-      names() %>%
+    id = degree_vals |>
+      names() |>
       as.integer(),
-    leverage_centrality = leverage_centrality_values %>% round(4),
+    leverage_centrality = leverage_centrality_values |> round(4),
     stringsAsFactors = FALSE)
 }

--- a/R/get_max_eccentricity.R
+++ b/R/get_max_eccentricity.R
@@ -14,19 +14,19 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Determine the graph's maximum
 #' # eccentricity
-#' graph %>%
+#' graph |>
 #'   get_max_eccentricity()
 #'
 #' # Create a full graph and then
 #' # get the maximum eccentricity
 #' # value for that
-#' create_graph() %>%
-#'   add_full_graph(n = 10) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 10) |>
 #'   get_max_eccentricity()
 #'
 #' @export

--- a/R/get_mean_distance.R
+++ b/R/get_mean_distance.R
@@ -13,17 +13,17 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Determine the mean distance
-#' graph %>%
+#' graph |>
 #'   get_mean_distance()
 #'
 #' # Create a full graph and then
 #' # get the mean distance value
-#' create_graph() %>%
-#'   add_full_graph(n = 10) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 10) |>
 #'   get_mean_distance()
 #'
 #' @export

--- a/R/get_min_cut_between.R
+++ b/R/get_min_cut_between.R
@@ -20,12 +20,12 @@
 #'
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Determine the minimum cut
 #' # between nodes `1` and `4`
-#' graph %>%
+#' graph |>
 #'   get_min_cut_between(
 #'     from = 1,
 #'     to = 2)
@@ -34,23 +34,23 @@
 #' # randomized values given to all
 #' # edges as the `capacity` attribute
 #' graph_capacity <-
-#'   create_graph() %>%
-#'   add_cycle(n = 5) %>%
-#'   select_edges() %>%
+#'   create_graph() |>
+#'   add_cycle(n = 5) |>
+#'   select_edges() |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = capacity,
 #'     value =
 #'       rnorm(
-#'         n = count_edges(.),
+#'         n = 5,
 #'         mean = 5,
-#'         sd = 1)) %>%
+#'         sd = 1)) |>
 #'   clear_selection()
 #'
 #' # Determine the minimum cut
 #' # between nodes `1` and `4` for
 #' # this graph, where `capacity`is
 #' # set as an edge attribute
-#' graph_capacity %>%
+#' graph_capacity |>
 #'   get_min_cut_between(
 #'     from = 1,
 #'     to = 2)
@@ -58,8 +58,8 @@
 #' # Create a full graph and then
 #' # get the minimum cut requirement
 #' # between nodes `2` and `8`
-#' create_graph() %>%
-#'   add_full_graph(n = 10) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 10) |>
 #'   get_min_cut_between(
 #'     from = 2,
 #'     to = 8)

--- a/R/get_min_eccentricity.R
+++ b/R/get_min_eccentricity.R
@@ -18,19 +18,19 @@
 #' @examples
 #' # Create a cycle graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Determine the graph's minimum
 #' # eccentricity
-#' graph %>%
+#' graph |>
 #'   get_min_eccentricity()
 #'
 #' # Create a full graph and then
 #' # get the minimum eccentricity
 #' # value for that
-#' create_graph() %>%
-#'   add_full_graph(n = 10) %>%
+#' create_graph() |>
+#'   add_full_graph(n = 10) |>
 #'   get_min_eccentricity()
 #'
 #' @export

--- a/R/get_multiedge_count.R
+++ b/R/get_multiedge_count.R
@@ -34,7 +34,7 @@
 #' # Get the total number of multiple
 #' # edges (those edges that share an
 #' # edge definition) in the graph
-#' graph %>% get_multiedge_count()
+#' graph |> get_multiedge_count()
 #'
 #' @export
 get_multiedge_count <- function(graph) {
@@ -49,10 +49,10 @@ get_multiedge_count <- function(graph) {
   # regardless of which definitions these
   # edges have
   multiedge_count <-
-    (graph$edges_df %>%
+    (graph$edges_df |>
        nrow()) -
-    (graph$edges_df %>%
-       dplyr::distinct(from, to) %>%
+    (graph$edges_df |>
+       dplyr::distinct(from, to) |>
        nrow())
 
   multiedge_count

--- a/R/get_nbrs.R
+++ b/R/get_nbrs.R
@@ -13,29 +13,29 @@
 #' # Create a simple, directed graph with 5
 #' # nodes and 4 edges
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 5)
 #'
 #' # Find all neighbor nodes for node `2`
-#' graph %>% get_nbrs(nodes = 2)
+#' graph |> get_nbrs(nodes = 2)
 #'
 #' # Find all neighbor nodes for nodes `1`
 #' # and `5`
-#' graph %>% get_nbrs(nodes = c(1, 5))
+#' graph |> get_nbrs(nodes = c(1, 5))
 #'
 #' # Color node `3` with purple, get its
 #' # neighbors and color those nodes green
 #' graph <-
-#'   graph %>%
-#'   select_nodes_by_id(nodes = 3) %>%
+#'   graph |>
+#'   select_nodes_by_id(nodes = 3) |>
 #'   set_node_attrs_ws(
 #'     node_attr = color,
-#'     value = "purple") %>%
-#'   clear_selection() %>%
+#'     value = "purple") |>
+#'   clear_selection() |>
 #'   select_nodes_by_id(
 #'     nodes = get_nbrs(
-#'       graph = .,
-#'       nodes = 3)) %>%
+#'       graph = graph,
+#'       nodes = 3)) |>
 #'   set_node_attrs_ws(
 #'     node_attr = color,
 #'     value = "green")

--- a/R/get_node_attrs.R
+++ b/R/get_node_attrs.R
@@ -17,11 +17,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 4,
 #'     m = 4,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = c(2.5, 8.2, 4.2, 2.4))
@@ -29,14 +29,14 @@
 #' # Get all of the values from
 #' # the `value` node attribute
 #' # as a named vector
-#' graph %>%
+#' graph |>
 #'   get_node_attrs(
 #'     node_attr = value)
 #'
 #' # To only return node attribute
 #' # values for specified nodes,
 #' # use the `nodes` argument
-#' graph %>%
+#' graph |>
 #'   get_node_attrs(
 #'     node_attr = value,
 #'     nodes = c(1, 3))
@@ -53,8 +53,8 @@ get_node_attrs <- function(
 
   node_attr <- rlang::enquo(node_attr)
 
-  if (rlang::enquo(node_attr) %>%
-      rlang::get_expr() %>%
+  if (rlang::enquo(node_attr) |>
+      rlang::get_expr() |>
       as.character() %in% c("id", "nodes")) {
 
     cli::cli_abort(
@@ -68,7 +68,7 @@ get_node_attrs <- function(
   if (is.null(nodes)) {
 
     # Extract the node attribute values
-    node_attr_vals <- ndf %>% dplyr::pull(!!node_attr)
+    node_attr_vals <- ndf |> dplyr::pull(!!node_attr)
 
     # Extract the node names
     node_names <- ndf$id
@@ -84,11 +84,11 @@ get_node_attrs <- function(
     # Filter the ndf by the supplied
     # nodes
     ndf <-
-      ndf %>%
+      ndf |>
       dplyr::filter(id %in% nodes)
 
     # Extract the node attribute values
-    node_attr_vals <- ndf %>% dplyr::pull(!!node_attr)
+    node_attr_vals <- ndf |> dplyr::pull(!!node_attr)
 
     # Extract the node names
     node_names <- ndf$id

--- a/R/get_node_attrs_ws.R
+++ b/R/get_node_attrs_ws.R
@@ -28,11 +28,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 4,
 #'     m = 4,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = c(2.5, 8.2, 4.2, 2.4))
@@ -40,14 +40,14 @@
 #' # Select nodes with ID values
 #' # `1` and `3`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_id(
 #'     nodes = c(1, 3))
 #'
 #' # Get the node attribute values
 #' # for the `value` attribute, limited
 #' # to the current node selection
-#' graph %>%
+#' graph |>
 #'   get_node_attrs_ws(
 #'     node_attr = value)
 #'
@@ -65,8 +65,8 @@ get_node_attrs_ws <- function(
 
   node_attr <- rlang::enquo(node_attr)
 
-  if (rlang::enquo(node_attr) %>%
-      rlang::get_expr() %>%
+  if (rlang::enquo(node_attr) |>
+      rlang::get_expr() |>
       as.character() %in% c("id", "nodes")) {
 
     cli::cli_abort(
@@ -83,11 +83,11 @@ get_node_attrs_ws <- function(
   # Filter the ndf by the supplied
   # node ID values
   ndf <-
-    ndf %>%
+    ndf |>
     dplyr::filter(id %in% nodes)
 
   # Extract the node attribute values
-  node_attr_vals <- ndf %>% dplyr::pull(!!node_attr)
+  node_attr_vals <- ndf |> dplyr::pull(!!node_attr)
 
   # Add names to each of the values
   names(node_attr_vals) <- nodes

--- a/R/get_node_df.R
+++ b/R/get_node_df.R
@@ -11,35 +11,35 @@
 #' @examples
 #' # Create a graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 1,
-#'     type = "a") %>%
-#'   select_last_nodes_created() %>%
+#'     type = "a") |>
+#'   select_last_nodes_created() |>
 #'   add_n_nodes_ws(
 #'     n = 5,
 #'     direction = "from",
-#'     type = "b") %>%
+#'     type = "b") |>
 #'   select_nodes_by_id(
-#'     nodes = 1) %>%
+#'     nodes = 1) |>
 #'   set_node_attrs_ws(
 #'     node_attr = value,
-#'     value = 25.3) %>%
-#'   clear_selection() %>%
+#'     value = 25.3) |>
+#'   clear_selection() |>
 #'   select_nodes_by_id(
-#'     nodes = 2:4) %>%
+#'     nodes = 2:4) |>
 #'   set_node_attrs_ws(
 #'     node_attr = color,
-#'     value = "grey70") %>%
-#'   invert_selection() %>%
+#'     value = "grey70") |>
+#'   invert_selection() |>
 #'   set_node_attrs_ws(
 #'     node_attr = color,
-#'     value = "grey80") %>%
+#'     value = "grey80") |>
 #'   clear_selection()
 #'
 #' # Get the graph's internal node
 #' # data frame (ndf)
-#' graph %>%
+#' graph |>
 #'   get_node_df()
 #'
 #' @export

--- a/R/get_node_df_ws.R
+++ b/R/get_node_df_ws.R
@@ -26,11 +26,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 4,
 #'     m = 4,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = c(2.5, 8.2, 4.2, 2.4))
@@ -38,14 +38,14 @@
 #' # Select nodes with ID values
 #' # `1` and `3`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_id(
 #'     nodes = c(1, 3))
 #'
 #' # Get the node data frame that's
 #' # limited to the rows that correspond
 #' # to the node selection
-#' graph %>% get_node_df_ws()
+#' graph |> get_node_df_ws()
 #'
 #' @export
 get_node_df_ws <- function(graph) {
@@ -59,6 +59,6 @@ get_node_df_ws <- function(graph) {
   # Extract the node data frame (ndf)
   # from the graph and get only those nodes
   # from the node selection
-  graph$nodes_df %>%
+  graph$nodes_df |>
     dplyr::filter(id %in% graph$node_selection$node)
 }

--- a/R/get_node_ids.R
+++ b/R/get_node_ids.R
@@ -31,25 +31,25 @@
 #'     nodes_df = ndf)
 #'
 #' # Get a vector of all nodes in a graph
-#' graph %>% get_node_ids()
+#' graph |> get_node_ids()
 #'
 #' # Get a vector of node ID values using a
 #' # numeric comparison (i.e., all nodes with
 #' # `value` attribute greater than 3)
-#' graph %>%
+#' graph |>
 #'   get_node_ids(
 #'     conditions = value > 3)
 #'
 #' # Get a vector of node ID values using
 #' # a match pattern (i.e., all nodes with
 #' # `color` attribute of `green`)
-#' graph %>%
+#' graph |>
 #'   get_node_ids(
 #'     conditions = color == "green")
 #'
 #' # Use multiple conditions to return nodes
 #' # with the desired attribute values
-#' graph %>%
+#' graph |>
 #'   get_node_ids(
 #'     conditions =
 #'       color == "blue" &
@@ -81,5 +81,5 @@ get_node_ids <- function(
     return(NA)
   }
 
-  nodes_df %>% dplyr::pull("id")
+  nodes_df |> dplyr::pull("id")
 }

--- a/R/get_node_info.R
+++ b/R/get_node_info.R
@@ -13,13 +13,13 @@
 #' @examples
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5, m = 10,
 #'     set_seed = 23)
 #'
 #' # Get information on the graph's nodes
-#' graph %>% get_node_info()
+#' graph |> get_node_info()
 #'
 #' @export
 get_node_info <- function(graph) {

--- a/R/get_non_nbrs.R
+++ b/R/get_non_nbrs.R
@@ -13,11 +13,11 @@
 #' # Create a simple, directed graph with 5
 #' # nodes and 4 edges
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 5)
 #'
 #' # Find all non-neighbors of node `2`
-#' graph %>% get_non_nbrs(node = 2)
+#' graph |> get_non_nbrs(node = 2)
 #'
 #' @export
 get_non_nbrs <- function(

--- a/R/get_pagerank.R
+++ b/R/get_pagerank.R
@@ -15,7 +15,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -23,15 +23,15 @@
 #'
 #' # Get the PageRank scores
 #' # for all nodes in the graph
-#' graph %>%
+#' graph |>
 #'   get_pagerank()
 #'
 #' # Colorize nodes according to their
 #' # PageRank scores
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_pagerank(graph = .)) %>%
+#'     df = get_pagerank(graph)) |>
 #'   colorize_node_attrs(
 #'     node_attr_from = pagerank,
 #'     node_attr_to = fillcolor,
@@ -60,7 +60,7 @@ get_pagerank <- function(
 
   # Create df with the PageRank values
   data.frame(
-    id = names(pagerank_values) %>% as.integer(),
+    id = names(pagerank_values) |> as.integer(),
     pagerank = round(pagerank_values, 4),
     stringsAsFactors = FALSE)
 }

--- a/R/get_paths.R
+++ b/R/get_paths.R
@@ -21,34 +21,34 @@
 #' @examples
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 8) %>%
-#'   add_edge(from = 1, to = 2) %>%
-#'   add_edge(from = 1, to = 3) %>%
-#'   add_edge(from = 3, to = 4) %>%
-#'   add_edge(from = 3, to = 5) %>%
-#'   add_edge(from = 4, to = 6) %>%
-#'   add_edge(from = 2, to = 7) %>%
-#'   add_edge(from = 7, to = 5) %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 8) |>
+#'   add_edge(from = 1, to = 2) |>
+#'   add_edge(from = 1, to = 3) |>
+#'   add_edge(from = 3, to = 4) |>
+#'   add_edge(from = 3, to = 5) |>
+#'   add_edge(from = 4, to = 6) |>
+#'   add_edge(from = 2, to = 7) |>
+#'   add_edge(from = 7, to = 5) |>
 #'   add_edge(from = 4, to = 8)
 #'
 #' # Get a list of all paths outward from node `1`
-#' graph %>%
+#' graph |>
 #'   get_paths(from = 1)
 #'
 #' # Get a list of all paths leading to node `6`
-#' graph %>%
+#' graph |>
 #'   get_paths(to = 6)
 #'
 #' # Get a list of all paths from `1` to `5`
-#' graph %>%
+#' graph |>
 #'   get_paths(
 #'    from = 1,
 #'    to = 5)
 #'
 #' # Get a list of all paths from `1` up to a distance
 #' # of 2 node traversals
-#' graph %>%
+#' graph |>
 #'   get_paths(
 #'     from = 1,
 #'     distance = 2)

--- a/R/get_periphery.R
+++ b/R/get_periphery.R
@@ -13,11 +13,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function and
 #' # get the nodes in the graph periphery
-#' create_graph() %>%
+#' create_graph() |>
 #'   add_gnm_graph(
 #'     n = 28,
 #'     m = 35,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   get_periphery()
 #'
 #' @export
@@ -32,8 +32,8 @@ get_periphery <- function(graph) {
   # Get the node ID values for all nodes where the
   # eccentricity is equal to the graph diameter
   # (i.e., maximum eccentricity)
-  eccentricity %>%
-    dplyr::filter(eccentricity == get_max_eccentricity(graph)) %>%
-    dplyr::pull("id") %>%
+  eccentricity |>
+    dplyr::filter(eccentricity == get_max_eccentricity(graph)) |>
+    dplyr::pull("id") |>
     as.integer()
 }

--- a/R/get_predecessors.R
+++ b/R/get_predecessors.R
@@ -36,13 +36,13 @@
 #'
 #' # Get predecessors for node
 #' # `23` in the graph
-#' graph %>%
+#' graph |>
 #'   get_predecessors(
 #'     node = 23)
 #'
 #' # If there are no predecessors,
 #' # `NA` is returned
-#' graph %>%
+#' graph |>
 #'   get_predecessors(
 #'     node = 26)
 #'

--- a/R/get_radiality.R
+++ b/R/get_radiality.R
@@ -17,26 +17,26 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
 #'     set_seed = 23)
 #'
 #' # Get the radiality scores for nodes in the graph
-#' graph %>%
+#' graph |>
 #'   get_radiality()
 #'
 #' # Add the radiality values
 #' # to the graph as a node
 #' # attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_radiality(.))
+#'     df = get_radiality(graph))
 #'
 #' # Display the graph's node data frame
-#' graph %>%
+#' graph |>
 #'   get_node_df()
 #'
 #' @export
@@ -91,9 +91,9 @@ get_radiality <- function(
 
   # Create df with radiality scores
   data.frame(
-    id = radiality_values %>%
-      names() %>%
+    id = radiality_values |>
+      names() |>
       as.integer(),
-    radiality = radiality_values %>% round(4),
+    radiality = radiality_values |> round(4),
     stringsAsFactors = FALSE)
 }

--- a/R/get_reciprocity.R
+++ b/R/get_reciprocity.R
@@ -16,11 +16,11 @@
 #' # Define a graph where 2 edge definitions
 #' # have pairs of reciprocal edges
 #' graph <-
-#'   create_graph() %>%
-#'   add_cycle(n = 3) %>%
+#'   create_graph() |>
+#'   add_cycle(n = 3) |>
 #'   add_node(
 #'     from = 1,
-#'       to = 1) %>%
+#'       to = 1) |>
 #'   add_node(
 #'     from = 1,
 #'       to = 1)
@@ -30,22 +30,22 @@
 #' # 4 is the number reciprocating edges
 #' # and 7 is the total number of edges
 #' # in the graph)
-#' graph %>%
+#' graph |>
 #'   get_reciprocity()
 #'
 #' # For an undirected graph, all edges
 #' # are reciprocal, so the ratio will
 #' # always be 1
-#' graph %>%
-#'   set_graph_undirected() %>%
+#' graph |>
+#'   set_graph_undirected() |>
 #'   get_reciprocity()
 #'
 #' # For a graph with no edges, the graph
 #' # reciprocity cannot be determined (and
 #' # the same NA result is obtained from an
 #' # empty graph)
-#' create_graph() %>%
-#'   add_n_nodes(n = 5) %>%
+#' create_graph() |>
+#'   add_n_nodes(n = 5) |>
 #'   get_reciprocity()
 #'
 #' @export

--- a/R/get_s_connected_cmpts.R
+++ b/R/get_s_connected_cmpts.R
@@ -18,31 +18,34 @@
 #' # connection between 2 different
 #' # node cycles
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(
 #'     n = 3,
-#'     type = "cycle_1") %>%
+#'     type = "cycle_1") |>
 #'   add_cycle(
 #'     n = 4,
-#'     type = "cycle_2") %>%
+#'     type = "cycle_2")
+#'
+#' graph <-
+#'   graph |>
 #'   add_edge(
 #'     from =
 #'       get_node_ids(
-#'         graph = .,
+#'         graph = graph,
 #'         conditions =
-#'           type == "cycle_1") %>%
+#'           type == "cycle_1") |>
 #'         sample(size = 1),
 #'     to =
 #'       get_node_ids(
-#'         graph = .,
+#'         graph = graph,
 #'         conditions =
-#'           type == "cycle_2") %>%
+#'           type == "cycle_2") |>
 #'         sample(size = 1))
 #'
 #' # Get the strongly connected
 #' # components as a data frame of
 #' # nodes and their groupings
-#' graph %>% get_s_connected_cmpts()
+#' graph |> get_s_connected_cmpts()
 #'
 #' @export
 get_s_connected_cmpts <- function(graph) {
@@ -55,18 +58,18 @@ get_s_connected_cmpts <- function(graph) {
   # transform to an igraph object
   ig_graph <-
     create_graph(
-      nodes_df = graph %>%
-        get_node_df() %>%
+      nodes_df = graph |>
+        get_node_df() |>
         dplyr::select("id", "type", "label"),
-      edges_df = graph %>%
-        get_edge_df() %>%
+      edges_df = graph |>
+        get_edge_df() |>
         dplyr::select("id", "from", "to", "rel"),
-      directed = is_graph_directed(graph)) %>%
+      directed = is_graph_directed(graph)) |>
     to_igraph()
 
   # Get the component list from the graph
   components <-
-    ig_graph %>%
+    ig_graph |>
     igraph::components(mode = "strong")
 
   # Create the output data frame

--- a/R/get_selection.R
+++ b/R/get_selection.R
@@ -12,7 +12,7 @@
 #' @examples
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 6)
 #'
 #' # Select node `4`, then select
@@ -20,19 +20,19 @@
 #' # from node `4`, and finally
 #' # return the selection of nodes as
 #' # a vector object
-#' graph %>%
-#'   select_nodes(nodes = 4) %>%
+#' graph |>
+#'   select_nodes(nodes = 4) |>
 #'   select_nodes_in_neighborhood(
 #'     node = 4,
-#'     distance = 1) %>%
+#'     distance = 1) |>
 #'   get_selection()
 #'
 #' # Select edges associated with
 #' # node `4` and return the
 #' # selection of edges
-#' graph %>%
+#' graph |>
 #'   select_edges_by_node_id(
-#'     nodes = 4) %>%
+#'     nodes = 4) |>
 #'   get_selection()
 #'
 #' @export

--- a/R/get_similar_nbrs.R
+++ b/R/get_similar_nbrs.R
@@ -30,23 +30,23 @@
 #' # graph with 18 nodes and 22 edges
 #' # using the `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 18,
 #'     m = 25,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 18,
 #'       mean = 5,
-#'       sd = 1) %>% round(0))
+#'       sd = 1) |> round(0))
 #'
 #' # Starting with node `10`, we
 #' # can test whether any nodes
 #' # adjacent and beyond are
 #' # numerically equivalent in `value`
-#' graph %>%
+#' graph |>
 #'   get_similar_nbrs(
 #'     node = 10,
 #'     node_attr = value)
@@ -62,7 +62,7 @@
 #' # with a fairly large range to
 #' # determine if several nodes can be
 #' # selected
-#' graph %>%
+#' graph |>
 #'   get_similar_nbrs(
 #'     node = 10,
 #'     node_attr = value,
@@ -74,11 +74,11 @@
 #' # to be very large will effectively
 #' # return all nodes in the graph
 #' # except for the starting node
-#' graph %>%
+#' graph |>
 #'   get_similar_nbrs(
 #'     node = 10,
 #'     node_attr = value,
-#'     tol_abs = c(10, 10)) %>%
+#'     tol_abs = c(10, 10)) |>
 #'     length()
 #'
 #' @export
@@ -95,7 +95,7 @@ get_similar_nbrs <- function(
 
     # Get the requested `node_attr`
   node_attr <-
-    rlang::enquo(node_attr) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr) |> rlang::get_expr() |> as.character()
 
   # Get value to match on
   match <-

--- a/R/get_successors.R
+++ b/R/get_successors.R
@@ -36,13 +36,13 @@
 #'
 #' # Get sucessors for node
 #' # `4` in the graph
-#' graph %>%
+#' graph |>
 #'   get_successors(
 #'     node = 4)
 #'
 #' # If there are no successors,
 #' # NA is returned
-#' graph %>%
+#' graph |>
 #'   get_successors(
 #'     node = 1)
 #'

--- a/R/get_w_connected_cmpts.R
+++ b/R/get_w_connected_cmpts.R
@@ -14,17 +14,17 @@
 #' @examples
 #' # Create a graph with 2 cycles
 #' graph <-
-#'   create_graph() %>%
-#'   add_cycle(n = 4) %>%
+#'   create_graph() |>
+#'   add_cycle(n = 4) |>
 #'   add_cycle(n = 3)
 #'
 #' # Check if the graph is connected
-#' graph %>%
+#' graph |>
 #'   is_graph_connected()
 #'
 #' # Get the graph's weakly-connected
 #' # components
-#' graph %>% get_w_connected_cmpts()
+#' graph |> get_w_connected_cmpts()
 #'
 #' @export
 get_w_connected_cmpts <- function(graph) {
@@ -37,18 +37,18 @@ get_w_connected_cmpts <- function(graph) {
   # transform to an igraph object
   ig_graph <-
     create_graph(
-      nodes_df = graph %>%
-        get_node_df() %>%
+      nodes_df = graph |>
+        get_node_df() |>
         dplyr::select(id, type, label),
-      edges_df = graph %>%
-        get_edge_df() %>%
+      edges_df = graph |>
+        get_edge_df() |>
         dplyr::select(id, from, to, rel),
-      directed = is_graph_directed(graph)) %>%
+      directed = is_graph_directed(graph)) |>
     to_igraph()
 
   # Get the component list from the graph
   components <-
-    ig_graph %>%
+    ig_graph |>
     igraph::components(mode = "weak")
 
   # Create the output data frame

--- a/R/import_graph.R
+++ b/R/import_graph.R
@@ -36,11 +36,11 @@
 #'       package = "DiagrammeR"))
 #'
 #' # Get a count of the graph's nodes
-#' gml_graph %>%
+#' gml_graph |>
 #'   count_nodes()
 #'
 #' # Get a count of the graph's edges
-#' gml_graph %>%
+#' gml_graph |>
 #'   count_edges()
 #' }
 #'
@@ -96,7 +96,8 @@ import_graph <- function(
       utils::unzip(zipfile = dest_file)
 
       # Get the file name
-      base_name <- (strsplit(dest_file, split = "\\.") %>% unlist())[[1]]
+      base_name_parts <- strsplit(dest_file, split = "\\.") |> unlist()
+      base_name <- base_name_parts[[1]]
 
       graph_file <-
         list.files(pattern = paste0(base_name, ".*"))[
@@ -153,12 +154,12 @@ import_graph <- function(
     n_rows <- nrow(edges)
 
     edges <-
-      edges %>%
+      edges |>
       dplyr::mutate(
         id = seq_len(n_rows),
         rel = NA_character_
-        ) %>%
-      dplyr::relocate("id", "from", "to", "rel") %>%
+        ) |>
+      dplyr::relocate("id", "from", "to", "rel") |>
       as.data.frame(stringsAsFactors = FALSE)
 
     # Create a node data frame
@@ -224,7 +225,7 @@ import_graph <- function(
           unlist(
             strsplit(
               mtx_document[first_line:length(mtx_document)],
-              " "))))) %>%
+              " "))))) |>
       as.data.frame(stringsAsFactors = FALSE)
 
     # Create the graph
@@ -412,11 +413,11 @@ import_graph <- function(
       dplyr::tibble(
         from_label = from,
         to_label = to,
-        rel = rel) %>%
-      dplyr::right_join(ndf, c("from_label" = "label")) %>%
-      dplyr::select(from = "id", "to_label", "rel") %>%
-      dplyr::right_join(ndf, c("to_label" = "label")) %>%
-      dplyr::select("from", to = "id", "rel") %>%
+        rel = rel) |>
+      dplyr::right_join(ndf, c("from_label" = "label")) |>
+      dplyr::select(from = "id", "to_label", "rel") |>
+      dplyr::right_join(ndf, c("to_label" = "label")) |>
+      dplyr::select("from", to = "id", "rel") |>
       as.data.frame(stringsAsFactors = FALSE)
 
     # Create a graph object

--- a/R/invert_selection.R
+++ b/R/invert_selection.R
@@ -32,22 +32,22 @@
 #' # Select nodes with ID
 #' # values `1` and `3`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes(
 #'     nodes = c(1, 3))
 #'
 #' # Verify that a node
 #' # selection has been made
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Invert the selection
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   invert_selection()
 #'
 #' # Verify that the node
 #' # selection has been changed
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 invert_selection <- function(graph) {
@@ -80,8 +80,8 @@ invert_selection <- function(graph) {
     ndf <- graph$nodes_df
 
     inverted_nodes <-
-      ndf %>%
-      dplyr::filter(!(id %in% selection_nodes)) %>%
+      ndf |>
+      dplyr::filter(!(id %in% selection_nodes)) |>
       dplyr::select("id")
 
     # Add the node ID values to the active selection
@@ -103,8 +103,8 @@ invert_selection <- function(graph) {
     edf <- graph$edges_df
 
     inverted_edges <-
-      edf %>%
-      dplyr::filter(!(id %in% selection_edges)) %>%
+      edf |>
+      dplyr::filter(!(id %in% selection_edges)) |>
       dplyr::select("id", "from", "to")
 
     # Add the node ID values to the active selection

--- a/R/is_edge_loop.R
+++ b/R/is_edge_loop.R
@@ -13,26 +13,26 @@
 #' # Create a graph that has multiple
 #' # loop edges
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 4) %>%
+#'   create_graph() |>
+#'   add_path(n = 4) |>
 #'   add_edge(
 #'     from = 1,
-#'     to = 1) %>%
+#'     to = 1) |>
 #'   add_edge(
 #'     from = 3,
 #'     to = 3)
 #'
 #' # Get the graph's internal
 #' # edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Determine if edge `4` is
 #' # a loop edge
-#' graph %>% is_edge_loop(edge = 4)
+#' graph |> is_edge_loop(edge = 4)
 #'
 #' # Determine if edge `2` is
 #' # a loop edge
-#' graph %>% is_edge_loop(edge = 2)
+#' graph |> is_edge_loop(edge = 2)
 #'
 #' @export
 is_edge_loop <- function(
@@ -62,13 +62,13 @@ is_edge_loop <- function(
 
   # Obtain the edge definition
   from <-
-    edf %>%
-    dplyr::filter(id == !!edge) %>%
+    edf |>
+    dplyr::filter(id == !!edge) |>
     dplyr::pull("from")
 
   to <-
-    edf %>%
-    dplyr::filter(id == !!edge) %>%
+    edf |>
+    dplyr::filter(id == !!edge) |>
     dplyr::pull("to")
 
   # If the `from` and `to` node IDs

--- a/R/is_edge_multiple.R
+++ b/R/is_edge_multiple.R
@@ -14,27 +14,27 @@
 #' # Create a graph that has multiple
 #' # edges across some node pairs
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 4) %>%
+#'   create_graph() |>
+#'   add_path(n = 4) |>
 #'   add_edge(
 #'     from = 1,
-#'     to = 2) %>%
+#'     to = 2) |>
 #'   add_edge(
 #'     from = 3,
 #'     to = 4)
 #'
 #' # Get the graph's internal
 #' # edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Determine if edge `1` is
 #' # a multiple edge
-#' graph %>%
+#' graph |>
 #'   is_edge_multiple(edge = 1)
 #'
 #' # Determine if edge `2` is
 #' # a multiple edge
-#' graph %>%
+#' graph |>
 #'   is_edge_multiple(edge = 2)
 #'
 #' @export
@@ -66,20 +66,20 @@ is_edge_multiple <- function(
 
   # Obtain the edge definition
   from <-
-    edf %>%
-    dplyr::filter(id == !!edge) %>%
+    edf |>
+    dplyr::filter(id == !!edge) |>
     dplyr::pull("from")
 
   to <-
-    edf %>%
-    dplyr::filter(id == !!edge) %>%
+    edf |>
+    dplyr::filter(id == !!edge) |>
     dplyr::pull("to")
 
   # Determine if there are mulitple rows
   # where the definition of `from` and `to`
   # is valid
   multiple_edges <-
-    edf %>%
+    edf |>
     dplyr::filter(from == !!from, to == !!to)
 
   res <- nrow(multiple_edges) > 1

--- a/R/is_edge_mutual.R
+++ b/R/is_edge_mutual.R
@@ -14,27 +14,27 @@
 #' # Create a graph that has mutual
 #' # edges across some node pairs
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 4) %>%
+#'   create_graph() |>
+#'   add_path(n = 4) |>
 #'   add_edge(
 #'     from = 4,
-#'     to = 3) %>%
+#'     to = 3) |>
 #'   add_edge(
 #'     from = 2,
 #'     to = 1)
 #'
 #' # Get the graph's internal
 #' # edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Determine if edge `1` has
 #' # a mutual edge
-#' graph %>%
+#' graph |>
 #'   is_edge_mutual(edge = 1)
 #'
 #' # Determine if edge `2` has
 #' # a mutual edge
-#' graph %>%
+#' graph |>
 #'   is_edge_mutual(edge = 2)
 #'
 #' @export
@@ -65,20 +65,20 @@ is_edge_mutual <- function(
 
   # Obtain the edge definition
   from <-
-    edf %>%
-    dplyr::filter(id == !!edge) %>%
+    edf |>
+    dplyr::filter(id == !!edge) |>
     dplyr::pull("from")
 
   to <-
-    edf %>%
-    dplyr::filter(id == !!edge) %>%
+    edf |>
+    dplyr::filter(id == !!edge) |>
     dplyr::pull("to")
 
   # Determine if there is any row where
   # the definition of `from` and `to` is
   # reversed
   mutual_edges <-
-    edf %>%
+    edf |>
     dplyr::filter(from == !!to, to == !!from)
 
   res <- nrow(mutual_edges) > 0

--- a/R/is_edge_present.R
+++ b/R/is_edge_present.R
@@ -22,7 +22,7 @@
 #' # Create a simple graph with
 #' # a path of four nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 4,
 #'     type = "path",
@@ -31,19 +31,19 @@
 #'
 #' # Find out if edge ID `3`
 #' # is present in the graph
-#' graph %>%
+#' graph |>
 #'   is_edge_present(edge = 3)
 #'
 #' # Determine if there are any edges
 #' # with the definition `1` -> `2`
-#' graph %>%
+#' graph |>
 #'   is_edge_present(
 #'     from = 1,
 #'     to = 2)
 #'
 #' # Determine if there are any edges
 #' # with the definition `4` -> `5`
-#' graph %>%
+#' graph |>
 #'   is_edge_present(
 #'     from = 4,
 #'     to = 5)
@@ -52,7 +52,7 @@
 #' # defined by its labels as
 #' # `two` -> `three`, exists in
 #' # the graph
-#' graph %>%
+#' graph |>
 #'   is_edge_present(
 #'     from = "two",
 #'     to = "three")
@@ -61,8 +61,8 @@
 #' # and determine whether an
 #' # edge between nodes with labels
 #' # `three` and `two` exists
-#' graph %>%
-#'   set_graph_undirected() %>%
+#' graph |>
+#'   set_graph_undirected() |>
 #'   is_edge_present(
 #'     from = "three",
 #'     to = "two")

--- a/R/is_graph_connected.R
+++ b/R/is_graph_connected.R
@@ -12,20 +12,20 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function; this
 #' # graph is not connected
-#' create_graph() %>%
+#' create_graph() |>
 #'   add_gnm_graph(
 #'     n = 15,
 #'     m = 10,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   is_graph_connected()
 #'
 #' # Create another random graph;
 #' # this graph is connected
-#' create_graph() %>%
+#' create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   is_graph_connected()
 #'
 #' @export

--- a/R/is_graph_dag.R
+++ b/R/is_graph_dag.R
@@ -14,37 +14,37 @@
 #' # Create a directed graph containing
 #' # only a balanced tree
 #' graph_tree <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
 #'     k = 2, h = 3)
 #'
 #' # Determine whether this graph
 #' # is a DAG
-#' graph_tree %>%
+#' graph_tree |>
 #'   is_graph_dag()
 #'
 #' # Create a directed graph containing
 #' # a single cycle
 #' graph_cycle <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Determine whether this graph
 #' # is a DAG
-#' graph_cycle %>%
+#' graph_cycle |>
 #'   is_graph_dag()
 #'
 #' # Create an undirected graph
 #' # containing a balanced tree
 #' graph_tree_undirected <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_balanced_tree(
 #'     k = 2, h = 2)
 #'
 #' # Determine whether this graph
 #' # is a DAG
-#' graph_tree_undirected %>%
+#' graph_tree_undirected |>
 #'   is_graph_dag()
 #'
 #' @export

--- a/R/is_graph_directed.R
+++ b/R/is_graph_directed.R
@@ -17,13 +17,13 @@
 #'
 #' # Determine whether the graph
 #' # is directed
-#' graph %>% is_graph_directed()
+#' graph |> is_graph_directed()
 #'
 #' # Use the `set_graph_undirected()`
 #' # function and check again whether
 #' # the graph is directed
-#' graph %>%
-#'   set_graph_undirected() %>%
+#' graph |>
+#'   set_graph_undirected() |>
 #'   is_graph_directed()
 #'
 #' @export

--- a/R/is_graph_empty.R
+++ b/R/is_graph_empty.R
@@ -14,15 +14,15 @@
 #' graph <- create_graph()
 #'
 #' # Determine whether the graph is empty
-#' graph %>% is_graph_empty()
+#' graph |> is_graph_empty()
 #'
 #' # Create a non-empty graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(n = 3)
 #'
 #' # Determine whether this graph is empty
-#' graph %>% is_graph_empty()
+#' graph |> is_graph_empty()
 #'
 #' @export
 is_graph_empty <- function(graph) {

--- a/R/is_graph_simple.R
+++ b/R/is_graph_simple.R
@@ -12,12 +12,12 @@
 #' @examples
 #' # Create a graph with 2 cycles
 #' graph <-
-#'   create_graph() %>%
-#'   add_cycle(n = 4) %>%
+#'   create_graph() |>
+#'   add_cycle(n = 4) |>
 #'   add_cycle(n = 3)
 #'
 #' # Check if the graph is simple
-#' graph %>% is_graph_simple()
+#' graph |> is_graph_simple()
 #'
 #' @export
 is_graph_simple <- function(graph) {

--- a/R/is_graph_undirected.R
+++ b/R/is_graph_undirected.R
@@ -22,14 +22,14 @@
 #'
 #' # Determine whether the
 #' # graph is undirected
-#' graph %>% is_graph_undirected()
+#' graph |> is_graph_undirected()
 #'
 #' # Use the `set_graph_directed()`
 #' # function and check again
 #' # as to whether the graph is
 #' # undirected
-#' graph %>%
-#'   set_graph_directed() %>%
+#' graph |>
+#'   set_graph_directed() |>
 #'   is_graph_undirected()
 #'
 #' @export

--- a/R/is_graph_weighted.R
+++ b/R/is_graph_weighted.R
@@ -14,27 +14,27 @@
 #' # Create a graph where the edges have
 #' # a `weight` attribute
 #' graph <-
-#'   create_graph() %>%
-#'   add_cycle(n = 5) %>%
-#'   select_edges() %>%
+#'   create_graph() |>
+#'   add_cycle(n = 5) |>
+#'   select_edges() |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = weight,
-#'     value = c(3, 5, 2, 9, 6)) %>%
+#'     value = c(3, 5, 2, 9, 6)) |>
 #'   clear_selection()
 #'
 #' # Determine whether the graph
 #' # is a weighted graph
-#' graph %>% is_graph_weighted()
+#' graph |> is_graph_weighted()
 #'
 #' # Create graph where the edges do
 #' # not have a `weight` attribute
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' # Determine whether this graph
 #' # is weighted
-#' graph %>% is_graph_weighted()
+#' graph |> is_graph_weighted()
 #'
 #' @export
 is_graph_weighted <- function(graph) {

--- a/R/is_node_present.R
+++ b/R/is_node_present.R
@@ -15,7 +15,7 @@
 #' # Create a simple graph with
 #' # a path of four nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 4,
 #'     type = "path",
@@ -25,17 +25,17 @@
 #'
 #' # Determine if there is a node
 #' # with ID `1` in the graph
-#' graph %>%
+#' graph |>
 #'   is_node_present(node = 1)
 #'
 #' # Determine if there is a node
 #' # with ID `5` in the graph
-#' graph %>%
+#' graph |>
 #'   is_node_present(node = 5)
 #'
 #' # Determine if there is a node
 #' # with label `two` in the graph
-#' graph %>%
+#' graph |>
 #'   is_node_present(node = "two")
 #' @export
 is_node_present <- function(

--- a/R/is_property_graph.R
+++ b/R/is_property_graph.R
@@ -15,13 +15,13 @@
 #' # (with `type` values) and a
 #' # single edge (with a `rel`)
 #' simple_property_graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_node(
 #'     type = "a",
-#'     label = "first") %>%
+#'     label = "first") |>
 #'   add_node(
 #'     type = "b",
-#'     label = "second") %>%
+#'     label = "second") |>
 #'   add_edge(
 #'     from = "first",
 #'     to = "second",
@@ -35,15 +35,15 @@
 #' # If a `type` attribute is
 #' # removed, then this graph will
 #' # no longer be a property graph
-#' simple_property_graph %>%
+#' simple_property_graph |>
 #'   set_node_attrs(
 #'     node_attr = type,
 #'     values = NA,
-#'     nodes = 1) %>%
+#'     nodes = 1) |>
 #'   is_property_graph()
 #'
 #' # An empty graph will return FALSE
-#' create_graph() %>%
+#' create_graph() |>
 #'   is_property_graph()
 #'
 #' @export

--- a/R/join_edge_attrs.R
+++ b/R/join_edge_attrs.R
@@ -26,8 +26,8 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 5) %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 5) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5")
 #'
@@ -45,13 +45,13 @@
 #' # identically-named columns in the graph and the df
 #' # (in this case `from` and `to` are common to both)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_edge_attrs(
 #'     df = df)
 #'
 #' # Get the graph's internal edf to show that the
 #' # join has been made
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #' @family edge creation and removal
 #' @export
 join_edge_attrs <- function(
@@ -108,7 +108,7 @@ join_edge_attrs <- function(
 
   # Sort the columns in `edges`
   edges <-
-    edges %>% dplyr::relocate("id", "from", "to", "rel")
+    edges |> dplyr::relocate("id", "from", "to", "rel")
 
   # Modify the graph object
   graph$edges_df <- edges

--- a/R/join_node_attrs.R
+++ b/R/join_node_attrs.R
@@ -26,8 +26,8 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
-#'   add_n_nodes(n = 5) %>%
+#'   create_graph() |>
+#'   add_n_nodes(n = 5) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5")
 #'
@@ -43,26 +43,26 @@
 #' # identically-named columns in the graph and the df
 #' # (in this case the `id` column is common to both)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
 #'     df = df)
 #'
 #' # Get the graph's internal ndf to show that the
 #' # join has been made
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Get betweenness values for each node and
 #' # add them as a node attribute (Note the
 #' # common column name `id` in the different
 #' # tables results in a natural join)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_node_attrs(
-#'     df = get_betweenness(.))
+#'     df = get_betweenness(graph))
 #'
 #' # Get the graph's internal ndf to show that
 #' # this join has been made
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #' @family node creation and removal
 #' @export
 join_node_attrs <- function(
@@ -139,7 +139,7 @@ join_node_attrs <- function(
 
   # Ensure that the column ordering is correct
   nodes <-
-    nodes %>% dplyr::relocate("id", "type", "label")
+    nodes |> dplyr::relocate("id", "type", "label")
 
   # Modify the graph object
   graph$nodes_df <- nodes

--- a/R/layout_nodes_w_string.R
+++ b/R/layout_nodes_w_string.R
@@ -33,13 +33,13 @@
 #' # Create a graph with unique labels and
 #' # several node `type` groupings
 #' graph <-
-#'   create_graph() %>%
-#'   add_node(type = "a", label = "a") %>%
-#'   add_node(type = "a", label = "b") %>%
-#'   add_node(type = "b", label = "c") %>%
-#'   add_node(type = "b", label = "d") %>%
-#'   add_node(type = "b", label = "e") %>%
-#'   add_node(type = "c", label = "f") %>%
+#'   create_graph() |>
+#'   add_node(type = "a", label = "a") |>
+#'   add_node(type = "a", label = "b") |>
+#'   add_node(type = "b", label = "c") |>
+#'   add_node(type = "b", label = "d") |>
+#'   add_node(type = "b", label = "e") |>
+#'   add_node(type = "c", label = "f") |>
 #'   add_node(type = "c", label = "g")
 #'
 #' # Define a 'layout' for groups of nodes
@@ -64,7 +64,7 @@
 #' # we should sort the collection of node
 #' # before adding position information
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   layout_nodes_w_string(
 #'     layout = layout,
 #'     nodes = c("1" = "type:a",
@@ -77,7 +77,7 @@
 #' # Show the graph's node data frame
 #' # to confirm that `x` and `y` values
 #' # were added to each of the nodes
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #' @family node creation and removal
 #' @export
 layout_nodes_w_string <- function(
@@ -107,8 +107,8 @@ layout_nodes_w_string <- function(
   # Parse the `layout` object to get a vector
   # of rows
   layout <-
-    gsub(" ", "", layout) %>%
-    stringr::str_split("\n") %>%
+    gsub(" ", "", layout) |>
+    stringr::str_split("\n") |>
     unlist()
 
   layout <-
@@ -165,7 +165,7 @@ layout_nodes_w_string <- function(
               y = y_pts[i])
 
           position_table <-
-            position_table %>%
+            position_table |>
             dplyr::bind_rows(item_table)
         }
       }
@@ -173,19 +173,19 @@ layout_nodes_w_string <- function(
 
     # Filter the graph `ndf`
     ndf_part <-
-      ndf %>%
+      ndf |>
       dplyr::filter(!!rlang::parse_expr(paste0(node_attr, " == '", node_attr_val, "'")))
 
     # Optionally apply sorting
     if (!is.null(sort)) {
       if (sort_dir == "desc") {
         ndf_part <-
-          ndf_part %>%
+          ndf_part |>
           dplyr::arrange(dplyr::desc(!!sym(sort_attr)))
 
       } else {
         ndf_part <-
-          ndf_part %>%
+          ndf_part |>
           dplyr::arrange(!!sym(sort_attr))
       }
     }
@@ -207,7 +207,7 @@ layout_nodes_w_string <- function(
 
   # Join the `ndf_parts` to the main `ndf`
   ndf <-
-    ndf %>%
+    ndf |>
     dplyr::left_join(
       ndf_parts,
       by = c("id", "type", "label"))

--- a/R/mutate_edge_attrs.R
+++ b/R/mutate_edge_attrs.R
@@ -17,8 +17,8 @@
 #' @examples
 #' # Create a graph with 3 edges
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 4) %>%
+#'   create_graph() |>
+#'   add_path(n = 4) |>
 #'   set_edge_attrs(
 #'     edge_attr = width,
 #'     values = c(3.4, 2.3, 7.2))
@@ -26,13 +26,13 @@
 #' # Get the graph's internal edf
 #' # to show which edge attributes
 #' # are available
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Mutate the `width` edge
 #' # attribute, dividing each
 #' # value by 2
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_edge_attrs(
 #'     width = width / 2)
 #'
@@ -40,7 +40,7 @@
 #' # edf to show that the edge
 #' # attribute `width` had its
 #' # values changed
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Create a new edge attribute,
 #' # called `length`, that is the
@@ -48,22 +48,22 @@
 #' # 2 (and, also, round all values
 #' # to 2 decimal places)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_edge_attrs(
-#'     length = (log(width) + 2) %>%
+#'     length = (log(width) + 2) |>
 #'                round(2))
 #'
 #' # Get the graph's internal edf
 #' # to show that the edge attribute
 #' # values had been mutated
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Create a new edge attribute
 #' # called `area`, which is the
 #' # product of the `width` and
 #' # `length` attributes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_edge_attrs(
 #'     area = width * length)
 #'
@@ -71,7 +71,7 @@
 #' # to show that the edge attribute
 #' # values had been multiplied
 #' # together (with new attr `area`)
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -107,7 +107,7 @@ mutate_edge_attrs <- function(
       "The variables `id`, `from`, or `to` cannot undergo mutation.")
   }
 
-  edf <- edf %>% dplyr::mutate(!!!enquos(...))
+  edf <- edf |> dplyr::mutate(!!!enquos(...))
 
   # Update the graph
   graph$edges_df <- edf

--- a/R/mutate_edge_attrs_ws.R
+++ b/R/mutate_edge_attrs_ws.R
@@ -29,17 +29,17 @@
 #' # Create a graph with 3 edges
 #' # and then select edge `1`
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 4) %>%
+#'   create_graph() |>
+#'   add_path(n = 4) |>
 #'   set_edge_attrs(
 #'     edge_attr = width,
-#'     values = c(3.4, 2.3, 7.2)) %>%
+#'     values = c(3.4, 2.3, 7.2)) |>
 #'   select_edges(edges = 1)
 #'
 #' # Get the graph's internal edf
 #' # to show which edge attributes
 #' # are available
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Mutate the `width` edge
 #' # attribute for the edges
@@ -48,7 +48,7 @@
 #' # we divide each value in the
 #' # selection by 2
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_edge_attrs_ws(
 #'     width = width / 2)
 #'
@@ -56,7 +56,7 @@
 #' # edf to show that the edge
 #' # attribute `width` had its
 #' # values changed
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Create a new edge attribute,
 #' # called `length`, that is the
@@ -64,11 +64,11 @@
 #' # 2 (and, also, round all values
 #' # to 2 decimal places)
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
-#'   select_edges(edges = 2:3) %>%
+#'   graph |>
+#'   clear_selection() |>
+#'   select_edges(edges = 2:3) |>
 #'   mutate_edge_attrs_ws(
-#'     length = (log(width) + 2) %>%
+#'     length = (log(width) + 2) |>
 #'                round(2))
 #'
 #' # Get the graph's internal edf
@@ -77,14 +77,14 @@
 #' # for edges `2` and `3` (since
 #' # edge `1` is excluded, an NA
 #' # value is applied)
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Create a new edge attribute
 #' # called `area`, which is the
 #' # product of the `width` and
 #' # `length` attributes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_edge_attrs_ws(
 #'     area = width * length)
 #'
@@ -93,17 +93,17 @@
 #' # values had been multiplied
 #' # together (with new attr `area`)
 #' # for nodes `2` and `3`
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # We can invert the selection
 #' # and mutate edge `1` several
 #' # times to get an `area` value
 #' # for that edge
 #' graph <-
-#'   graph %>%
-#'   invert_selection() %>%
+#'   graph |>
+#'   invert_selection() |>
 #'   mutate_edge_attrs_ws(
-#'     length = (log(width) + 5) %>%
+#'     length = (log(width) + 5) |>
 #'                round(2),
 #'     area = width * length)
 #'
@@ -113,7 +113,7 @@
 #' # non-NA values for its edge
 #' # attributes without changing
 #' # those of the other edges
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -164,9 +164,9 @@ mutate_edge_attrs_ws <- function(
 
   edf <-
     dplyr::bind_rows(
-      edf %>% dplyr::filter(!(!!enquo(s))) %>% dplyr::mutate(!!!enquos(...)),
-      edf %>% dplyr::filter(!!enquo(s))
-    ) %>%
+      edf |> dplyr::filter(!(!!enquo(s))) |> dplyr::mutate(!!!enquos(...)),
+      edf |> dplyr::filter(!!enquo(s))
+    ) |>
     dplyr::arrange(!!enquo(order))
 
   graph$edges_df <- edf

--- a/R/mutate_node_attrs.R
+++ b/R/mutate_node_attrs.R
@@ -17,8 +17,8 @@
 #' @examples
 #' # Create a graph with 3 nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 3) %>%
+#'   create_graph() |>
+#'   add_path(n = 3) |>
 #'   set_node_attrs(
 #'     node_attr = width,
 #'     values = c(1.4, 0.3, 1.1))
@@ -26,13 +26,13 @@
 #' # Get the graph's internal ndf
 #' # to show which node attributes
 #' # are available
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Mutate the `width` node
 #' # attribute, dividing each
 #' # value by 2
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_node_attrs(
 #'     width = width / 2)
 #'
@@ -40,7 +40,7 @@
 #' # ndf to show that the node
 #' # attribute `width` had its
 #' # values changed
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create a new node attribute,
 #' # called `length`, that is the
@@ -48,22 +48,22 @@
 #' # 2 (and, also, round all values
 #' # to 2 decimal places)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_node_attrs(
-#'     length = (log(width) + 2) %>%
+#'     length = (log(width) + 2) |>
 #'                round(2))
 #'
 #' # Get the graph's internal ndf
 #' # to show that the node attribute
 #' # values had been mutated
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create a new node attribute
 #' # called `area`, which is the
 #' # product of the `width` and
 #' # `length` attributes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_node_attrs(
 #'     area = width * length)
 #'
@@ -71,7 +71,7 @@
 #' # to show that the node attribute
 #' # values had been multiplied
 #' # together (with new attr `area`)
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -103,7 +103,7 @@ mutate_node_attrs <- function(
     cli::cli_abort("The variable `id` cannot undergo mutation.")
   }
 
-  ndf <- ndf %>% dplyr::mutate(!!!enquos(...))
+  ndf <- ndf |> dplyr::mutate(!!!enquos(...))
 
   # Update the graph
   graph$nodes_df <- ndf

--- a/R/mutate_node_attrs_ws.R
+++ b/R/mutate_node_attrs_ws.R
@@ -31,17 +31,17 @@
 #' # Create a graph with 3 nodes
 #' # and then select node `1`
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 3) %>%
+#'   create_graph() |>
+#'   add_path(n = 3) |>
 #'   set_node_attrs(
 #'     node_attr = width,
-#'     values = c(1.4, 0.3, 1.1)) %>%
+#'     values = c(1.4, 0.3, 1.1)) |>
 #'   select_nodes(nodes = 1)
 #'
 #' # Get the graph's internal ndf
 #' # to show which node attributes
 #' # are available
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Mutate the `width` node
 #' # attribute for the nodes
@@ -50,7 +50,7 @@
 #' # we divide each value in the
 #' # selection by 2
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_node_attrs_ws(
 #'     width = width / 2)
 #'
@@ -58,7 +58,7 @@
 #' # ndf to show that the node
 #' # attribute `width` was
 #' # mutated only for node `1`
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create a new node attribute,
 #' # called `length`, that is the
@@ -66,11 +66,11 @@
 #' # 2 (and, also, round all values
 #' # to 2 decimal places)
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
-#'   select_nodes(nodes = 2:3) %>%
+#'   graph |>
+#'   clear_selection() |>
+#'   select_nodes(nodes = 2:3) |>
 #'   mutate_node_attrs_ws(
-#'     length = (log(width) + 2) %>%
+#'     length = (log(width) + 2) |>
 #'                round(2))
 #'
 #' # Get the graph's internal ndf
@@ -79,14 +79,14 @@
 #' # for nodes `2` and `3` (since
 #' # node `1` is excluded, an NA
 #' # value is applied)
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create a new node attribute
 #' # called `area`, which is the
 #' # product of the `width` and
 #' # `length` attributes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   mutate_node_attrs_ws(
 #'     area = width * length)
 #'
@@ -95,17 +95,17 @@
 #' # values had been multiplied
 #' # together (with new attr `area`)
 #' # for nodes `2` and `3`
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # We can invert the selection
 #' # and mutate node `1` several
 #' # times to get an `area` value
 #' # for that node
 #' graph <-
-#'   graph %>%
-#'   invert_selection() %>%
+#'   graph |>
+#'   invert_selection() |>
 #'   mutate_node_attrs_ws(
-#'     length = (log(width) + 5) %>%
+#'     length = (log(width) + 5) |>
 #'                round(2),
 #'     area = width * length)
 #'
@@ -115,7 +115,7 @@
 #' # non-NA values for its node
 #' # attributes without changing
 #' # those of the other nodes
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -163,9 +163,9 @@ mutate_node_attrs_ws <- function(
 
   ndf <-
     dplyr::bind_rows(
-      ndf %>% dplyr::filter(!(!!enquo(s))) %>% dplyr::mutate(!!!enquos(...)),
-      ndf %>% dplyr::filter(!!enquo(s))
-    ) %>%
+      ndf |> dplyr::filter(!(!!enquo(s))) |> dplyr::mutate(!!!enquos(...)),
+      ndf |> dplyr::filter(!!enquo(s))
+    ) |>
     dplyr::arrange(!!enquo(order))
 
   graph$nodes_df <- ndf

--- a/R/node_aes.R
+++ b/R/node_aes.R
@@ -86,7 +86,7 @@
 #' # a path with several node
 #' # aesthetic attributes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 3,
 #'     type = "path",
@@ -101,12 +101,12 @@
 #' # node data frame; the node
 #' # aesthetic attributes have
 #' # been inserted
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create a new graph which is
 #' # fully connected
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_full_graph(
 #'     n = 4,
 #'     node_data = node_data(value = 1:4),
@@ -179,7 +179,7 @@ node_aes <- function(shape = NULL,
       margin = margin)
 
   non_null_attrs <-
-    seq_along(attr_values) %>%
+    seq_along(attr_values) |>
     purrr::map_chr(.f = function(x) {
       if (!is.null(attr_values[[x]])) {
         names(attr_values[x])

--- a/R/node_data.R
+++ b/R/node_data.R
@@ -12,7 +12,7 @@
 #' # a path with several node
 #' # data attributes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 3,
 #'     type = "path",
@@ -24,7 +24,7 @@
 #' # node data frame; the node
 #' # data attributes have been
 #' # inserted
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #' @family node creation and removal
 #' @export
 node_data <- function(...) {

--- a/R/nudge_node_positions_ws.R
+++ b/R/nudge_node_positions_ws.R
@@ -33,16 +33,16 @@
 #' @examples
 #' # Create a simple graph with 4 nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_node(
 #'     type = "a",
-#'     label = "one") %>%
+#'     label = "one") |>
 #'   add_node(
 #'     type = "a",
-#'     label = "two") %>%
+#'     label = "two") |>
 #'   add_node(
 #'     type = "b",
-#'     label = "three") %>%
+#'     label = "three") |>
 #'   add_node(
 #'     type = "b",
 #'     label = "four")
@@ -50,13 +50,13 @@
 #' # Add position information to each of
 #' # the graph's nodes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_position(
-#'     node = 1, x = 1, y = 1) %>%
+#'     node = 1, x = 1, y = 1) |>
 #'   set_node_position(
-#'     node = 2, x = 2, y = 2) %>%
+#'     node = 2, x = 2, y = 2) |>
 #'   set_node_position(
-#'     node = 3, x = 3, y = 3) %>%
+#'     node = 3, x = 3, y = 3) |>
 #'   set_node_position(
 #'     node = 4, x = 4, y = 4)
 #'
@@ -68,27 +68,27 @@
 #' # Move the selected nodes (all the nodes,
 #' # in this case) 5 units to the right
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   nudge_node_positions_ws(
 #'     dx = 5, dy = 0)
 #'
 #' # View the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Now select nodes that have `type == "b"`
 #' # and move them in the `y` direction 2 units
 #' # (the graph still has an active selection
 #' # and so it must be cleared first)
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
+#'   graph |>
+#'   clear_selection() |>
 #'   select_nodes(
-#'     conditions = type == "b") %>%
+#'     conditions = type == "b") |>
 #'   nudge_node_positions_ws(
 #'     dx = 0, dy = 2)
 #'
 #' # View the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 nudge_node_positions_ws <- function(
@@ -127,7 +127,7 @@ nudge_node_positions_ws <- function(
   # Determine which of the nodes selected have position
   # information set (i.e., not NA)
   ndf_filtered <-
-    ndf %>%
+    ndf |>
     dplyr::filter(id %in% nodes, !is.na(x), !is.na(y))
 
   # If there are nodes to move, replace the `nodes`
@@ -146,10 +146,10 @@ nudge_node_positions_ws <- function(
   # a vectorized `if` statement across all nodes for
   # the `x` and `y` node attribute
   ndf_new <-
-    ndf %>%
+    ndf |>
     dplyr::mutate(x = dplyr::case_when(
       id %in% as.integer(nodes) ~ x + dx,
-      !(id %in% as.integer(nodes)) ~ x)) %>%
+      !(id %in% as.integer(nodes)) ~ x)) |>
     dplyr::mutate(y = dplyr::case_when(
       id %in% nodes ~ y + dy,
       !(id %in% as.integer(nodes)) ~ y))

--- a/R/open_graph.R
+++ b/R/open_graph.R
@@ -12,7 +12,7 @@
 #' # a probability value of 0.05
 #' gnp_graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnp_graph(
 #'     n = 100,
 #'     p = 0.05

--- a/R/print.R
+++ b/R/print.R
@@ -8,7 +8,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -36,10 +36,10 @@ print.dgr_graph <- function(x, ...) {
       "get_global_graph_attr_info" = " info: `get_global_graph_attr_info()`")
 
   # Get a count of all nodes in the graph
-  node_count <- x %>% count_nodes()
+  node_count <- x |> count_nodes()
 
   # Get a count of all edges in the graph
-  edge_count <- x %>% count_edges()
+  edge_count <- x |> count_edges()
 
   # Get the node `type` status
   if (all(is.na(x$nodes_df$type))) {
@@ -50,23 +50,23 @@ print.dgr_graph <- function(x, ...) {
 
     node_type_status <-
       paste0(
-        x$nodes_df$type %>%
-          unique() %>%
-          base::setdiff(NA_character_) %>%
+        x$nodes_df$type |>
+          unique() |>
+          base::setdiff(NA_character_) |>
           length(), " val",
         ifelse(
-          x$nodes_df$type %>%
-            unique() %>%
-            base::setdiff(NA_character_) %>%
+          x$nodes_df$type |>
+            unique() |>
+            base::setdiff(NA_character_) |>
             length() > 1, "s", ""))
 
   } else if (!anyNA(x$nodes_df$type)) {
 
     node_type_status <-
       paste0(
-        x$nodes_df$type %>%
-          unique() %>%
-          base::setdiff(NA_character_) %>%
+        x$nodes_df$type |>
+          unique() |>
+          base::setdiff(NA_character_) |>
           length(), " vals - complete")
   }
 
@@ -78,23 +78,23 @@ print.dgr_graph <- function(x, ...) {
   } else if (!all(is.na(x$nodes_df$label)) && anyNA(x$nodes_df$label)) {
     node_label_status <-
       paste0(
-        x$nodes_df$label %>%
-          unique() %>%
-          base::setdiff(NA_character_) %>%
+        x$nodes_df$label |>
+          unique() |>
+          base::setdiff(NA_character_) |>
           length(), " val",
         ifelse(
-          x$nodes_df$label %>%
-            unique() %>%
-            base::setdiff(NA_character_) %>%
+          x$nodes_df$label |>
+            unique() |>
+            base::setdiff(NA_character_) |>
             length() > 1, "s", ""))
 
   } else if (!anyNA(x$nodes_df$label)) {
 
     node_label_status <-
       paste0(
-        x$nodes_df$label %>%
-          unique() %>%
-          base::setdiff(NA_character_) %>%
+        x$nodes_df$label |>
+          unique() |>
+          base::setdiff(NA_character_) |>
           length(), " vals - complete")
 
     if (!anyDuplicated(x$nodes_df$label)) {
@@ -107,8 +107,8 @@ print.dgr_graph <- function(x, ...) {
 
   # Get a list of extra node attributes
   node_extra_attrs <-
-    x$nodes_df %>%
-    colnames() %>%
+    x$nodes_df |>
+    colnames() |>
     base::setdiff(c("id", "type", "label"))
 
   if (length(node_extra_attrs) > 0) {
@@ -154,29 +154,29 @@ print.dgr_graph <- function(x, ...) {
 
     edge_rel_status <-
       paste0(
-        x$edges_df$rel %>%
-          unique() %>%
-          base::setdiff(NA_character_) %>%
+        x$edges_df$rel |>
+          unique() |>
+          base::setdiff(NA_character_) |>
           length(), " val",
         ifelse(
-          x$edges_df$rel %>%
-            unique() %>%
-            base::setdiff(NA_character_) %>%
+          x$edges_df$rel |>
+            unique() |>
+            base::setdiff(NA_character_) |>
             length() > 1, "s", ""))
 
   } else if (!anyNA(x$edges_df$rel)) {
     edge_rel_status <-
       paste0(
-        x$edges_df$rel %>%
-          unique() %>%
-          base::setdiff(NA_character_) %>%
+        x$edges_df$rel |>
+          unique() |>
+          base::setdiff(NA_character_) |>
           length(), " vals - complete")
   }
 
   # Get a list of extra edge attributes
   edge_extra_attrs <-
-    x$edges_df %>%
-    colnames() %>%
+    x$edges_df |>
+    colnames() |>
     base::setdiff(c("id", "from", "to", "rel"))
 
   if (length(edge_extra_attrs) > 0) {
@@ -462,7 +462,7 @@ print.dgr_graph <- function(x, ...) {
   number_of_actions_logged <- nrow(x$graph_log)
 
   tail_actions_logged <-
-    x$graph_log %>%
+    x$graph_log |>
     utils::tail(3)
 
   number_of_actions_in_tail <-

--- a/R/recode_edge_attrs.R
+++ b/R/recode_edge_attrs.R
@@ -24,11 +24,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 4,
 #'     m = 6,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_edge_attrs(
 #'     edge_attr = rel,
 #'     values = c("a", "b", "a",
@@ -37,7 +37,7 @@
 #' # Get the graph's internal edf
 #' # to show which edge attributes
 #' # are available
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Recode the `rel` node
 #' # attribute, creating a new edge
@@ -46,7 +46,7 @@
 #' # `b` maps to `1.5`, and all
 #' # other values become `0.5`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   recode_edge_attrs(
 #'     edge_attr_from = rel,
 #'     "a -> 1.0",
@@ -59,7 +59,7 @@
 #' # attribute values had been
 #' # recoded and copied into a
 #' # new node attribute
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -83,11 +83,11 @@ recode_edge_attrs <- function(
 
   # Get the requested `edge_attr_from`
   edge_attr_from <-
-    rlang::enquo(edge_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `edge_attr_to`
   edge_attr_to <-
-    rlang::enquo(edge_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_to) |> rlang::get_expr() |> as.character()
 
 
   if (length(edge_attr_to) == 0) {

--- a/R/recode_node_attrs.R
+++ b/R/recode_node_attrs.R
@@ -24,11 +24,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 10,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = shape,
 #'     values =
@@ -39,14 +39,14 @@
 #' # Get the graph's internal ndf
 #' # to show which node
 #' # attributes are available
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Recode the `shape` node
 #' # attribute, so that `circle`
 #' # is recoded to `square` and that
 #' # `rectangle` becomes `triangle`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   recode_node_attrs(
 #'     node_attr_from = shape,
 #'     "circle -> square",
@@ -55,7 +55,7 @@
 #' # Get the graph's internal
 #' # ndf to show that the node
 #' # attribute values had been recoded
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Create a new node attribute,
 #' # called `color`, that is based
@@ -64,7 +64,7 @@
 #' # color and map all other shapes
 #' # to a `green` color
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   recode_node_attrs(
 #'     node_attr_from = shape,
 #'     "square -> red",
@@ -73,7 +73,7 @@
 #'
 #' # Get the graph's internal ndf
 #' # to see the change
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -97,11 +97,11 @@ recode_node_attrs <- function(
 
   # Get the requested `node_attr_from`
   node_attr_from <-
-    rlang::enquo(node_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `node_attr_to`
   node_attr_to <-
-    rlang::enquo(node_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_to) |> rlang::get_expr() |> as.character()
 
   if (length(node_attr_to) == 0) {
     node_attr_to <- NULL

--- a/R/remove_graph_from_graph_series.R
+++ b/R/remove_graph_from_graph_series.R
@@ -15,39 +15,39 @@
 #' @examples
 #' # Create three graphs
 #' graph_1 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 4)
 #'
 #' graph_2 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' graph_3 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_star(n = 6)
 #'
 #' # Create an empty graph series
 #' # and add the graphs
 #' series <-
-#'   create_graph_series() %>%
+#'   create_graph_series() |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_1) %>%
+#'     graph = graph_1) |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_2) %>%
+#'     graph = graph_2) |>
 #'   add_graph_to_graph_series(
 #'     graph = graph_3)
 #'
 #' # Remove the second graph
 #' # from the graph series
 #' series <-
-#'   series %>%
+#'   series |>
 #'   remove_graph_from_graph_series(
 #'     index = 2)
 #'
 #' # With `get_graph_series_info()`,
 #' # we can ensure that a graph
 #' # was removed
-#' series %>%
+#' series |>
 #'   get_graph_series_info()
 #'
 #' @export

--- a/R/rename_edge_attrs.R
+++ b/R/rename_edge_attrs.R
@@ -16,11 +16,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 8,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_edge_attrs(
 #'     edge_attr = color,
 #'     values = "green")
@@ -28,12 +28,12 @@
 #' # Get the graph's internal edf
 #' # to show which edge attributes
 #' # are available
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Rename the `color` node
 #' # attribute as `weight`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   rename_edge_attrs(
 #'     edge_attr_from = color,
 #'     edge_attr_to = labelfontcolor)
@@ -41,7 +41,7 @@
 #' # Get the graph's internal
 #' # edf to show that the edge
 #' # attribute had been renamed
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -63,11 +63,11 @@ rename_edge_attrs <- function(
 
   # Get the requested `edge_attr_from`
   edge_attr_from <-
-    rlang::enquo(edge_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `edge_attr_to`
   edge_attr_to <-
-    rlang::enquo(edge_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_to) |> rlang::get_expr() |> as.character()
 
   # Stop function if `edge_attr_from` and
   # `edge_attr_to` are identical

--- a/R/rename_node_attrs.R
+++ b/R/rename_node_attrs.R
@@ -16,30 +16,30 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 8,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = shape,
-#'     values = "circle") %>%
+#'     values = "circle") |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 5,
 #'       mean = 5,
-#'       sd = 1) %>% round(1))
+#'       sd = 1) |> round(1))
 #'
 #' # Get the graph's internal ndf
 #' # to show which node attributes
 #' # are available
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Rename the `value` node
 #' # attribute as `weight`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   rename_node_attrs(
 #'     node_attr_from = value,
 #'     node_attr_to = weight)
@@ -47,7 +47,7 @@
 #' # Get the graph's internal
 #' # ndf to show that the node
 #' # attribute had been renamed
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -69,11 +69,11 @@ rename_node_attrs <- function(
 
   # Get the requested `node_attr_from`
   node_attr_from <-
-    rlang::enquo(node_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `node_attr_to`
   node_attr_to <-
-    rlang::enquo(node_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_to) |> rlang::get_expr() |> as.character()
 
   # Stop function if `node_attr_from` and
   # `node_attr_to` are identical

--- a/R/render_graph.R
+++ b/R/render_graph.R
@@ -22,47 +22,47 @@
 #'
 #'   # Render a graph that's a
 #'   # balanced tree
-#'   create_graph() %>%
+#'   create_graph() |>
 #'     add_balanced_tree(
 #'       k = 2, h = 3
-#'     ) %>%
+#'     ) |>
 #'     render_graph()
 #'
 #'   # Use the `tree` layout for
 #'   # better node placement in this
 #'   # hierarchical graph
-#'   create_graph() %>%
+#'   create_graph() |>
 #'     add_balanced_tree(
 #'       k = 2, h = 3
-#'     ) %>%
+#'     ) |>
 #'     render_graph(layout = "tree")
 #'
 #'   # Plot the same tree graph but
 #'   # don't show the node ID values
-#'   create_graph() %>%
+#'   create_graph() |>
 #'     add_balanced_tree(
 #'       k = 2, h = 3
-#'     ) %>%
-#'     set_node_attr_to_display() %>%
+#'     ) |>
+#'     set_node_attr_to_display() |>
 #'     render_graph(layout = "tree")
 #'
 #'   # Create a circle graph
-#'   create_graph() %>%
+#'   create_graph() |>
 #'     add_gnm_graph(
 #'       n = 55,
 #'       m = 75,
 #'       set_seed = 23
-#'     ) %>%
+#'     ) |>
 #'     render_graph(
 #'       layout = "circle"
 #'     )
 #'
 #'   # Render the graph using the
 #'   # `visNetwork` output option
-#'   create_graph() %>%
+#'   create_graph() |>
 #'     add_balanced_tree(
 #'       k = 2, h = 3
-#'     ) %>%
+#'     ) |>
 #'     render_graph(
 #'       output = "visNetwork"
 #'     )
@@ -119,9 +119,9 @@ render_graph <- function(
     if ("fillcolor" %in% graph$global_attrs$attr) {
 
       graph$nodes_df$fillcolor <-
-        graph$global_attrs %>%
-        dplyr::filter(attr == "fillcolor", attr_type == "node") %>%
-        dplyr::pull("value") %>%
+        graph$global_attrs |>
+        dplyr::filter(attr == "fillcolor", attr_type == "node") |>
+        dplyr::pull("value") |>
         as.character()
     } else {
       graph$nodes_df$fillcolor <- "white"
@@ -142,13 +142,13 @@ render_graph <- function(
   if ("fillcolor" %in% colnames(graph$nodes_df)) {
 
     graph$nodes_df <-
-      graph$nodes_df %>%
+      graph$nodes_df |>
       dplyr::left_join(
-        x11_hex() %>%
-          dplyr::as_tibble() %>%
+        x11_hex() |>
+          dplyr::as_tibble() |>
           dplyr::mutate(hex = toupper(hex)),
         by = c("fillcolor" = "x11_name")
-      ) %>%
+      ) |>
       dplyr::mutate(
         fillcolor = dplyr::coalesce(hex, fillcolor),
         .keep = "unused"
@@ -161,8 +161,8 @@ render_graph <- function(
   ) {
 
     graph$nodes_df$fontcolor <-
-      tibble::tibble(value = graph$nodes_df$fillcolor) %>%
-      dplyr::mutate(value_x = contrasting_text_color(background_color = value)) %>%
+      tibble::tibble(value = graph$nodes_df$fillcolor) |>
+      dplyr::mutate(value_x = contrasting_text_color(background_color = value)) |>
       dplyr::pull("value_x")
   }
 
@@ -192,7 +192,7 @@ render_graph <- function(
     # different layouts
     if (layout == "tree") {
       m_coords <-
-        to_igraph(graph) %>%
+        to_igraph(graph) |>
         igraph::layout_with_sugiyama()
       m_coords <- m_coords[["layout"]]
 
@@ -217,8 +217,8 @@ render_graph <- function(
                           "neato" = igraph::layout_with_fr
       )
 
-      m_coords <- graph %>%
-        to_igraph() %>%
+      m_coords <- graph |>
+        to_igraph() |>
         fn_igraph()
 
       if (!is.matrix(m_coords)) {
@@ -274,7 +274,7 @@ render_graph <- function(
     svg_vec <-
       strsplit(DiagrammeRsvg::export_svg(
         grViz(diagram = dot_code)
-      ), "\n") %>%
+      ), "\n") |>
       unlist()
 
     # Get a tibble of SVG data
@@ -283,36 +283,36 @@ render_graph <- function(
     svg_lines <-
       "<svg display=\"block\" margin=\"0 auto\" position=\"absolute\" width=\"100%\" height=\"100%\""
 
-    svg_line_no <- svg_tbl %>%
-      dplyr::filter(type == "svg") %>%
+    svg_line_no <- svg_tbl |>
+      dplyr::filter(type == "svg") |>
       dplyr::pull("index")
 
     # Modify <svg> attrs
     svg_vec[svg_line_no] <- svg_lines
 
-    if ("image" %in% colnames(graph %>% get_node_df())) {
+    if ("image" %in% colnames(graph |> get_node_df())) {
       node_id_images <-
-        graph %>%
-        get_node_df() %>%
-        dplyr::select("id", "image") %>%
-        dplyr::filter(nzchar(image)) %>%
+        graph |>
+        get_node_df() |>
+        dplyr::select("id", "image") |>
+        dplyr::filter(nzchar(image)) |>
         dplyr::pull("id")
 
       filter_lines <-
-        graph %>%
-        get_node_df() %>%
-        dplyr::select("id", "image") %>%
-        dplyr::filter(nzchar(image)) %>%
-        dplyr::mutate(filter_lines = as.character(glue::glue("<filter id=\"{id}\" x=\"0%\" y=\"0%\" width=\"100%\" height=\"100%\"><feImage xlink:href=\"{image}\"/></filter>"))) %>%
-        dplyr::pull("filter_lines") %>%
+        graph |>
+        get_node_df() |>
+        dplyr::select("id", "image") |>
+        dplyr::filter(nzchar(image)) |>
+        dplyr::mutate(filter_lines = as.character(glue::glue("<filter id=\"{id}\" x=\"0%\" y=\"0%\" width=\"100%\" height=\"100%\"><feImage xlink:href=\"{image}\"/></filter>"))) |>
+        dplyr::pull("filter_lines") |>
         paste(collapse = "\n")
 
       filter_shape_refs <- as.character(glue::glue(" filter=\"url(#{node_id_images})\" "))
 
       svg_shape_nos <-
-        svg_tbl %>%
-        dplyr::filter(node_id %in% node_id_images) %>%
-        dplyr::filter(type == "node_block") %>%
+        svg_tbl |>
+        dplyr::filter(node_id %in% node_id_images) |>
+        dplyr::filter(type == "node_block") |>
         dplyr::pull("index")
 
       svg_shape_nos <- svg_shape_nos + 3
@@ -332,22 +332,22 @@ render_graph <- function(
     }
 
     # # Get the name of the function
-    # if ("fa_icon" %in% colnames(graph %>% get_node_df())) {
+    # if ("fa_icon" %in% colnames(graph |> get_node_df())) {
     #
     #   # Using a fontawesome icon requires the fontawesome package;
     #   # if it's not present, stop with a message
     #   if (requireNamespace("fontawesome", quietly = TRUE)) {
     #
     #     node_id_fa <-
-    #       graph %>%
-    #       get_node_df() %>%
-    #       dplyr::select(id, fa_icon) %>%
-    #       dplyr::filter(fa_icon != "") %>%
-    #       dplyr::filter(!is.na(fa_icon)) %>%
+    #       graph |>
+    #       get_node_df() |>
+    #       dplyr::select(id, fa_icon) |>
+    #       dplyr::filter(fa_icon != "") |>
+    #       dplyr::filter(!is.na(fa_icon)) |>
     #       dplyr::mutate(fa_uri = NA_character_)
     #
     #     node_id_svg <-
-    #       node_id_fa %>%
+    #       node_id_fa |>
     #       dplyr::pull(id)
     #
     #     for (i in seq(nrow(node_id_fa))) {
@@ -369,16 +369,16 @@ render_graph <- function(
     #     }
     #
     #     filter_lines <-
-    #       node_id_fa %>%
-    #       dplyr::pull(fa_uri) %>%
+    #       node_id_fa |>
+    #       dplyr::pull(fa_uri) |>
     #       paste(collapse = "\n")
     #
     #     filter_shape_refs <- as.character(glue::glue(" filter=\"url(#{node_id_svg})\" "))
     #
     #     svg_shape_nos <-
-    #       svg_tbl %>%
-    #       dplyr::filter(node_id %in% node_id_svg) %>%
-    #       dplyr::filter(type == "node_block") %>%
+    #       svg_tbl |>
+    #       dplyr::filter(node_id %in% node_id_svg) |>
+    #       dplyr::filter(type == "node_block") |>
     #       dplyr::pull(index)
     #
     #     svg_shape_nos <- svg_shape_nos + 3

--- a/R/render_graph_from_graph_series.R
+++ b/R/render_graph_from_graph_series.R
@@ -18,25 +18,25 @@
 #' \dontrun{
 #' # Create three graphs
 #' graph_1 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 4)
 #'
 #' graph_2 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 5)
 #'
 #' graph_3 <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_star(n = 6)
 #'
 #' # Create an empty graph series
 #' # and add the graphs
 #' series <-
-#'   create_graph_series() %>%
+#'   create_graph_series() |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_1) %>%
+#'     graph = graph_1) |>
 #'   add_graph_to_graph_series(
-#'     graph = graph_2) %>%
+#'     graph = graph_2) |>
 #'   add_graph_to_graph_series(
 #'     graph = graph_3)
 #'

--- a/R/reorder_graph_actions.R
+++ b/R/reorder_graph_actions.R
@@ -18,7 +18,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 4,
 #'     m = 4,
@@ -27,17 +27,17 @@
 #' # Add three graph actions to the
 #' # graph
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_graph_action(
 #'     fcn = "rescale_node_attrs",
 #'     node_attr_from = "pagerank",
 #'     node_attr_to = "width",
-#'     action_name = "pgrnk_to_width") %>%
+#'     action_name = "pgrnk_to_width") |>
 #'   add_graph_action(
 #'     fcn = "set_node_attr_w_fcn",
 #'     node_attr_fcn = "get_pagerank",
 #'     column_name = "pagerank",
-#'     action_name = "get_pagerank") %>%
+#'     action_name = "get_pagerank") |>
 #'   add_graph_action(
 #'     fcn = "colorize_node_attrs",
 #'     node_attr_from = "width",
@@ -47,7 +47,7 @@
 #' # View the graph actions for the graph
 #' # object by using the function called
 #' # `get_graph_actions()`
-#' graph %>% get_graph_actions()
+#' graph |> get_graph_actions()
 #'
 #' # We note that the order isn't
 #' # correct and that the `get_pagerank`
@@ -58,14 +58,14 @@
 #' # and specify the reordering with a
 #' # numeric vector
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   reorder_graph_actions(
 #'     indices = c(2, 1, 3))
 #'
 #' # View the graph actions for the graph
 #' # object once again to verify that
 #' # we have the desired order of actions
-#' graph %>% get_graph_actions()
+#' graph |> get_graph_actions()
 #'
 #' @export
 reorder_graph_actions <- function(
@@ -90,8 +90,8 @@ reorder_graph_actions <- function(
   # Get the `action_index` values
   # available in `graph$graph_actions`
   available_indices <-
-    graph %>%
-    get_graph_actions() %>%
+    graph |>
+    get_graph_actions() |>
     dplyr::pull("action_index")
 
   # Verify that the provided values
@@ -117,7 +117,7 @@ reorder_graph_actions <- function(
   # Get a revised data frame with graph actions
   # in the requested order
   revised_graph_actions <-
-    graph_actions_tbl[revised_indices, ] %>%
+    graph_actions_tbl[revised_indices, ] |>
     dplyr::mutate(action_index = dplyr::row_number())
 
   # Replace `graph$graph_actions` with the

--- a/R/rescale_edge_attrs.R
+++ b/R/rescale_edge_attrs.R
@@ -27,28 +27,28 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 7,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_edge_attrs(
 #'     edge_attr = weight,
 #'     values = rnorm(
-#'       n = count_edges(.),
+#'       n = 7,
 #'       mean = 5,
 #'       sd = 1))
 #'
 #' # Get the graph's internal edf
 #' # to show which edge attributes
 #' # are available
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Rescale the `weight` edge
 #' # attribute, so that its values
 #' # are rescaled between 0 and 1
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   rescale_edge_attrs(
 #'     edge_attr_from = weight,
 #'     to_lower_bound = 0,
@@ -57,7 +57,7 @@
 #' # Get the graph's internal edf
 #' # to show that the edge attribute
 #' # values had been rescaled
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Scale the values in the `weight`
 #' # edge attribute to different
@@ -66,12 +66,12 @@
 #' # numerical values for the
 #' # `penwidth` attribute
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   rescale_edge_attrs(
 #'     edge_attr_from = weight,
 #'     to_lower_bound = "gray80",
 #'     to_upper_bound = "gray20",
-#'     edge_attr_to = color) %>%
+#'     edge_attr_to = color) |>
 #'   rescale_edge_attrs(
 #'     edge_attr_from = weight,
 #'     to_lower_bound = 0.5,
@@ -84,7 +84,7 @@
 #' # in `color` and scaled numerical
 #' # values are in the `penwidth`
 #' # edge attribute
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -110,11 +110,11 @@ rescale_edge_attrs <- function(
 
   # Get the requested `edge_attr_from`
   edge_attr_from <-
-    rlang::enquo(edge_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `edge_attr_to`
   edge_attr_to <-
-    rlang::enquo(edge_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr_to) |> rlang::get_expr() |> as.character()
 
   if (length(edge_attr_to) == 0) {
     edge_attr_to <- NULL
@@ -136,11 +136,11 @@ rescale_edge_attrs <- function(
 
   # Extract the vector to rescale from the `edges` df
   vector_to_rescale <-
-    edges %>%
+    edges |>
     dplyr::mutate(
       dplyr::across(
         dplyr::all_of(edge_attr_from),
-        as.numeric)) %>%
+        as.numeric)) |>
     dplyr::pull(var = !!edge_attr_from)
 
   # TODO condition could be simplified to

--- a/R/rescale_node_attrs.R
+++ b/R/rescale_node_attrs.R
@@ -27,28 +27,28 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 10,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 5,
 #'       mean = 5,
-#'       sd = 1) %>% round(1))
+#'       sd = 1) |> round(1))
 #'
 #' # Get the graph's internal ndf
 #' # to show which node attributes
 #' # are available
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Rescale the `value` node
 #' # attribute, so that its values
 #' # are rescaled between 0 and 1
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   rescale_node_attrs(
 #'     node_attr_from = value,
 #'     to_lower_bound = 0,
@@ -57,19 +57,19 @@
 #' # Get the graph's internal ndf
 #' # to show that the node attribute
 #' # values had been rescaled
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Scale the values in the `value`
 #' # node attribute to different
 #' # shades of gray for the `fillcolor`
 #' # and `fontcolor` node attributes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   rescale_node_attrs(
 #'     node_attr_from = value,
 #'     to_lower_bound = "gray80",
 #'     to_upper_bound = "gray20",
-#'     node_attr_to = fillcolor) %>%
+#'     node_attr_to = fillcolor) |>
 #'   rescale_node_attrs(
 #'     node_attr_from = value,
 #'     to_lower_bound = "gray5",
@@ -81,7 +81,7 @@
 #' # grayscale colors are now available
 #' # in the `fillcolor` and `fontcolor`
 #' # node attributes
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -107,11 +107,11 @@ rescale_node_attrs <- function(
 
   # Get the requested `node_attr_from`
   node_attr_from <-
-    rlang::enquo(node_attr_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `node_attr_to`
   node_attr_to <-
-    rlang::enquo(node_attr_to) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr_to) |> rlang::get_expr() |> as.character()
 
   if (length(node_attr_to) == 0) {
     node_attr_to <- NULL
@@ -133,12 +133,12 @@ rescale_node_attrs <- function(
 
   # Extract the vector to rescale from the `nodes` df
   vector_to_rescale <-
-    nodes %>%
+    nodes |>
     dplyr::mutate(
       dplyr::across(
         dplyr::all_of(node_attr_from),
         .fns = as.numeric)
-      ) %>%
+      ) |>
     dplyr::pull(var = !!node_attr_from)
 
   # TODO condition could be simplified to

--- a/R/rev_edge_dir.R
+++ b/R/rev_edge_dir.R
@@ -13,23 +13,23 @@
 #' # Create a graph with a
 #' # directed tree
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
 #'     k = 2, h = 2)
 #'
 #' # Inspect the graph's edges
-#' graph %>% get_edges()
+#' graph |> get_edges()
 #'
 #' # Reverse the edge directions
 #' # such that edges are directed
 #' # toward the root of the tree
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   rev_edge_dir()
 #'
 #' # Inspect the graph's edges
 #' # after their reversal
-#' graph %>% get_edges()
+#' graph |> get_edges()
 #'
 #' @family edge creation and removal
 #'

--- a/R/rev_edge_dir_ws.R
+++ b/R/rev_edge_dir_ws.R
@@ -24,17 +24,17 @@
 #' # Create a graph with a
 #' # directed tree
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
 #'     k = 2, h = 2)
 #'
 #' # Inspect the graph's edges
-#' graph %>% get_edges()
+#' graph |> get_edges()
 #'
 #' # Select all edges associated
 #' # with nodes `1` and `2`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges_by_node_id(
 #'     nodes = 1:2)
 #'
@@ -42,12 +42,12 @@
 #' # of the edges associated with
 #' # nodes `1` and `2`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   rev_edge_dir_ws()
 #'
 #' # Inspect the graph's edges
 #' # after their reversal
-#' graph %>% get_edges()
+#' graph |> get_edges()
 #'
 #' @family edge creation and removal
 #'
@@ -85,12 +85,12 @@ rev_edge_dir_ws <- function(graph) {
   # Selectively modify the edge direction and create
   # a new edf
   edges_new <-
-    edges %>%
-    dplyr::filter(id %in% edge_ids) %>%
-    dplyr::filter(from != to) %>%
-    dplyr::rename(from = "to", to = "from") %>%
-    dplyr::relocate("id", "from", "to") %>%
-    dplyr::bind_rows(edges %>% dplyr::filter(!(id %in% edge_ids)))
+    edges |>
+    dplyr::filter(id %in% edge_ids) |>
+    dplyr::filter(from != to) |>
+    dplyr::rename(from = "to", to = "from") |>
+    dplyr::relocate("id", "from", "to") |>
+    dplyr::bind_rows(edges |> dplyr::filter(!(id %in% edge_ids)))
 
   # Modify the graph object
   graph$edges_df <- edges_new

--- a/R/save_graph.R
+++ b/R/save_graph.R
@@ -15,7 +15,7 @@
 #' # a probability value of 0.05
 #' gnp_graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_gnp_graph(
 #'     n = 100,
 #'     p = 0.05)
@@ -51,7 +51,7 @@ save_graph <- function(
   }
 
   # Append the file extension to the file path
-  file_name <- file %>% paste0(".dgr")
+  file_name <- file |> paste0(".dgr")
 
   # Save the graph or graph series
   saveRDS(x, file = file_name, compress = "xz")

--- a/R/select_edges.R
+++ b/R/select_edges.R
@@ -45,41 +45,41 @@
 #'
 #' # Explicitly select the edge `1`->`4`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges(
 #'     from = 1,
 #'     to = 4)
 #'
 #' # Verify that an edge selection has been made
 #' # using the `get_selection()` function
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Select edges based on the relationship label
 #' # being `z`
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
+#'   graph |>
+#'   clear_selection() |>
 #'   select_edges(
 #'     conditions = rel == "z")
 #'
 #' # Verify that an edge selection has been made, and
 #' # recall that the `2`->`3` edge uniquely has the
 #' # `z` relationship label
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Select edges based on the edge value attribute
 #' # being greater than 3.0 (first clearing the current
 #' # selection of edges)
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
+#'   graph |>
+#'   clear_selection() |>
 #'   select_edges(
 #'     conditions = value > 3.0)
 #'
 #' # Verify that the correct edge selection has been
 #' # made; in this case, edges `1`->`4` and
 #' # `3`->`1` have values for `value` > 3.0
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 select_edges <- function(
@@ -140,7 +140,7 @@ select_edges <- function(
     from_val <- from
 
     edges_df <-
-      edges_df %>%
+      edges_df |>
       dplyr::filter(from %in% from_val)
   }
 
@@ -157,13 +157,13 @@ select_edges <- function(
     to_val <- to
 
     edges_df <-
-      edges_df %>%
+      edges_df |>
       dplyr::filter(to %in% to_val)
   }
 
   # Select only the `id`, `to`, and `from` columns
   edges_selected <-
-    edges_df %>%
+    edges_df |>
     dplyr::select(edge = "id", "from", "to")
 
   # Create an integer vector representing edges
@@ -194,8 +194,8 @@ select_edges <- function(
 
   # Filter `edges_df` to provide the correct esdf
   edges_combined <-
-    graph$edges_df %>%
-    dplyr::filter(id %in% edges_combined) %>%
+    graph$edges_df |>
+    dplyr::filter(id %in% edges_combined) |>
     dplyr::select(edge = "id", "from", "to")
 
   # Add the edge ID values to the active selection

--- a/R/select_edges_by_edge_id.R
+++ b/R/select_edges_by_edge_id.R
@@ -17,39 +17,39 @@
 #' @examples
 #' # Create a graph with 5 nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 5)
 #'
 #' # Create a graph selection by selecting
 #' # edges with edge IDs `1` and `2`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges_by_edge_id(
 #'     edges = 1:2)
 #'
 #' # Get the selection of edges
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Perform another selection of edges,
 #' # with edge IDs `1`, `2`, and `4`
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
+#'   graph |>
+#'   clear_selection() |>
 #'   select_edges_by_edge_id(
 #'     edges = c(1, 2, 4))
 #'
 #' # Get the selection of edges
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Get the fraction of edges selected
 #' # over all the edges in the graph
-#' graph %>%
-#'   {
-#'     l <- get_selection(.) %>%
-#'       length(.)
-#'     e <- count_edges(.)
-#'     l/e
-#'   }
+#' l <- graph |>
+#'   get_selection() |>
+#'   length()
+#'
+#' e <- graph |> count_edges()
+#'
+#' l/e
 #'
 #' @export
 select_edges_by_edge_id <- function(
@@ -72,7 +72,7 @@ select_edges_by_edge_id <- function(
 
   # Filter the edf by the requested edge IDs
   edges_selected <-
-    edges_df %>%
+    edges_df |>
     dplyr::filter(id %in% edges)
 
   # Obtain the input graph's node and edge
@@ -102,8 +102,8 @@ select_edges_by_edge_id <- function(
 
   # Filter `edges_df` to provide the correct esdf
   edges_combined <-
-    graph$edges_df %>%
-    dplyr::filter(id %in% edges_combined) %>%
+    graph$edges_df |>
+    dplyr::filter(id %in% edges_combined) |>
     dplyr::select(edge = "id", from, to)
 
   # Add the edge ID values to the active selection

--- a/R/select_edges_by_node_id.R
+++ b/R/select_edges_by_node_id.R
@@ -18,39 +18,39 @@
 #' @examples
 #' # Create a graph with 5 nodes
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 5)
 #'
 #' # Create a graph selection by selecting edges
 #' # associated with nodes `1` and `2`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges_by_node_id(
 #'     nodes = 1:2)
 #'
 #' # Get the selection of edges
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Perform another selection of edges, with nodes
 #' # `1`, `2`, and `4`
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
+#'   graph |>
+#'   clear_selection() |>
 #'   select_edges_by_node_id(
 #'     nodes = c(1, 2, 4))
 #'
 #' # Get the selection of edges
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Get a fraction of the edges selected over all
 #' # the edges in the graph
-#' graph %>%
-#'   {
-#'     l <- get_selection(.) %>%
-#'       length(.)
-#'     e <- count_edges(.)
-#'     l/e
-#'   }
+#' l <- graph |>
+#'   get_selection() |>
+#'   length()
+#'
+#' e <- graph |> count_edges()
+#'
+#' l/e
 #'
 #' @export
 select_edges_by_node_id <- function(
@@ -76,7 +76,7 @@ select_edges_by_node_id <- function(
 
   # Filter the edf by the requested node IDs
   edges_selected <-
-    edges_df %>%
+    edges_df |>
     dplyr::filter(from %in% nodes | to %in% nodes)
 
   # Obtain the input graph's node and edge
@@ -106,8 +106,8 @@ select_edges_by_node_id <- function(
 
   # Filter `edges_df` to provide the correct esdf
   edges_combined <-
-    graph$edges_df %>%
-    dplyr::filter(id %in% edges_combined) %>%
+    graph$edges_df |>
+    dplyr::filter(id %in% edges_combined) |>
     dplyr::select(edge = "id", "from", "to")
 
   # Add the edge ID values to the active selection

--- a/R/select_last_edges_created.R
+++ b/R/select_last_edges_created.R
@@ -14,10 +14,10 @@
 #' # Create a graph and add a cycle and then
 #' # a tree in 2 separate function calls
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(
 #'     n = 3,
-#'     rel = "a") %>%
+#'     rel = "a") |>
 #'   add_balanced_tree(
 #'     k = 2, h = 2,
 #'     rel = "b")
@@ -26,16 +26,16 @@
 #' # from the tree) and then set their edge
 #' # color to be `red`
 #' graph <-
-#'   graph %>%
-#'   select_last_edges_created() %>%
+#'   graph |>
+#'   select_last_edges_created() |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = color,
-#'     value = "red") %>%
+#'     value = "red") |>
 #'   clear_selection()
 #'
 #' # Display the graph's internal edge
 #' # data frame to verify the change
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @export
 select_last_edges_created <- function(graph) {
@@ -50,25 +50,25 @@ select_last_edges_created <- function(graph) {
   check_graph_contains_edges(graph)
 
   graph_transform_steps <-
-    graph$graph_log %>%
+    graph$graph_log |>
     dplyr::mutate(
       step_created_edges = as.integer(function_used %in% edge_creation_functions()),
       step_deleted_edges = as.integer(function_used %in% edge_deletion_functions()),
       step_init_with_edges = as.integer(function_used %in% graph_init_functions() &
                                           edges > 0)
-    ) %>%
+    ) |>
     dplyr::filter(
       dplyr::if_any(
         .cols = c(step_created_edges, step_deleted_edges, step_init_with_edges),
         .fns = function(x) x == 1
       )
-    ) %>%
+    ) |>
     dplyr::select(-"version_id", -"time_modified", -"duration")
 
   if (nrow(graph_transform_steps) > 0) {
 
-    if (graph_transform_steps %>%
-        utils::tail(1) %>%
+    if (graph_transform_steps |>
+        utils::tail(1) |>
         dplyr::pull(step_deleted_edges) == 1) {
 
       cli::cli_abort(
@@ -77,25 +77,25 @@ select_last_edges_created <- function(graph) {
     } else {
       if (nrow(graph_transform_steps) > 1) {
         number_of_edges_created <-
-          (graph_transform_steps %>%
-             dplyr::select(edges) %>%
-             utils::tail(2) %>%
+          (graph_transform_steps |>
+             dplyr::select(edges) |>
+             utils::tail(2) |>
              dplyr::pull(edges))[2] -
-          (graph_transform_steps %>%
-             dplyr::select(edges) %>%
-             utils::tail(2) %>%
+          (graph_transform_steps |>
+             dplyr::select(edges) |>
+             utils::tail(2) |>
              dplyr::pull(edges))[1]
       } else {
         number_of_edges_created <-
-          graph_transform_steps %>%
+          graph_transform_steps |>
           dplyr::pull(edges)
       }
     }
 
     edge_id_values <-
-      graph$edges_df %>%
-      dplyr::select("id") %>%
-      utils::tail(number_of_edges_created) %>%
+      graph$edges_df |>
+      dplyr::select("id") |>
+      utils::tail(number_of_edges_created) |>
       dplyr::pull(id)
   } else {
     edge_id_values <- NA
@@ -116,7 +116,7 @@ select_last_edges_created <- function(graph) {
 
     # Update the `graph_log` df with an action
     graph$graph_log <-
-      graph$graph_log[-nrow(graph$graph_log), ] %>%
+      graph$graph_log[-nrow(graph$graph_log), ] |>
       add_action_to_log(
         version_id = nrow(graph$graph_log) + 1L,
         function_used = fcn_name,

--- a/R/select_last_nodes_created.R
+++ b/R/select_last_nodes_created.R
@@ -14,11 +14,11 @@
 #' # Create a graph and add 4 nodes
 #' # in 2 separate function calls
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("a_1", "a_2")) %>%
+#'     label = c("a_1", "a_2")) |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "b",
@@ -28,16 +28,16 @@
 #' # from the last function call) and then
 #' # set their color to be `red`
 #' graph <-
-#'   graph %>%
-#'   select_last_nodes_created() %>%
+#'   graph |>
+#'   select_last_nodes_created() |>
 #'   set_node_attrs_ws(
 #'     node_attr = color,
-#'     value = "red") %>%
+#'     value = "red") |>
 #'   clear_selection()
 #'
 #' # Display the graph's internal node
 #' # data frame to verify the change
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 select_last_nodes_created <- function(graph) {
@@ -52,25 +52,25 @@ select_last_nodes_created <- function(graph) {
   check_graph_contains_nodes(graph)
 
   graph_transform_steps <-
-    graph$graph_log %>%
+    graph$graph_log |>
     dplyr::mutate(
       step_created_nodes = as.integer(function_used %in% node_creation_functions()),
       step_deleted_nodes = as.integer(function_used %in% node_deletion_functions()),
       step_init_with_nodes = as.integer(function_used %in% graph_init_functions() &
                                           nodes > 0)
-    ) %>%
+    ) |>
     dplyr::filter(
       dplyr::if_any(
         c(step_created_nodes, step_deleted_nodes, step_init_with_nodes),
         .fns = function(x) x == 1
       )
-    ) %>%
+    ) |>
     dplyr::select(-"version_id", -"time_modified", -"duration")
 
   if (nrow(graph_transform_steps) > 0) {
 
-    if (graph_transform_steps %>%
-        utils::tail(1) %>%
+    if (graph_transform_steps |>
+        utils::tail(1) |>
         dplyr::pull(step_deleted_nodes) == 1) {
 
       cli::cli_abort(
@@ -79,25 +79,25 @@ select_last_nodes_created <- function(graph) {
     } else {
       if (nrow(graph_transform_steps) > 1) {
         number_of_nodes_created <-
-          (graph_transform_steps %>%
-             dplyr::select(nodes) %>%
-             utils::tail(2) %>%
+          (graph_transform_steps |>
+             dplyr::select(nodes) |>
+             utils::tail(2) |>
              dplyr::pull(nodes))[2] -
-          (graph_transform_steps %>%
-             dplyr::select(nodes) %>%
-             utils::tail(2) %>%
+          (graph_transform_steps |>
+             dplyr::select(nodes) |>
+             utils::tail(2) |>
              dplyr::pull(nodes))[1]
       } else {
         number_of_nodes_created <-
-          graph_transform_steps %>%
+          graph_transform_steps |>
           dplyr::pull("nodes")
       }
     }
 
     node_id_values <-
-      graph$nodes_df %>%
-      dplyr::select("id") %>%
-      utils::tail(number_of_nodes_created) %>%
+      graph$nodes_df |>
+      dplyr::select("id") |>
+      utils::tail(number_of_nodes_created) |>
       dplyr::pull("id")
   } else {
     node_id_values <- NA
@@ -117,7 +117,7 @@ select_last_nodes_created <- function(graph) {
 
     # Update the `graph_log` df with an action
     graph$graph_log <-
-      graph$graph_log[-nrow(graph$graph_log), ] %>%
+      graph$graph_log[-nrow(graph$graph_log), ] |>
       add_action_to_log(
         version_id = nrow(graph$graph_log) + 1L,
         function_used = fcn_name,

--- a/R/select_nodes.R
+++ b/R/select_nodes.R
@@ -40,39 +40,39 @@
 #'
 #' # Explicitly select nodes `1` and `3`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes(nodes = c(1, 3))
 #'
 #' # Verify that the node selection has been made
 #' # using the `get_selection()` function
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Select nodes based on the node `type`
 #' # being `z`
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
+#'   graph |>
+#'   clear_selection() |>
 #'   select_nodes(
 #'     conditions = type == "z")
 #'
 #' # Verify that an node selection has been made, and
 #' # recall that the `3` and `4` nodes are of the
 #' # `z` type
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Select edges based on the node value attribute
 #' # being greater than 3.0 (first clearing the current
 #' # selection of nodes)
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
+#'   graph |>
+#'   clear_selection() |>
 #'   select_nodes(
 #'     conditions = value > 3.0)
 #'
 #' # Verify that the correct node selection has been
 #' # made; in this case, nodes `1` and `3` have values
 #' # for `value` greater than 3.0
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 select_nodes <- function(
@@ -119,7 +119,7 @@ select_nodes <- function(
 
   # Get the nodes as a vector
   nodes_selected <-
-    nodes_df %>%
+    nodes_df |>
     dplyr::pull("id")
 
   # If a `nodes` vector provided, get the intersection

--- a/R/select_nodes_by_degree.R
+++ b/R/select_nodes_by_degree.R
@@ -22,7 +22,7 @@
 #' # Create a random graph using
 #' # the `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 35, m = 125,
 #'     set_seed = 23)
@@ -30,17 +30,17 @@
 #' # Report which nodes have a
 #' # total degree (in-degree +
 #' # out-degree) of exactly 9
-#' graph %>%
+#' graph |>
 #'   select_nodes_by_degree(
-#'     expressions = "deg == 9") %>%
+#'     expressions = "deg == 9") |>
 #'   get_selection()
 #'
 #' # Report which nodes have a
 #' # total degree greater than or
 #' # equal to 9
-#' graph %>%
+#' graph |>
 #'   select_nodes_by_degree(
-#'     expressions = "deg >= 9") %>%
+#'     expressions = "deg >= 9") |>
 #'   get_selection()
 #'
 #' # Combine two calls of
@@ -51,11 +51,11 @@
 #' # default, those `select...()`
 #' # functions will `union` the
 #' # sets of nodes selected)
-#' graph %>%
+#' graph |>
 #'   select_nodes_by_degree(
-#'     expressions = "deg < 3") %>%
+#'     expressions = "deg < 3") |>
 #'   select_nodes_by_degree(
-#'     expressions = "deg > 10") %>%
+#'     expressions = "deg > 10") |>
 #'   get_selection()
 #'
 #' # Combine two calls of
@@ -66,12 +66,12 @@
 #' # to 10 (the key here is to
 #' # `intersect` the sets of nodes
 #' # selected in the second call)
-#' graph %>%
+#' graph |>
 #'   select_nodes_by_degree(
-#'     expressions = "deg >= 3") %>%
+#'     expressions = "deg >= 3") |>
 #'   select_nodes_by_degree(
 #'     expressions = "deg <= 10",
-#'     set_op = "intersect") %>%
+#'     set_op = "intersect") |>
 #'   get_selection()
 #'
 #' # Select all nodes with an
@@ -80,15 +80,15 @@
 #' # selected nodes (coloring the
 #' # selected nodes red)
 #' graph_2 <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_degree(
-#'     expressions = "indeg > 5") %>%
+#'     expressions = "indeg > 5") |>
 #'   set_node_attrs_ws(
 #'     node_attr = color,
 #'     value = "red")
 #'
 #' # Get the selection of nodes
-#' graph_2 %>% get_selection()
+#' graph_2 |> get_selection()
 #'
 #' @export
 select_nodes_by_degree <- function(
@@ -113,8 +113,8 @@ select_nodes_by_degree <- function(
 
   # Get a data frame with node ID and degree types
   node_degree <-
-    get_node_info(graph) %>%
-    dplyr::select("id", "deg", "indeg", "outdeg") %>%
+    get_node_info(graph) |>
+    dplyr::select("id", "deg", "indeg", "outdeg") |>
     dplyr::filter(!!!parse_exprs(expressions))
 
   # Get the node ID values from the filtered table

--- a/R/select_nodes_by_id.R
+++ b/R/select_nodes_by_id.R
@@ -27,8 +27,8 @@
 #'
 #' # Select nodes `1` to `5` and show that
 #' # selection of nodes with `get_selection()`
-#' graph %>%
-#'   select_nodes_by_id(nodes = 1:5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 1:5) |>
 #'   get_selection()
 #'
 #' @export

--- a/R/select_nodes_in_neighborhood.R
+++ b/R/select_nodes_in_neighborhood.R
@@ -20,7 +20,7 @@
 #' # Create a graph containing
 #' # a balanced tree
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
 #'     k = 2, h = 2)
 #'
@@ -31,27 +31,27 @@
 #' # nodes that are 1 connection
 #' # away from node `1`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_in_neighborhood(
 #'     node = 1,
 #'     distance = 1)
 #'
 #' # Get the selection of nodes
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Perform another selection
 #' # of nodes, this time with a
 #' # neighborhood spanning 2 nodes
 #' # from node `1`
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
+#'   graph |>
+#'   clear_selection() |>
 #'   select_nodes_in_neighborhood(
 #'     node = 1,
 #'     distance = 2)
 #'
 #' # Get the selection of nodes
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 select_nodes_in_neighborhood <- function(

--- a/R/set_cache.R
+++ b/R/set_cache.R
@@ -18,7 +18,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 22,
@@ -29,15 +29,15 @@
 #' # all nodes from `1` to `10` and
 #' # store in the graph's cache
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_cache(
 #'     name = "closeness_vector",
-#'     to_cache = get_closeness(.),
+#'     to_cache = get_closeness(graph),
 #'     col = "closeness"
 #'   )
 #'
 #' # Get the graph's cache
-#' graph %>%
+#' graph |>
 #'   get_cache(name = "closeness_vector")
 #'
 #' # Get the difference of betweenness
@@ -45,16 +45,16 @@
 #' # the graph and store the vector in
 #' # the graph's cache
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_cache(
 #'     name = "difference",
 #'     to_cache =
-#'       get_betweenness(.)$betweenness -
-#'         get_closeness(.)$closeness
+#'       get_betweenness(graph)$betweenness -
+#'         get_closeness(graph)$closeness
 #'   )
 #'
 #' # Get the graph's cache
-#' graph %>%
+#' graph |>
 #'   get_cache(name = "difference")
 #'
 #' @export

--- a/R/set_edge_attr_to_display.R
+++ b/R/set_edge_attr_to_display.R
@@ -29,11 +29,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 4,
 #'     m = 4,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_edge_attrs(
 #'     edge_attr = value,
 #'     values = c(2.5, 8.2, 4.2, 2.4))
@@ -43,7 +43,7 @@
 #' # the edge `value` attribute (for
 #' # the other edges, display nothing)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_edge_attr_to_display(
 #'     edges = 1:3,
 #'     attr = value,
@@ -53,20 +53,20 @@
 #' # `display` edge attribute will show, for
 #' # each row, which edge attribute value to
 #' # display when the graph is rendered
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # This function can be called multiple
 #' # times on a graph; after the first time
 #' # (i.e., creation of the `display`
 #' # attribute), the `default` value won't
 #' # be used
-#' graph %>%
+#' graph |>
 #'   set_edge_attr_to_display(
 #'     edges = 4,
-#'     attr = to) %>%
+#'     attr = to) |>
 #'   set_edge_attr_to_display(
 #'     edges = c(1, 3),
-#'     attr = id) %>%
+#'     attr = id) |>
 #'   get_edge_df()
 #'
 #' @family edge creation and removal
@@ -90,7 +90,7 @@ set_edge_attr_to_display <- function(
 
   # Get the requested `attr`
   attr <-
-    rlang::enquo(attr) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(attr) |> rlang::get_expr() |> as.character()
 
   if (attr == "NULL") {
     attr <- NULL
@@ -145,7 +145,7 @@ set_edge_attr_to_display <- function(
 
   # Join the `attr_to_display` table with the `edf`
   edf <-
-    edf %>%
+    edf |>
     dplyr::left_join(attr_to_display, by = "id")
 
   # Get the column numbers for the `.x`
@@ -158,7 +158,7 @@ set_edge_attr_to_display <- function(
   if (!is.null(attr)) {
 
     display_col <-
-      dplyr::coalesce(edf[, y_col], edf[, x_col]) %>%
+      dplyr::coalesce(edf[, y_col], edf[, x_col]) |>
       as.data.frame(stringsAsFactors = FALSE)
 
   } else if (is.null(attr)) {
@@ -169,7 +169,7 @@ set_edge_attr_to_display <- function(
     display_col <-
       dplyr::case_when(
         display_col == "is_na" ~ NA_character_,
-        .default = display_col) %>%
+        .default = display_col) |>
       as.data.frame(stringsAsFactors = FALSE)
   }
 
@@ -183,7 +183,7 @@ set_edge_attr_to_display <- function(
   # Bind the `display_col` df to the `edf` df and
   # modify the ordering of the columns
   edf <-
-    dplyr::bind_cols(edf, display_col) %>%
+    dplyr::bind_cols(edf, display_col) |>
     dplyr::relocate("id", "from", "to", "rel", "display")
 
   # Replace the graph's edge data frame with `edf`

--- a/R/set_edge_attrs.R
+++ b/R/set_edge_attrs.R
@@ -40,7 +40,7 @@
 #' # for edges `1`->`4` and `3`->`1`
 #' # in the graph
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_edge_attrs(
 #'     edge_attr = color,
 #'     values = "green",
@@ -50,7 +50,7 @@
 #' # Set attribute `color = "blue"`
 #' # for all edges in the graph
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_edge_attrs(
 #'     edge_attr = color,
 #'     values = "blue")
@@ -59,7 +59,7 @@
 #' # for all edges in graph outbound
 #' # from node with ID value `1`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_edge_attrs(
 #'     edge_attr = color,
 #'     values = "pink",
@@ -69,7 +69,7 @@
 #' # for all edges in graph inbound
 #' # to node with ID `1`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_edge_attrs(
 #'     edge_attr = color,
 #'     values = "black",
@@ -91,7 +91,7 @@ set_edge_attrs <- function(
 
   # Get the requested `edge_attr`
   edge_attr <-
-    rlang::enquo(edge_attr) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr) |> rlang::get_expr() |> as.character()
 
   if (edge_attr %in% c("id", "from", "to")) {
 

--- a/R/set_edge_attrs_ws.R
+++ b/R/set_edge_attrs_ws.R
@@ -26,7 +26,7 @@
 #' @examples
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 6)
 #'
 #' # Select specific edges from
@@ -34,9 +34,9 @@
 #' # attribute `color = blue` to
 #' # those selected edges
 #' graph <-
-#'   graph %>%
-#'   select_nodes_by_id(nodes = 2:4) %>%
-#'   trav_out_edge() %>%
+#'   graph |>
+#'   select_nodes_by_id(nodes = 2:4) |>
+#'   trav_out_edge() |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = color,
 #'     value = "blue")
@@ -45,7 +45,7 @@
 #' # frame to verify that the
 #' # edge attribute has been set
 #' # for specific edges
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @family edge creation and removal
 #'
@@ -70,7 +70,7 @@ set_edge_attrs_ws <- function(
 
   # Get the requested `edge_attr`
   edge_attr <-
-    rlang::enquo(edge_attr) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(edge_attr) |> rlang::get_expr() |> as.character()
 
   # Get vectors of edge ID values for the
   # edge selection
@@ -85,7 +85,7 @@ set_edge_attrs_ws <- function(
 
   } else {
     graph$edges_df <-
-      graph$edges_df %>%
+      graph$edges_df |>
       dplyr::mutate(edge_attr__ = dplyr::case_when(
         id %in% edge_ids ~ value))
 

--- a/R/set_graph_directed.R
+++ b/R/set_graph_directed.R
@@ -13,19 +13,19 @@
 #' # undirected tree
 #' graph <-
 #'   create_graph(
-#'     directed = FALSE) %>%
+#'     directed = FALSE) |>
 #'   add_balanced_tree(
 #'     k = 2, h = 2)
 #'
 #' # Convert this graph from
 #' # undirected to directed
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_graph_directed()
 #'
 #' # Perform a check on whether
 #' # graph is directed
-#' graph %>% is_graph_directed()
+#' graph |> is_graph_directed()
 #'
 #' @export
 set_graph_directed <- function(graph) {

--- a/R/set_graph_name.R
+++ b/R/set_graph_name.R
@@ -15,7 +15,7 @@
 #'
 #' # Provide the new graph with a name
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_graph_name(
 #'     name = "example_name")
 #'

--- a/R/set_graph_time.R
+++ b/R/set_graph_time.R
@@ -17,20 +17,20 @@
 #' # Provide the new graph with a timestamp (if `tz`
 #' # is not supplied, `GMT` is used as the time zone)
 #' graph_1 <-
-#'   graph %>%
+#'   graph |>
 #'   set_graph_time(time = "2015-10-25 15:23:00")
 #'
 #' # Provide the new graph with a timestamp that is
 #' # the current time; the time zone is inferred from
 #' # the user's locale
 #' graph_2 <-
-#'   graph %>%
+#'   graph |>
 #'   set_graph_time()
 #'
 #' # The time zone can be updated when a timestamp
 #' # is present
 #' graph_2 <-
-#'   graph_2 %>%
+#'   graph_2 |>
 #'   set_graph_time(tz = "America/Los_Angeles")
 #'
 #' @export

--- a/R/set_graph_undirected.R
+++ b/R/set_graph_undirected.R
@@ -12,19 +12,19 @@
 #' # Create a graph with a
 #' # directed tree
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_balanced_tree(
 #'     k = 2, h = 2)
 #'
 #' # Convert this graph from
 #' # directed to undirected
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_graph_undirected()
 #'
 #' # Perform a check on whether
 #' # graph is directed
-#' graph %>% is_graph_directed()
+#' graph |> is_graph_directed()
 #'
 #' @export
 set_graph_undirected <- function(graph) {

--- a/R/set_node_attr_to_display.R
+++ b/R/set_node_attr_to_display.R
@@ -29,11 +29,11 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 4,
 #'     m = 4,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = c(2.5, 8.2, 4.2, 2.4))
@@ -43,7 +43,7 @@
 #' # the node `value` attribute (for
 #' # the other nodes, display nothing)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_attr_to_display(
 #'     nodes = 1:3,
 #'     attr = value,
@@ -53,20 +53,20 @@
 #' # `display` node attribute will show for
 #' # each row, which node attribute value to
 #' # display when the graph is rendered
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # This function can be called multiple
 #' # times on a graph; after the first time
 #' # (i.e., creation of the `display`
 #' # attribute), the `default` value won't
 #' # be used
-#' graph %>%
+#' graph |>
 #'   set_node_attr_to_display(
 #'     nodes = 4,
-#'     attr = label) %>%
+#'     attr = label) |>
 #'   set_node_attr_to_display(
 #'     nodes = c(1, 3),
-#'     attr = id) %>%
+#'     attr = id) |>
 #'   get_node_df()
 #'
 #' @family node creation and removal
@@ -90,7 +90,7 @@ set_node_attr_to_display <- function(
 
   # Get the requested `attr`
   attr <-
-    rlang::enquo(attr) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(attr) |> rlang::get_expr() |> as.character()
 
   # If nothing provided for `attr`, set
   # it as NULL
@@ -147,7 +147,7 @@ set_node_attr_to_display <- function(
 
   # Join the `attr_to_display` table with the `ndf`
   ndf <-
-    ndf %>%
+    ndf |>
     dplyr::left_join(attr_to_display, by = "id")
 
   # Get the column numbers for the `.x`
@@ -161,12 +161,12 @@ set_node_attr_to_display <- function(
     display_col <-
       dplyr::coalesce(ndf[, y_col], ndf[, x_col])
 
-    display_col <- dplyr::na_if(display_col, "is_na") %>%
+    display_col <- dplyr::na_if(display_col, "is_na") |>
       as.data.frame(stringsAsFactors = FALSE)
 
   } else {
     display_col <-
-      dplyr::coalesce(ndf[, y_col], ndf[, x_col]) %>%
+      dplyr::coalesce(ndf[, y_col], ndf[, x_col]) |>
       as.data.frame(stringsAsFactors = FALSE)
   }
 
@@ -180,7 +180,7 @@ set_node_attr_to_display <- function(
   # Bind the `display_col` df to the `ndf` df and
   # modify the ordering of the columns
   ndf <-
-    dplyr::bind_cols(ndf, display_col) %>%
+    dplyr::bind_cols(ndf, display_col) |>
     dplyr::relocate("id", "type", "label", "display")
 
   # Replace the graph's node data frame with `ndf`

--- a/R/set_node_attr_w_fcn.R
+++ b/R/set_node_attr_w_fcn.R
@@ -27,34 +27,34 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 22,
-#'     set_seed = 23) %>%
+#'     set_seed = 23) |>
 #'   set_node_attrs(
 #'     node_attr = value,
 #'     values = rnorm(
-#'       n = count_nodes(.),
+#'       n = 10,
 #'       mean = 5,
-#'       sd = 1) %>% round(1))
+#'       sd = 1) |> round(1))
 #'
 #' # Get the betweenness values for
 #' # each of the graph's nodes as a
 #' # node attribute
 #' graph_1 <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_attr_w_fcn(
 #'     node_attr_fcn = "get_betweenness")
 #'
 #' # Inspect the graph's internal
 #' # node data frame
-#' graph_1 %>% get_node_df()
+#' graph_1 |> get_node_df()
 #'
 #' # If a specified function takes argument
 #' # values, these can be supplied as well
 #' graph_2 <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_attr_w_fcn(
 #'     node_attr_fcn = "get_alpha_centrality",
 #'     alpha = 2,
@@ -62,18 +62,18 @@
 #'
 #' # Inspect the graph's internal
 #' # node data frame
-#' graph_2 %>% get_node_df()
+#' graph_2 |> get_node_df()
 #'
 #' # The new column name can be provided
 #' graph_3 <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_attr_w_fcn(
 #'     node_attr_fcn = "get_pagerank",
 #'     column_name = "pagerank")
 #'
 #' # Inspect the graph's internal
 #' # node data frame
-#' graph_3 %>% get_node_df()
+#' graph_3 |> get_node_df()
 #'
 #' # If `graph_3` is modified by
 #' # adding a new node then the column
@@ -82,17 +82,17 @@
 #' # the existing column name to provide
 #' # updated values
 #' graph_3 <-
-#'   graph_3 %>%
+#'   graph_3 |>
 #'   add_node(
 #'     from = 1,
-#'     to = 3) %>%
+#'     to = 3) |>
 #'   set_node_attr_w_fcn(
 #'     node_attr_fcn = "get_pagerank",
 #'     column_name = "pagerank")
 #'
 #' # Inspect the graph's internal
 #' # node data frame
-#' graph_3 %>% get_node_df()
+#' graph_3 |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -125,7 +125,7 @@ set_node_attr_w_fcn <- function(
   if (length(extras) > 0) {
 
   nodes_df <-
-    graph$nodes_df %>%
+    graph$nodes_df |>
     dplyr::inner_join(
       eval(
         parse(
@@ -136,20 +136,20 @@ set_node_attr_w_fcn <- function(
                   "=",
                   extras,
                   collapse =  ", "),
-            ")"))) %>%
+            ")"))) |>
         dplyr::mutate(id = as.integer(id)),
       by = "id")
 
   } else {
 
     nodes_df <-
-      graph$nodes_df %>%
+      graph$nodes_df |>
       dplyr::inner_join(
         eval(
           parse(
             text = paste0(
               node_attr_fcn,
-              "(graph)"))) %>%
+              "(graph)"))) |>
           dplyr::mutate(id = as.integer(id)),
         by = "id")
   }

--- a/R/set_node_attrs.R
+++ b/R/set_node_attrs.R
@@ -39,25 +39,25 @@
 #' # Set attribute `color = "green"` for
 #' # nodes `1` and `3` using the graph object
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_attrs(
 #'     node_attr = color,
 #'     values = "green",
 #'     nodes = c(1, 3))
 #'
 #' # View the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Set attribute `color = "blue"` for
 #' # all nodes in the graph
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_attrs(
 #'     node_attr = color,
 #'     values = "blue")
 #'
 #' # Display the graph's ndf
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -74,7 +74,7 @@ set_node_attrs <- function(
 
   # Get the requested `node_attr`
   node_attr <-
-    rlang::enquo(node_attr) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr) |> rlang::get_expr() |> as.character()
 
   # Stop function if `node_attr` is `id`
   # if (node_attr == "id") {

--- a/R/set_node_attrs_ws.R
+++ b/R/set_node_attrs_ws.R
@@ -28,17 +28,17 @@
 #' @examples
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(n = 6)
 #'
 #' # Select specific nodes from the graph and
 #' # apply the node attribute `color = blue` to
 #' # those selected nodes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes_by_id(
-#'     nodes = 1:4) %>%
-#'   trav_out() %>%
+#'     nodes = 1:4) |>
+#'   trav_out() |>
 #'   set_node_attrs_ws(
 #'     node_attr = color,
 #'     value = "blue")
@@ -46,7 +46,7 @@
 #' # Show the internal node data frame to verify
 #' # that the node attribute has been set for
 #' # specific node
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'
@@ -71,7 +71,7 @@ set_node_attrs_ws <- function(
 
   # Get the requested `node_attr`
   node_attr <-
-    rlang::enquo(node_attr) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(node_attr) |> rlang::get_expr() |> as.character()
 
   # Get vector of node ID values
   nodes <- graph$node_selection$node
@@ -93,7 +93,7 @@ set_node_attrs_ws <- function(
 
   # Update the `graph_log` df with an action
   graph$graph_log <-
-    graph$graph_log[-nrow(graph$graph_log), ] %>%
+    graph$graph_log[-nrow(graph$graph_log), ] |>
     add_action_to_log(
       version_id = nrow(graph$graph_log) + 1L,
       function_used = fcn_name,

--- a/R/set_node_position.R
+++ b/R/set_node_position.R
@@ -22,25 +22,25 @@
 #' @examples
 #' # Create a simple graph with 4 nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_node(label = "one") %>%
-#'   add_node(label = "two") %>%
-#'   add_node(label = "three") %>%
+#'   create_graph() |>
+#'   add_node(label = "one") |>
+#'   add_node(label = "two") |>
+#'   add_node(label = "three") |>
 #'   add_node(label = "four")
 #'
 #' # Add position information to each of
 #' # the graph's nodes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_position(
 #'     node = 1,
-#'     x = 1, y = 1) %>%
+#'     x = 1, y = 1) |>
 #'   set_node_position(
 #'     node = 2,
-#'     x = 2, y = 2) %>%
+#'     x = 2, y = 2) |>
 #'   set_node_position(
 #'     node = 3,
-#'     x = 3, y = 3) %>%
+#'     x = 3, y = 3) |>
 #'   set_node_position(
 #'     node = 4,
 #'     x = 4, y = 4)
@@ -49,27 +49,27 @@
 #' # verify that the `x` and `y` node
 #' # attributes are available and set to
 #' # the values provided
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # The same function can modify the data
 #' # in the `x` and `y` attributes
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_position(
 #'     node = 1,
-#'     x = 1, y = 4) %>%
+#'     x = 1, y = 4) |>
 #'   set_node_position(
 #'     node = 2,
-#'     x = 3, y = 3) %>%
+#'     x = 3, y = 3) |>
 #'   set_node_position(
 #'     node = 3,
-#'     x = 3, y = 2) %>%
+#'     x = 3, y = 2) |>
 #'   set_node_position(
 #'     node = 4,
 #'     x = 4, y = 1)
 #'
 #' # View the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Position changes can also be made by
 #' # supplying a node `label` value (and setting
@@ -77,18 +77,18 @@
 #' # all `label` values in the graph's ndf must
 #' # be unique and non-NA
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   set_node_position(
 #'     node = "one",
 #'     x = 1, y = 1,
-#'     use_labels = TRUE) %>%
+#'     use_labels = TRUE) |>
 #'   set_node_position(
 #'     node = "two",
 #'     x = 2, y = 2,
 #'     use_labels = TRUE)
 #'
 #' # View the graph's node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @family node creation and removal
 #'

--- a/R/spectools.R
+++ b/R/spectools.R
@@ -119,7 +119,7 @@ replace_in_spec <- function(spec, envir = parent.frame()) {
           gsub(
             "^([0-9]+)(.*)", "\\1",
             strsplit(spec_body, paste0("@@", i, "-"))[[1]][2]
-          ) %>%
+          ) |>
           as.numeric()
 
         if (the_index > length(eval_expressions[[i]])) {

--- a/R/to_igraph.R
+++ b/R/to_igraph.R
@@ -12,7 +12,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 36,
 #'     m = 50,
@@ -47,7 +47,7 @@ to_igraph <- function(graph) {
   # Extract the graph's edge data frame and
   # exclude the `id` column
   edf <-
-    graph$edges_df %>%
+    graph$edges_df |>
     dplyr::select(-"id")
 
   igraph::graph_from_data_frame(

--- a/R/transform_to_complement_graph.R
+++ b/R/transform_to_complement_graph.R
@@ -17,22 +17,22 @@
 #' # Create a simple graph
 #' # with a single cycle
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(n = 4)
 #'
 #' # Get the graph's edge
 #' # data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Create the complement
 #' # of the graph
 #' graph_c <-
-#'   graph %>%
+#'   graph |>
 #'     transform_to_complement_graph()
 #'
 #' # Get the edge data frame
 #' # for the complement graph
-#' graph_c %>% get_edge_df()
+#' graph_c |> get_edge_df()
 #'
 #' @export
 transform_to_complement_graph <- function(
@@ -54,14 +54,14 @@ transform_to_complement_graph <- function(
   nodes_created <- graph$last_node
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Get the number of edges ever created for
   # this graph
   edges_created <- graph$last_edge
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Convert the graph to an igraph object
   ig_graph <- to_igraph(graph)
@@ -70,7 +70,7 @@ transform_to_complement_graph <- function(
   ig_graph <- igraph::complementer(ig_graph, loops = loops)
 
   # Get the edge data frame for the complement graph
-  edf_new <- from_igraph(ig_graph) %>% get_edge_df()
+  edf_new <- from_igraph(ig_graph) |> get_edge_df()
 
   # Add edge ID values to the complement graph edf
   edf_new$id <- seq_len(nrow(edf_new))
@@ -86,14 +86,14 @@ transform_to_complement_graph <- function(
     remove_linked_dfs(graph)
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- graph %>% count_nodes()
+  nodes_graph_2 <- graph |> count_nodes()
 
   # Get the number of nodes added to
   # the graph
   nodes_added <- nodes_graph_2 - nodes_graph_1
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph

--- a/R/transform_to_min_spanning_tree.R
+++ b/R/transform_to_min_spanning_tree.R
@@ -13,7 +13,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 10,
 #'     m = 15,
@@ -23,7 +23,7 @@
 #' # values for each pair of
 #' # nodes as a square matrix
 #' j_sim_matrix <-
-#'   graph %>%
+#'   graph |>
 #'     get_jaccard_similarity()
 #'
 #' # Create a weighted, undirected
@@ -31,7 +31,7 @@
 #' # (effectively treating that
 #' # matrix as an adjacency matrix)
 #' graph <-
-#'   j_sim_matrix %>%
+#'   j_sim_matrix |>
 #'   from_adj_matrix(weighted = TRUE)
 #'
 #' # The graph in this case is a fully connected graph
@@ -41,17 +41,17 @@
 #' # connected subgraph where the edges retained have
 #' # the lowest similarity values possible
 #' min_spanning_tree_graph <-
-#'   graph %>%
-#'   transform_to_min_spanning_tree() %>%
+#'   graph |>
+#'   transform_to_min_spanning_tree() |>
 #'   copy_edge_attrs(
 #'     edge_attr_from = weight,
-#'     edge_attr_to = label) %>%
+#'     edge_attr_to = label) |>
 #'   set_edge_attrs(
 #'     edge_attr = fontname,
-#'     values = "Helvetica") %>%
+#'     values = "Helvetica") |>
 #'   set_edge_attrs(
 #'     edge_attr = color,
-#'     values = "gray85") %>%
+#'     values = "gray85") |>
 #'   rescale_edge_attrs(
 #'     edge_attr_from = weight,
 #'     to_lower_bound = 0.5,

--- a/R/transform_to_subgraph_ws.R
+++ b/R/transform_to_subgraph_ws.R
@@ -51,39 +51,39 @@
 #' # Create a selection of nodes, this selects
 #' # nodes `1`, `3`, and `5`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_nodes(
 #'     conditions = value > 3)
 #'
 #' # Create a subgraph based on the selection
 #' subgraph <-
-#'   graph %>%
+#'   graph |>
 #'   transform_to_subgraph_ws()
 #'
 #' # Display the graph's node data frame
-#' subgraph %>% get_node_df()
+#' subgraph |> get_node_df()
 #'
 #' # Display the graph's edge data frame
-#' subgraph %>% get_edge_df()
+#' subgraph |> get_edge_df()
 #'
 #' # Create a selection of edges, this selects
 #' # edges `1`, `2`
 #' graph <-
-#'   graph %>%
-#'   clear_selection() %>%
+#'   graph |>
+#'   clear_selection() |>
 #'   select_edges(
 #'   edges = c(1,2))
 #'
 #' # Create a subgraph based on the selection
 #' subgraph <-
-#'   graph %>%
+#'   graph |>
 #'   transform_to_subgraph_ws()
 #'
 #' # Display the graph's node data frame
-#' subgraph %>% get_node_df()
+#' subgraph |> get_node_df()
 #'
 #' # Display the graph's edge data frame
-#' subgraph %>% get_edge_df()
+#' subgraph |> get_edge_df()
 #'
 #' @export
 transform_to_subgraph_ws <- function(graph) {
@@ -104,10 +104,10 @@ transform_to_subgraph_ws <- function(graph) {
   }
 
   # Get the number of nodes in the graph
-  nodes_graph_1 <- graph %>% count_nodes()
+  nodes_graph_1 <- graph |> count_nodes()
 
   # Get the number of edges in the graph
-  edges_graph_1 <- graph %>% count_edges()
+  edges_graph_1 <- graph |> count_edges()
 
   # Filter the nodes in the graph
   if (graph_contains_node_selection(graph)) {
@@ -115,11 +115,11 @@ transform_to_subgraph_ws <- function(graph) {
     selection <- graph$node_selection$node
 
     ndf <-
-      graph$nodes_df %>%
+      graph$nodes_df |>
       dplyr::filter(id %in% selection)
 
     edf <-
-      graph$edges_df %>%
+      graph$edges_df |>
       dplyr::filter(from %in% selection, to %in% selection)
 
     # Create a subgraph
@@ -136,11 +136,11 @@ transform_to_subgraph_ws <- function(graph) {
       data.frame(id = selection)
 
     edf <-
-      graph$edges_df %>%
+      graph$edges_df |>
       dplyr::semi_join(selection_df, by = "id")
 
     ndf <-
-      graph$nodes_df %>%
+      graph$nodes_df |>
       dplyr::filter(id %in% unique(c(edf$from, edf$to)))
 
     # Create a subgraph
@@ -153,14 +153,14 @@ transform_to_subgraph_ws <- function(graph) {
     remove_linked_dfs(graph)
 
   # Get the updated number of nodes in the graph
-  nodes_graph_2 <- graph %>% count_nodes()
+  nodes_graph_2 <- graph |> count_nodes()
 
   # Get the number of nodes added to
   # the graph
   nodes_added <- nodes_graph_2 - nodes_graph_1
 
   # Get the updated number of edges in the graph
-  edges_graph_2 <- graph %>% count_edges()
+  edges_graph_2 <- graph |> count_edges()
 
   # Get the number of edges added to
   # the graph
@@ -185,7 +185,7 @@ transform_to_subgraph_ws <- function(graph) {
   # Perform graph actions, if any are available
   if (nrow(graph$graph_actions) > 0) {
     graph <-
-      graph %>%
+      graph |>
       trigger_graph_actions()
   }
 

--- a/R/trav_both.R
+++ b/R/trav_both.R
@@ -49,15 +49,15 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("asd", "iekd")) %>%
+#'     label = c("asd", "iekd")) |>
 #'   add_n_nodes(
 #'     n = 3,
 #'     type = "b",
-#'     label = c("idj", "edl", "ohd")) %>%
+#'     label = c("idj", "edl", "ohd")) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5",
 #'     rel = c(NA, "A", "B", "C", "D"))
@@ -82,89 +82,89 @@
 #' # Join the data frame to the graph's internal
 #' # edge data frame (edf)
 #' graph <-
-#'   graph %>%
-#'   join_edge_attrs(df = df_edges) %>%
+#'   graph |>
+#'   join_edge_attrs(df = df_edges) |>
 #'   join_node_attrs(df = df_nodes)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a simple traversal from node `3`
 #' # to adjacent nodes with no conditions on
 #' # the nodes traversed to
-#' graph %>%
-#'   select_nodes_by_id(nodes = 3) %>%
-#'   trav_both() %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 3) |>
+#'   trav_both() |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # nodes, filtering to those nodes that have
 #' # numeric values less than `8.0` for
 #' # the `values` node attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both(
-#'     conditions = values < 8.0) %>%
+#'     conditions = values < 8.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any adjacent
 #' # nodes, filtering to those nodes that
 #' # have a `type` attribute of `b`
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_both(
-#'     conditions = type == "b") %>%
+#'     conditions = type == "b") |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # nodes, and use multiple conditions for the
 #' # traversal
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both(
 #'     conditions =
 #'       type == "a" &
-#'       values > 8.0) %>%
+#'       values > 8.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # nodes, and use multiple conditions with
 #' # a single-length vector
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both(
 #'     conditions =
-#'       type == "a" | values > 8.0) %>%
+#'       type == "a" | values > 8.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # nodes, and use a regular expression as
 #' # a filtering condition
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both(
-#'     conditions = grepl("..d", label)) %>%
+#'     conditions = grepl("..d", label)) |>
 #'   get_selection()
 #'
 #' # Create another simple graph to demonstrate
 #' # copying of node attribute values to traversed
 #' # nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 5) %>%
-#'   select_nodes_by_id(nodes = c(2, 4)) %>%
+#'   create_graph() |>
+#'   add_path(n = 5) |>
+#'   select_nodes_by_id(nodes = c(2, 4)) |>
 #'   set_node_attrs_ws(
 #'     node_attr = value,
 #'     value = 5)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a traversal from the inner nodes
 #' # (`2` and `4`) to their adjacent nodes (`1`,
@@ -174,14 +174,14 @@
 #' # to `3` will occur from `2` and `4` (and
 #' # multiple values passed will be summed)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_both(
 #'     copy_attrs_from = value,
 #'     agg = "sum")
 #'
 #' # Show the graph's internal node data frame
 #' # after this change
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 trav_both <- function(
@@ -216,11 +216,11 @@ trav_both <- function(
 
   # Get the requested `copy_attrs_from`
   copy_attrs_from <-
-    rlang::enquo(copy_attrs_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `copy_attrs_as`
   copy_attrs_as <-
-    rlang::enquo(copy_attrs_as) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_as) |> rlang::get_expr() |> as.character()
 
   if (length(copy_attrs_from) == 0) {
     copy_attrs_from <- NULL
@@ -249,13 +249,13 @@ trav_both <- function(
   # Find all nodes that are connected to the
   # starting nodes via outgoing edges
   valid_nodes <-
-    graph %>%
-    get_nbrs(starting_nodes) %>%
+    graph |>
+    get_nbrs(starting_nodes) |>
     as.integer()
 
   valid_nodes <-
-    dplyr::tibble(id = valid_nodes) %>%
-    dplyr::inner_join(ndf, by = "id") %>%
+    dplyr::tibble(id = valid_nodes) |>
+    dplyr::inner_join(ndf, by = "id") |>
     dplyr::distinct()
 
   # If no rows returned, then there are no
@@ -271,7 +271,7 @@ trav_both <- function(
   # Maybe quo_is_null ?
   if (!rlang::quo_is_null(rlang::enquo(conditions))) {
 
-    valid_nodes <- valid_nodes %>% dplyr::filter({{ conditions }})
+    valid_nodes <- valid_nodes |> dplyr::filter({{ conditions }})
   }
 
   # If the option is taken to copy node attribute
@@ -280,28 +280,28 @@ trav_both <- function(
   if (!is.null(copy_attrs_from)) {
 
     from_join <-
-      valid_nodes %>%
-      dplyr::select("id") %>%
-      dplyr::inner_join(edf %>% dplyr::select(from, to), by = c("id" = "from")) %>%
-      dplyr::inner_join(ndf %>% dplyr::select("id", !!enquo(copy_attrs_from)), by = c("to" = "id")) %>%
+      valid_nodes |>
+      dplyr::select("id") |>
+      dplyr::inner_join(edf |> dplyr::select(from, to), by = c("id" = "from")) |>
+      dplyr::inner_join(ndf |> dplyr::select("id", !!enquo(copy_attrs_from)), by = c("to" = "id")) |>
       dplyr::select("id", !!enquo(copy_attrs_from))
 
     to_join <-
-      valid_nodes %>%
-      dplyr::select("id") %>%
-      dplyr::inner_join(edf %>% dplyr::select(from, to), by = c("id" = "to")) %>%
-      dplyr::inner_join(ndf %>% dplyr::select("id", !!enquo(copy_attrs_from)), by = c("from" = "id")) %>%
+      valid_nodes |>
+      dplyr::select("id") |>
+      dplyr::inner_join(edf |> dplyr::select(from, to), by = c("id" = "to")) |>
+      dplyr::inner_join(ndf |> dplyr::select("id", !!enquo(copy_attrs_from)), by = c("from" = "id")) |>
       dplyr::select("id", !!enquo(copy_attrs_from))
 
     nodes <-
-      from_join %>%
-      dplyr::union_all(to_join) %>%
-      dplyr::group_by(id) %>%
+      from_join |>
+      dplyr::union_all(to_join) |>
+      dplyr::group_by(id) |>
       dplyr::summarize(!!copy_attrs_from :=
                          match.fun(!!agg)(!!as.name(copy_attrs_from),
-                                           na.rm = TRUE)) %>%
-      dplyr::right_join(ndf, by = "id") %>%
-      dplyr::relocate(id, type, label) %>%
+                                           na.rm = TRUE)) |>
+      dplyr::right_join(ndf, by = "id") |>
+      dplyr::relocate(id, type, label) |>
       as.data.frame(stringsAsFactors = FALSE)
 
     # Get column numbers that end with ".x" or ".y"

--- a/R/trav_both_edge.R
+++ b/R/trav_both_edge.R
@@ -47,15 +47,15 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("asd", "iekd")) %>%
+#'     label = c("asd", "iekd")) |>
 #'   add_n_nodes(
 #'     n = 3,
 #'     type = "b",
-#'     label = c("idj", "edl", "ohd")) %>%
+#'     label = c("idj", "edl", "ohd")) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5",
 #'     rel = c(NA, "A", "B", "C", "D"))
@@ -72,106 +72,106 @@
 #' # Join the data frame to the graph's internal
 #' # edge data frame (edf)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_edge_attrs(df = df)
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a simple traversal from nodes to
 #' # adjacent edges with no conditions on the
 #' # nodes traversed to
-#' graph %>%
-#'   select_nodes_by_id(nodes = 3) %>%
-#'   trav_both_edge() %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 3) |>
+#'   trav_both_edge() |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # edges, filtering to those edges that have
 #' # NA values for the `rel` edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both_edge(
-#'     conditions = is.na(rel)) %>%
+#'     conditions = is.na(rel)) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # edges, filtering to those edges that have
 #' # numeric values greater than `6.5` for
 #' # the `rel` edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both_edge(
-#'     conditions = values > 6.5) %>%
+#'     conditions = values > 6.5) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any adjacent
 #' # edges, filtering to those edges that
 #' # have values equal to `C` for the `rel`
 #' # edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_both_edge(
-#'     conditions = rel == "C") %>%
+#'     conditions = rel == "C") |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # edges, filtering to those edges that
 #' # have values in the set `B` and `C` for
 #' # the `rel` edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both_edge(
-#'     conditions = rel %in% c("B", "C")) %>%
+#'     conditions = rel %in% c("B", "C")) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # edges, and use multiple conditions for the
 #' # traversal
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both_edge(
 #'     conditions =
 #'       rel %in% c("B", "C") &
-#'       values > 4.0) %>%
+#'       values > 4.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # edges, and use multiple conditions with
 #' # a single-length vector
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both_edge(
 #'     conditions =
 #'       rel %in% c("B", "C") |
-#'       values > 4.0) %>%
+#'       values > 4.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any adjacent
 #' # edges, and use a regular expression as
 #' # a filtering condition
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_both_edge(
-#'     conditions = grepl("B|C", rel)) %>%
+#'     conditions = grepl("B|C", rel)) |>
 #'   get_selection()
 #'
 #' # Create another simple graph to demonstrate
 #' # copying of node attribute values to traversed
 #' # edges
 #' graph <-
-#'   create_graph() %>%
-#'   add_path(n = 4) %>%
-#'   select_nodes_by_id(nodes = 2:3) %>%
+#'   create_graph() |>
+#'   add_path(n = 4) |>
+#'   select_nodes_by_id(nodes = 2:3) |>
 #'   set_node_attrs_ws(
 #'     node_attr = value,
 #'     value = 5)
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>%get_edge_df()
+#' graph |>get_edge_df()
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Perform a traversal from the nodes to
 #' # the adjacent edges while also applying
@@ -180,14 +180,14 @@
 #' # all contributing nodes adding as an edge
 #' # attribute)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_both_edge(
 #'     copy_attrs_from = value,
 #'     agg = "sum")
 #'
 #' # Show the graph's internal edge data frame
 #' # after this change
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @export
 trav_both_edge <- function(
@@ -218,11 +218,11 @@ trav_both_edge <- function(
 
   # Get the requested `copy_attrs_from`
   copy_attrs_from <-
-    rlang::enquo(copy_attrs_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `copy_attrs_as`
   copy_attrs_as <-
-    rlang::enquo(copy_attrs_as) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_as) |> rlang::get_expr() |> as.character()
 
   if (length(copy_attrs_from) == 0) {
     copy_attrs_from <- NULL
@@ -252,9 +252,9 @@ trav_both_edge <- function(
   # starting nodes and remove edges that
   # are loops
   valid_edges <-
-    edf %>%
+    edf |>
     dplyr::filter(from %in% starting_nodes |
-                    to %in% starting_nodes) %>%
+                    to %in% starting_nodes) |>
     dplyr::filter(to != from)
 
   # If traversal conditions are provided then
@@ -280,25 +280,25 @@ trav_both_edge <- function(
     if (!(copy_attrs_from %in% colnames(edf))) {
 
       from_join <-
-        ndf %>%
-        dplyr::select("id", !!enquo(copy_attrs_from)) %>%
-        dplyr::filter(id %in% starting_nodes) %>%
+        ndf |>
+        dplyr::select("id", !!enquo(copy_attrs_from)) |>
+        dplyr::filter(id %in% starting_nodes) |>
         dplyr::right_join(
-          valid_edges %>%
-            dplyr::select(-"rel") %>%
+          valid_edges |>
+            dplyr::select(-"rel") |>
             dplyr::rename(e_id = "id"),
-          by = c("id" = "from")) %>%
+          by = c("id" = "from")) |>
         dplyr::select("e_id", !!enquo(copy_attrs_from))
 
       to_join <-
-        ndf %>%
-        dplyr::select("id", !!enquo(copy_attrs_from)) %>%
-        dplyr::filter(id %in% starting_nodes) %>%
+        ndf |>
+        dplyr::select("id", !!enquo(copy_attrs_from)) |>
+        dplyr::filter(id %in% starting_nodes) |>
         dplyr::right_join(
-          valid_edges %>%
-            dplyr::select(-"rel") %>%
+          valid_edges |>
+            dplyr::select(-"rel") |>
             dplyr::rename(e_id = "id"),
-          by = c("id" = "to")) %>%
+          by = c("id" = "to")) |>
         dplyr::select("e_id", !!enquo(copy_attrs_from))
 
       if (!is.null(copy_attrs_as)) {
@@ -316,23 +316,23 @@ trav_both_edge <- function(
 
       edges <-
         dplyr::bind_rows(
-          from_join, to_join) %>%
-        dplyr::left_join(edf, by = c("e_id" = "id")) %>%
-        dplyr::rename(id = "e_id") %>%
-        dplyr::group_by(id) %>%
+          from_join, to_join) |>
+        dplyr::left_join(edf, by = c("e_id" = "id")) |>
+        dplyr::rename(id = "e_id") |>
+        dplyr::group_by(id) |>
         dplyr::summarize(!!copy_attrs_from :=
                            match.fun(!!agg)(!!as.name(copy_attrs_from),
-                                             na.rm = TRUE)) %>%
-        dplyr::right_join(edf, by = "id") %>%
-        dplyr::relocate("id", "from", "to", "rel") %>%
+                                             na.rm = TRUE)) |>
+        dplyr::right_join(edf, by = "id") |>
+        dplyr::relocate("id", "from", "to", "rel") |>
         as.data.frame(stringsAsFractions = FALSE)
     }
 
     if (copy_attrs_from %in% colnames(edf)) {
 
       from_join <-
-        ndf %>%
-        dplyr::select("id", !!enquo(copy_attrs_from)) %>%
+        ndf |>
+        dplyr::select("id", !!enquo(copy_attrs_from)) |>
         dplyr::filter(id %in% starting_nodes)
 
       if (!is.null(copy_attrs_as)) {
@@ -347,10 +347,10 @@ trav_both_edge <- function(
       }
 
       from_join <-
-        from_join %>%
+        from_join |>
         dplyr::right_join(
-          valid_edges %>%
-            dplyr::select(-"rel") %>%
+          valid_edges |>
+            dplyr::select(-"rel") |>
             dplyr::rename(e_id = "id"),
           by = c("id" = "from"))
 
@@ -374,12 +374,12 @@ trav_both_edge <- function(
 
       # Drop the ".x" column
       from_join <-
-        from_join %>%
+        from_join |>
         dplyr::select("e_id", !!enquo(copy_attrs_from))
 
       to_join <-
-        ndf %>%
-        dplyr::select("id", !!enquo(copy_attrs_from)) %>%
+        ndf |>
+        dplyr::select("id", !!enquo(copy_attrs_from)) |>
         dplyr::filter(id %in% starting_nodes)
 
       if (!is.null(copy_attrs_as)) {
@@ -388,10 +388,10 @@ trav_both_edge <- function(
       }
 
       to_join <-
-        to_join %>%
+        to_join |>
         dplyr::right_join(
-          valid_edges %>%
-            dplyr::select(-"rel") %>%
+          valid_edges |>
+            dplyr::select(-"rel") |>
             dplyr::rename(e_id = "id"),
           by = c("id" = "to"))
 
@@ -420,12 +420,12 @@ trav_both_edge <- function(
 
       # Drop the ".x" column
       to_join <-
-        to_join %>%
+        to_join |>
         dplyr::select("e_id", !!enquo(copy_attrs_from))
 
       edges <-
         dplyr::bind_rows(
-          from_join, to_join) %>%
+          from_join, to_join) |>
         dplyr::left_join(edf, by = c("e_id" = "id"))
 
       # Get column numbers that end with ".x" or ".y"
@@ -450,13 +450,13 @@ trav_both_edge <- function(
       edges <- edges[-split_var_x_col]
 
       joined_edges <-
-        edges %>%
-        dplyr::arrange(e_id) %>%
-        dplyr::rename(id = "e_id") %>%
-        dplyr::group_by(id) %>%
+        edges |>
+        dplyr::arrange(e_id) |>
+        dplyr::rename(id = "e_id") |>
+        dplyr::group_by(id) |>
         dplyr::summarize(!!copy_attrs_from :=
                             match.fun(!!agg)(!!as.name(copy_attrs_from),
-                                              na.rm = TRUE), .groups = "drop") %>%
+                                              na.rm = TRUE), .groups = "drop") |>
         dplyr::right_join(edf, by = "id")
 
       # Get column numbers that end with ".x" or ".y"
@@ -481,9 +481,9 @@ trav_both_edge <- function(
       joined_edges <- joined_edges[-split_var_x_col]
 
       edges <-
-        joined_edges %>%
-        dplyr::relocate("id", "from", "to", "rel") %>%
-        dplyr::arrange(id) %>%
+        joined_edges |>
+        dplyr::relocate("id", "from", "to", "rel") |>
+        dplyr::arrange(id) |>
         as.data.frame(stringsAsFractions = FALSE)
     }
 

--- a/R/trav_in.R
+++ b/R/trav_in.R
@@ -49,15 +49,15 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("asd", "iekd")) %>%
+#'     label = c("asd", "iekd")) |>
 #'   add_n_nodes(
 #'     n = 3,
 #'     type = "b",
-#'     label = c("idj", "edl", "ohd")) %>%
+#'     label = c("idj", "edl", "ohd")) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5",
 #'     rel = c(NA, "A", "B", "C", "D"))
@@ -82,109 +82,110 @@
 #' # Join the data frame to the graph's internal
 #' # edge data frame (edf)
 #' graph <-
-#'   graph %>%
-#'   join_edge_attrs(df = df_edges) %>%
+#'   graph |>
+#'   join_edge_attrs(df = df_edges) |>
 #'   join_node_attrs(df = df_nodes)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a simple traversal from node `4` to
 #' # inward adjacent edges with no conditions
 #' # on the nodes traversed to
-#' graph %>%
-#'   select_nodes_by_id(nodes = 4) %>%
-#'   trav_in() %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 4) |>
+#'   trav_in() |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to inbound-facing
 #' # nodes, filtering to those nodes that have
 #' # numeric values greater than `5.0` for
 #' # the `values` node attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 4) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 4) |>
 #'   trav_in(
-#'     conditions = values > 5.0) %>%
+#'     conditions = values > 5.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any inbound
 #' # nodes, filtering to those nodes that
 #' # have a `type` attribute of `b`
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in(
-#'     conditions = type == "b") %>%
+#'     conditions = type == "b") |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any inbound
 #' # nodes, filtering to those nodes that
 #' # have a degree of `2`
-#' graph %>%
-#'   {
-#'   node_degrees <-
-#'     get_node_info(.) %>%
-#'     dplyr::select(id, deg)
-#'   join_node_attrs(., node_degrees)
-#'   } %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' node_degrees <- graph |>
+#'   get_node_info() |>
+#'   dplyr::select(id, deg)
+#'
+#' graph <- graph |>
+#'   join_node_attrs(df = node_degrees)
+#'
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in(
-#'     conditions = deg == 2) %>%
+#'     conditions = deg == 2) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any inbound
 #' # nodes, and use multiple conditions for the
 #' # traversal
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in(
 #'     conditions =
 #'       type == "a" &
-#'       values > 6.0) %>%
+#'       values > 6.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any inbound
 #' # nodes, and use multiple conditions with
 #' # a single-length vector
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in(
 #'     conditions =
-#'       type == "b" | values > 6.0) %>%
+#'       type == "b" | values > 6.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any inbound
 #' # nodes, and use a regular expression as
 #' # a filtering condition
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_in(
-#'     conditions = grepl("^i.*", label)) %>%
+#'     conditions = grepl("^i.*", label)) |>
 #'   get_selection()
 #'
 #' # Create another simple graph to demonstrate
 #' # copying of node attribute values to traversed
 #' # nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_node() %>%
-#'   select_nodes() %>%
+#'   create_graph() |>
+#'   add_node() |>
+#'   select_nodes() |>
 #'   add_n_nodes_ws(
 #'     n = 2,
-#'     direction = "from") %>%
-#'   clear_selection() %>%
-#'   select_nodes_by_id(nodes = 2:3) %>%
+#'     direction = "from") |>
+#'   clear_selection() |>
+#'   select_nodes_by_id(nodes = 2:3) |>
 #'   set_node_attrs_ws(
 #'     node_attr = value,
 #'     value = 5)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a traversal from the outer nodes
 #' # (`2` and `3`) to the central node (`1`) while
@@ -193,14 +194,14 @@
 #' # both nodes before applying the value to the
 #' # target node)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_in(
 #'     copy_attrs_from = value,
 #'     agg = "sum")
 #'
 #' # Show the graph's internal node data frame
 #' # after this change
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 trav_in <- function(
@@ -231,11 +232,11 @@ trav_in <- function(
 
   # Get the requested `copy_attrs_from`
   copy_attrs_from <-
-    rlang::enquo(copy_attrs_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `copy_attrs_as`
   copy_attrs_as <-
-    rlang::enquo(copy_attrs_as) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_as) |> rlang::get_expr() |> as.character()
 
   if (length(copy_attrs_from) == 0) {
     copy_attrs_from <- NULL
@@ -264,14 +265,14 @@ trav_in <- function(
   # Find all nodes that are connected to the
   # starting nodes via incoming edges
   valid_nodes <-
-    edf %>%
-    dplyr::filter(to != from) %>%
-    dplyr::filter(to %in% starting_nodes) %>%
+    edf |>
+    dplyr::filter(to != from) |>
+    dplyr::filter(to %in% starting_nodes) |>
     dplyr::distinct(from)
 
   valid_nodes <-
-    dplyr::as_tibble(valid_nodes) %>%
-    dplyr::rename(id = "from") %>%
+    dplyr::as_tibble(valid_nodes) |>
+    dplyr::rename(id = "from") |>
     dplyr::inner_join(ndf, by = "id")
 
   # If no rows returned, then there are no
@@ -295,29 +296,29 @@ trav_in <- function(
   if (!is.null(copy_attrs_from)) {
 
     nodes <-
-      valid_nodes %>%
-      dplyr::select(id) %>%
-      dplyr::inner_join(edf %>% dplyr::select("from", "to"), by = c("id" = "from")) %>%
-      dplyr::inner_join(ndf %>% dplyr::select("id", !!enquo(copy_attrs_from)), by = c("to" = "id")) %>%
+      valid_nodes |>
+      dplyr::select(id) |>
+      dplyr::inner_join(edf |> dplyr::select("from", "to"), by = c("id" = "from")) |>
+      dplyr::inner_join(ndf |> dplyr::select("id", !!enquo(copy_attrs_from)), by = c("to" = "id")) |>
       dplyr::select("id", !!enquo(copy_attrs_from))
 
     # If the values to be copied are numeric,
     # perform aggregation on the values
-    if (nodes[, 2] %>% unlist() %>% is.numeric()) {
+    if (nodes[, 2] |> unlist() |> is.numeric()) {
       nodes <-
-        nodes %>%
-        dplyr::group_by(id) %>%
+        nodes |>
+        dplyr::group_by(id) |>
         dplyr::summarize(!!copy_attrs_from :=
                            match.fun(!!agg)(!!as.name(copy_attrs_from),
-                                             na.rm = TRUE)) %>%
+                                             na.rm = TRUE)) |>
         dplyr::ungroup()
     }
 
     nodes <-
-      nodes %>%
-      dplyr::right_join(ndf, by = "id") %>%
-      dplyr::relocate("id", "type", "label") %>%
-      dplyr::arrange(id) %>%
+      nodes |>
+      dplyr::right_join(ndf, by = "id") |>
+      dplyr::relocate("id", "type", "label") |>
+      dplyr::arrange(id) |>
       as.data.frame(stringsAsFactors = FALSE)
 
     # Get column numbers that end with ".x" or ".y"

--- a/R/trav_in_edge.R
+++ b/R/trav_in_edge.R
@@ -42,15 +42,15 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("asd", "iekd")) %>%
+#'     label = c("asd", "iekd")) |>
 #'   add_n_nodes(
 #'     n = 3,
 #'     type = "b",
-#'     label = c("idj", "edl", "ohd")) %>%
+#'     label = c("idj", "edl", "ohd")) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5",
 #'     rel = c(NA, "A", "B", "C", "D"))
@@ -68,29 +68,29 @@
 #' # Join the data frame to the graph's
 #' # internal edge data frame (edf)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_edge_attrs(df = df)
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a simple traversal from
 #' # nodes to inbound edges with no
 #' # conditions on the nodes
 #' # traversed to
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
-#'   trav_in_edge() %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
+#'   trav_in_edge() |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any
 #' # inbound edges, filtering to
 #' # those edges that have NA values
 #' # for the `rel` edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_in_edge(
-#'     conditions = is.na(rel)) %>%
+#'     conditions = is.na(rel)) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any
@@ -100,10 +100,10 @@
 #' # (since there are no allowed
 #' # traversals, the selection of node
 #' # `2` is retained)
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_in_edge(
-#'     conditions = !is.na(rel)) %>%
+#'     conditions = !is.na(rel)) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any
@@ -111,20 +111,20 @@
 #' # edges that have numeric values
 #' # greater than `5.5` for the `rel`
 #' # edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in_edge(
-#'     conditions = values > 5.5) %>%
+#'     conditions = values > 5.5) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any
 #' # inbound edges, filtering to those
 #' # edges that have values equal to
 #' # `D` for the `rel` edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in_edge(
-#'     conditions = rel == "D") %>%
+#'     conditions = rel == "D") |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any
@@ -132,49 +132,49 @@
 #' # edges that have values in the set
 #' # `C` and `D` for the `rel` edge
 #' # attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in_edge(
-#'     conditions = rel %in% c("C", "D")) %>%
+#'     conditions = rel %in% c("C", "D")) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any
 #' # inbound edges, and use multiple
 #' # conditions for the traversal
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in_edge(
 #'     conditions =
 #'       rel %in% c("C", "D") &
-#'       values > 5.5) %>%
+#'       values > 5.5) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any
 #' # inbound edges, and use multiple
 #' # conditions with a single-length
 #' # vector
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in_edge(
 #'     conditions =
 #'       rel %in% c("D", "E") |
-#'       values > 5.5) %>%
+#'       values > 5.5) |>
 #'   get_selection()
 #'
 #' # Traverse from node `5` to any
 #' # inbound edges, and use a regular
 #' # expression as a filtering condition
-#' graph %>%
-#'   select_nodes_by_id(nodes = 5) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 5) |>
 #'   trav_in_edge(
-#'     conditions = grepl("C|D", rel)) %>%
+#'     conditions = grepl("C|D", rel)) |>
 #'   get_selection()
 #'
 #' # Show the graph's internal ndf
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edf
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a traversal from all
 #' # nodes to their incoming edges and,
@@ -182,14 +182,14 @@
 #' # node attribute to any of the nodes'
 #' # incoming edges
 #' graph <-
-#'   graph %>%
-#'   select_nodes() %>%
+#'   graph |>
+#'   select_nodes() |>
 #'   trav_in_edge(
 #'     copy_attrs_from = label)
 #'
 #' # Show the graph's internal edge
 #' # data frame after this change
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @export
 trav_in_edge <- function(
@@ -219,11 +219,11 @@ trav_in_edge <- function(
 
   # Get the requested `copy_attrs_from`
   copy_attrs_from <-
-    rlang::enquo(copy_attrs_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `copy_attrs_as`
   copy_attrs_as <-
-    rlang::enquo(copy_attrs_as) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_as) |> rlang::get_expr() |> as.character()
 
   if (length(copy_attrs_from) == 0) {
     copy_attrs_from <- NULL
@@ -253,8 +253,8 @@ trav_in_edge <- function(
   # starting nodes and remove edges that
   # are loops
   valid_edges <-
-    edf %>%
-    dplyr::filter(to %in% starting_nodes) %>%
+    edf |>
+    dplyr::filter(to %in% starting_nodes) |>
     dplyr::filter(to != from)
 
   # If no rows returned, then there are no
@@ -285,8 +285,8 @@ trav_in_edge <- function(
   if (!is.null(copy_attrs_from)) {
 
     ndf_2 <-
-      ndf %>%
-      dplyr::filter(id %in% starting_nodes) %>%
+      ndf |>
+      dplyr::filter(id %in% starting_nodes) |>
       dplyr::select("id", !!enquo(copy_attrs_from))
 
     if (!is.null(copy_attrs_as)) {
@@ -303,11 +303,11 @@ trav_in_edge <- function(
     if (!(copy_attrs_from %in% colnames(edf))) {
 
       edges <-
-        ndf_2 %>%
-        dplyr::right_join(edf, c("id" = "to")) %>%
-        dplyr::rename(to = "id") %>%
-        dplyr::rename(id = "id.y") %>%
-        dplyr::relocate("id", "from", "to", "rel") %>%
+        ndf_2 |>
+        dplyr::right_join(edf, c("id" = "to")) |>
+        dplyr::rename(to = "id") |>
+        dplyr::rename(id = "id.y") |>
+        dplyr::relocate("id", "from", "to", "rel") |>
         dplyr::arrange(id)
     }
 
@@ -315,8 +315,8 @@ trav_in_edge <- function(
     if (copy_attrs_from %in% colnames(edf)) {
 
       edges <-
-        ndf_2 %>%
-        dplyr::right_join(edf, by = c("id" = "to")) %>%
+        ndf_2 |>
+        dplyr::right_join(edf, by = c("id" = "to")) |>
         dplyr::rename(to = "id", id = "id.y")
 
       # Get column numbers that end with ".x" or ".y"
@@ -342,8 +342,8 @@ trav_in_edge <- function(
 
       # Reorder columns
       edges <-
-        edges %>%
-        dplyr::relocate("id", "from", "to", "rel") %>%
+        edges |>
+        dplyr::relocate("id", "from", "to", "rel") |>
         dplyr::arrange(id)
     }
 

--- a/R/trav_in_node.R
+++ b/R/trav_in_node.R
@@ -45,15 +45,15 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("asd", "iekd")) %>%
+#'     label = c("asd", "iekd")) |>
 #'   add_n_nodes(
 #'     n = 3,
 #'     type = "b",
-#'     label = c("idj", "edl", "ohd")) %>%
+#'     label = c("idj", "edl", "ohd")) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5",
 #'     rel = c(NA, "A", "B", "C", "D"))
@@ -78,40 +78,40 @@
 #' # Join the data frame to the graph's internal
 #' # edge data frame (edf)
 #' graph <-
-#'   graph %>%
-#'   join_edge_attrs(df = df_edges) %>%
+#'   graph |>
+#'   join_edge_attrs(df = df_edges) |>
 #'   join_node_attrs(df = df_nodes)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a simple traversal from the
 #' # edge `1`->`3` to the attached node
 #' # in the direction of the edge; here, no
 #' # conditions are placed on the nodes
 #' # traversed to
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 1,
-#'     to = 3) %>%
-#'   trav_in_node() %>%
+#'     to = 3) |>
+#'   trav_in_node() |>
 #'   get_selection()
 #'
 #' # Traverse from edges `2`->`5` and
 #' # `3`->`5` to the attached node along
 #' # the direction of the edge; both
 #' # traversals lead to the same node
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 2,
-#'     to = 5) %>%
+#'     to = 5) |>
 #'   select_edges(
 #'     from = 3,
-#'     to = 5) %>%
-#'   trav_in_node() %>%
+#'     to = 5) |>
+#'   trav_in_node() |>
 #'   get_selection()
 #'
 #' # Traverse from the edge `1`->`3`
@@ -119,12 +119,12 @@
 #' # is incoming, this time filtering
 #' # numeric values greater than `5.0` for
 #' # the `values` node attribute
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 1,
-#'     to = 3) %>%
+#'     to = 3) |>
 #'   trav_in_node(
-#'     conditions = values > 5.0) %>%
+#'     conditions = values > 5.0) |>
 #'   get_selection()
 #'
 #' # Traverse from the edge `1`->`3`
@@ -134,60 +134,60 @@
 #' # the `values` node attribute (the
 #' # condition is not met so the original
 #' # selection of edge `1` -> `3` remains)
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 1,
-#'     to = 3) %>%
+#'     to = 3) |>
 #'   trav_in_node(
-#'     conditions = values < 5.0) %>%
+#'     conditions = values < 5.0) |>
 #'   get_selection()
 #'
 #' # Traverse from the edge `1`->`2` to
 #' # the node `2` using multiple conditions
 #' # with a single-length vector
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 1,
-#'     to = 2) %>%
+#'     to = 2) |>
 #'   trav_in_node(
 #'     conditions =
 #'       grepl(".*d$", label) |
-#'       values < 6.0) %>%
+#'       values < 6.0) |>
 #'   get_selection()
 #'
 #' # Create another simple graph to demonstrate
 #' # copying of edge attribute values to traversed
 #' # nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_node() %>%
-#'   select_nodes() %>%
+#'   create_graph() |>
+#'   add_node() |>
+#'   select_nodes() |>
 #'   add_n_nodes_ws(
 #'     n = 2,
-#'     direction = "to") %>%
-#'   clear_selection() %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#'     direction = "to") |>
+#'   clear_selection() |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   set_node_attrs_ws(
 #'     node_attr = value,
-#'     value = 8) %>%
-#'   clear_selection() %>%
-#'   select_edges_by_edge_id(edges = 1) %>%
+#'     value = 8) |>
+#'   clear_selection() |>
+#'   select_edges_by_edge_id(edges = 1) |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = value,
-#'     value = 5) %>%
-#'   clear_selection() %>%
-#'   select_edges_by_edge_id(edges = 2) %>%
+#'     value = 5) |>
+#'   clear_selection() |>
+#'   select_edges_by_edge_id(edges = 2) |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = value,
-#'     value = 5) %>%
-#'   clear_selection() %>%
+#'     value = 5) |>
+#'   clear_selection() |>
 #'   select_edges()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Perform a traversal from the edges to
 #' # the central node (`1`) while also applying
@@ -195,14 +195,14 @@
 #' # this case summing the `value` of 5 from
 #' # both edges before adding as a node attribute)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_in_node(
 #'     copy_attrs_from = value,
 #'     agg = "sum")
 #'
 #' # Show the graph's internal node data frame
 #' # after this change
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 trav_in_node <- function(
@@ -233,11 +233,11 @@ trav_in_node <- function(
 
   # Get the requested `copy_attrs_from`
   copy_attrs_from <-
-    rlang::enquo(copy_attrs_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `copy_attrs_as`
   copy_attrs_as <-
-    rlang::enquo(copy_attrs_as) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_as) |> rlang::get_expr() |> as.character()
 
   if (length(copy_attrs_from) == 0) {
     copy_attrs_from <- NULL
@@ -265,8 +265,8 @@ trav_in_node <- function(
   # Find all nodes that are connected to the
   # starting edges
   valid_nodes <-
-    starting_edges %>%
-    dplyr::distinct(to) %>%
+    starting_edges |>
+    dplyr::distinct(to) |>
     dplyr::left_join(ndf, by = c("to" = "id"))
 
   # If traversal conditions are provided then
@@ -290,9 +290,9 @@ trav_in_node <- function(
   if (!is.null(copy_attrs_from)) {
 
     nodes <-
-      starting_edges %>%
-      dplyr::semi_join(valid_nodes, by = "to") %>%
-      dplyr::left_join(edf, by = c("edge" = "id")) %>%
+      starting_edges |>
+      dplyr::semi_join(valid_nodes, by = "to") |>
+      dplyr::left_join(edf, by = c("edge" = "id")) |>
       dplyr::select("to.y", !!enquo(copy_attrs_from))
 
 
@@ -308,14 +308,14 @@ trav_in_node <- function(
     }
 
     nodes <-
-      nodes %>%
-      dplyr::rename(id = to.y) %>%
-      dplyr::group_by(id) %>%
+      nodes |>
+      dplyr::rename(id = to.y) |>
+      dplyr::group_by(id) |>
       dplyr::summarize(!!copy_attrs_from :=
                          match.fun(!!agg)(!!as.name(copy_attrs_from),
-                                           na.rm = TRUE)) %>%
-      dplyr::right_join(ndf, by = "id") %>%
-      dplyr::relocate("id", "type", "label") %>%
+                                           na.rm = TRUE)) |>
+      dplyr::right_join(ndf, by = "id") |>
+      dplyr::relocate("id", "type", "label") |>
       as.data.frame(stringsAsFactors = FALSE)
 
     # If edge attribute exists as a column in the ndf
@@ -344,7 +344,7 @@ trav_in_node <- function(
 
       # Reorder columns
       nodes <-
-        nodes %>%
+        nodes |>
         dplyr::relocate("id", "type", "label")
     }
 

--- a/R/trav_in_until.R
+++ b/R/trav_in_until.R
@@ -44,11 +44,11 @@
 #' # nodes from beginning to end;
 #' # select the last path node
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 10,
 #'     node_data = node_data(
-#'       value = 1:10)) %>%
+#'       value = 1:10)) |>
 #'   select_nodes_by_id(
 #'     nodes = 10)
 #'
@@ -56,13 +56,13 @@
 #' # until stopping at a node where
 #' # the `value` attribute is 1
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_in_until(
 #'     conditions =
 #'       value == 1)
 #'
 #' # Get the graph's node selection
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Create two cycles in a graph and
 #' # add values of 1 to 6 to the
@@ -70,15 +70,15 @@
 #' # 12 in the second; select nodes
 #' # `6` and `12`
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(
 #'     n = 6,
 #'     node_data = node_data(
-#'       value = 1:6)) %>%
+#'       value = 1:6)) |>
 #'   add_cycle(
 #'     n = 6,
 #'     node_data = node_data(
-#'       value = 7:12)) %>%
+#'       value = 7:12)) |>
 #'   select_nodes_by_id(
 #'     nodes = c(6, 12))
 #'
@@ -90,14 +90,14 @@
 #' # keep the finally traversed to
 #' # nodes that satisfy the conditions
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_in_until(
 #'     conditions =
 #'       value %in% c(1, 2, 10),
 #'     exclude_unmatched = TRUE)
 #'
 #' # Get the graph's node selection
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 trav_in_until <- function(
@@ -133,13 +133,13 @@ trav_in_until <- function(
 
   starting_nodes <-
     suppressMessages(
-      graph %>%
+      graph |>
         get_selection())
 
   # Determine which nodes satisfy the
   # conditions provided
   all_nodes_conditions_met <-
-    graph %>%
+    graph |>
     get_node_ids(conditions = {{ conditions }})
 
   # Get the name of the function
@@ -150,7 +150,7 @@ trav_in_until <- function(
     # Clear the active selection
     graph <-
       suppressMessages(
-        graph %>%
+        graph |>
           clear_selection())
 
     # Remove action from graph log
@@ -185,7 +185,7 @@ trav_in_until <- function(
   repeat {
 
     # Perform traversal
-    graph <- graph %>% trav_in()
+    graph <- graph |> trav_in()
 
     # Remove action from graph log
     graph$graph_log <-
@@ -193,18 +193,18 @@ trav_in_until <- function(
 
     # If any nodes are `all_nodes_conditions_met` nodes
     # deselect that node and save the node in a stack
-    if (any(suppressMessages(graph %>% get_selection()) %in%
+    if (any(suppressMessages(graph |> get_selection()) %in%
             all_nodes_conditions_met)) {
 
       node_stack <-
         c(node_stack,
           intersect(
-            suppressMessages(graph %>% get_selection()),
+            suppressMessages(graph |> get_selection()),
             all_nodes_conditions_met))
 
       # Remove the node from the active selection
       graph <-
-        graph %>% deselect_nodes(nodes = node_stack)
+        graph |> deselect_nodes(nodes = node_stack)
 
       # Remove action from graph log
       graph$graph_log <-
@@ -228,28 +228,28 @@ trav_in_until <- function(
       }
 
       path_nodes <-
-        node_stack %>%
+        node_stack |>
         purrr::map(
           .f = function(x) {
-            graph %>%
-              to_igraph() %>%
+            graph |>
+              to_igraph() |>
               igraph::all_simple_paths(
                 from = x,
                 to = starting_nodes,
-                mode = "out") %>%
-              unlist() %>%
-              as.integer()}) %>%
-        unlist() %>%
+                mode = "out") |>
+              unlist() |>
+              as.integer()}) |>
+        unlist() |>
         unique()
 
       graph <-
-        graph %>%
+        graph |>
         select_nodes_by_id(unique(path_nodes))
 
     } else {
 
       graph <-
-        graph %>%
+        graph |>
         select_nodes_by_id(unique(node_stack))
     }
 
@@ -266,8 +266,8 @@ trav_in_until <- function(
 
       graph <-
         suppressMessages(
-          graph %>%
-            clear_selection() %>%
+          graph |>
+            clear_selection() |>
             select_nodes_by_id(
               intersect(new_selection, all_nodes_conditions_met)))
 
@@ -295,7 +295,7 @@ trav_in_until <- function(
   # Perform graph actions, if any are available
   if (nrow(graph$graph_actions) > 0) {
     graph <-
-      graph %>%
+      graph |>
       trigger_graph_actions()
   }
 

--- a/R/trav_out.R
+++ b/R/trav_out.R
@@ -49,15 +49,15 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("asd", "iekd")) %>%
+#'     label = c("asd", "iekd")) |>
 #'   add_n_nodes(
 #'     n = 3,
 #'     type = "b",
-#'     label = c("idj", "edl", "ohd")) %>%
+#'     label = c("idj", "edl", "ohd")) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5",
 #'     rel = c(NA, "A", "B", "C", "D"))
@@ -82,112 +82,111 @@
 #' # Join the data frame to the graph's internal
 #' # edge data frame (edf)
 #' graph <-
-#'   graph %>%
-#'   join_edge_attrs(df = df_edges) %>%
+#'   graph |>
+#'   join_edge_attrs(df = df_edges) |>
 #'   join_node_attrs(df = df_nodes)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a simple traversal from node `3`
 #' # to outward adjacent nodes with no conditions
 #' # on the nodes traversed to
-#' graph %>%
-#'   select_nodes_by_id(nodes = 3) %>%
-#'   trav_out() %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 3) |>
+#'   trav_out() |>
 #'   get_selection()
 #'
 #' # Traverse from node `1` to outbound
 #' # nodes, filtering to those nodes that have
 #' # numeric values greater than `7.0` for
 #' # the `values` node attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 1) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 1) |>
 #'   trav_out(
-#'     conditions = values > 7.0) %>%
+#'     conditions = values > 7.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `1` to any outbound
 #' # nodes, filtering to those nodes that
 #' # have a `type` attribute of `b`
-#' graph %>%
-#'   select_nodes_by_id(nodes = 1) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 1) |>
 #'   trav_out(
-#'     conditions = type == "b") %>%
+#'     conditions = type == "b") |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any outbound
 #' # nodes, filtering to those nodes that
 #' # have a degree of `1`
-#' graph %>%
-#'   {
-#'   node_degrees <-
-#'     get_node_info(.) %>%
-#'     dplyr::select(id, deg)
-#'   join_node_attrs(
-#'     graph = .,
-#'     df = node_degrees)
-#'   } %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' node_degrees <- graph |>
+#'   get_node_info() |>
+#'   dplyr::select(id, deg)
+#'
+#' graph <- graph |>
+#'   join_node_attrs(df = node_degrees)
+#'
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_out(
-#'     conditions = deg == 1) %>%
+#'     conditions = deg == 1) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any outbound
 #' # nodes, and use multiple conditions for
 #' # the traversal
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_out(
 #'     conditions =
 #'       type == "a" &
-#'       values > 8.0) %>%
+#'       values > 8.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any
 #' # outbound nodes, and use multiple
 #' # conditions with a single-length vector
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_out(
 #'     conditions =
 #'       type == "b" |
-#'       values > 8.0) %>%
+#'       values > 8.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any outbound
 #' # nodes, and use a regular expression as
 #' # a filtering condition
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_out(
-#'     conditions = grepl("..d", label)) %>%
+#'     conditions = grepl("..d", label)) |>
 #'   get_selection()
 #'
 #' # Create another simple graph to demonstrate
 #' # copying of node attribute values to traversed
 #' # nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_node() %>%
-#'   select_nodes() %>%
+#'   create_graph() |>
+#'   add_node() |>
+#'   select_nodes() |>
 #'   add_n_nodes_ws(
 #'     n = 2,
-#'     direction = "to") %>%
-#'   clear_selection() %>%
-#'   select_nodes_by_id(nodes = 2:3) %>%
+#'     direction = "to") |>
+#'   clear_selection() |>
+#'   select_nodes_by_id(nodes = 2:3) |>
 #'   set_node_attrs_ws(
 #'     node_attr = value,
 #'     value = 5)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a traversal from the outer nodes
 #' # (`2` and `3`) to the central node (`1`) while
@@ -196,14 +195,14 @@
 #' # both nodes before applying that value to the
 #' # target node)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_out(
 #'     copy_attrs_from = value,
 #'     agg = "sum")
 #'
 #' # Show the graph's internal node data
 #' # frame after this change
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 trav_out <- function(
@@ -235,11 +234,11 @@ trav_out <- function(
 
   # Get the requested `copy_attrs_from`
   copy_attrs_from <-
-    rlang::enquo(copy_attrs_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `copy_attrs_as`
   copy_attrs_as <-
-    rlang::enquo(copy_attrs_as) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_as) |> rlang::get_expr() |> as.character()
 
   if (length(copy_attrs_from) == 0) {
     copy_attrs_from <- NULL
@@ -268,14 +267,14 @@ trav_out <- function(
   # Find all nodes that are connected to the
   # starting nodes via outgoing edges
   valid_nodes <-
-    edf %>%
-    dplyr::filter(to != from) %>%
-    dplyr::filter(from %in% starting_nodes) %>%
+    edf |>
+    dplyr::filter(to != from) |>
+    dplyr::filter(from %in% starting_nodes) |>
     dplyr::distinct(to)
 
   valid_nodes <-
-    dplyr::as_tibble(valid_nodes) %>%
-    dplyr::rename(id = "to") %>%
+    dplyr::as_tibble(valid_nodes) |>
+    dplyr::rename(id = "to") |>
     dplyr::inner_join(ndf, by = "id")
 
   # If no rows returned, then there are no
@@ -299,18 +298,18 @@ trav_out <- function(
   if (!is.null(copy_attrs_from)) {
 
     nodes <-
-      valid_nodes %>%
-      dplyr::select(id) %>%
-      dplyr::inner_join(edf %>% dplyr::select("from", "to"), by = c("id" = "to")) %>%
-      dplyr::inner_join(ndf %>% dplyr::select("id", !!enquo(copy_attrs_from)), by = c("from" = "id")) %>%
+      valid_nodes |>
+      dplyr::select(id) |>
+      dplyr::inner_join(edf |> dplyr::select("from", "to"), by = c("id" = "to")) |>
+      dplyr::inner_join(ndf |> dplyr::select("id", !!enquo(copy_attrs_from)), by = c("from" = "id")) |>
       dplyr::select("id", !!enquo(copy_attrs_from))
 
     # If the values to be copied are numeric,
     # perform aggregation on the values
-    if (nodes[, 2] %>% unlist() %>% is.numeric()) {
+    if (nodes[, 2] |> unlist() |> is.numeric()) {
       nodes <-
-        nodes %>%
-        dplyr::group_by(id) %>%
+        nodes |>
+        dplyr::group_by(id) |>
         dplyr::summarize(!!copy_attrs_from :=
                            match.fun(!!agg)(!!as.name(copy_attrs_from),
                                              na.rm = TRUE),
@@ -318,9 +317,9 @@ trav_out <- function(
     }
 
     nodes <-
-      nodes %>%
-      dplyr::right_join(ndf, by = "id") %>%
-      dplyr::relocate(id, type, label) %>%
+      nodes |>
+      dplyr::right_join(ndf, by = "id") |>
+      dplyr::relocate(id, type, label) |>
       as.data.frame(stringsAsFactors = FALSE)
 
     # Get column numbers that end with ".x" or ".y"

--- a/R/trav_out_edge.R
+++ b/R/trav_out_edge.R
@@ -42,18 +42,18 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("asd", "iekd")) %>%
+#'     label = c("asd", "iekd")) |>
 #'   add_n_nodes(
 #'     n = 3,
 #'     type = "b",
-#'     label = c("idj", "edl", "ohd")) %>%
+#'     label = c("idj", "edl", "ohd")) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5",
-#'     rel = c(NA, "A", "B", "C", "D")) %>%
+#'     rel = c(NA, "A", "B", "C", "D")) |>
 #'   set_node_attrs(
 #'     node_attr = values,
 #'     values = c(2.3, 4.7, 9.4,
@@ -71,92 +71,92 @@
 #' # Join the data frame to the graph's internal
 #' # edge data frame (edf)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   join_edge_attrs(
 #'     df = df)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a simple traversal from nodes to
 #' # outbound edges with no conditions on the
 #' # nodes traversed to
-#' graph %>%
-#'   select_nodes_by_id(nodes = 1) %>%
-#'   trav_out_edge() %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 1) |>
+#'   trav_out_edge() |>
 #'   get_selection()
 #'
 #' # Traverse from node `1` to any outbound
 #' # edges, filtering to those edges that have
 #' # NA values for the `rel` edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 1) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 1) |>
 #'   trav_out_edge(
-#'     conditions = is.na(rel)) %>%
+#'     conditions = is.na(rel)) |>
 #'   get_selection()
 #'
 #' # Traverse from node `3` to any outbound
 #' # edges, filtering to those edges that have
 #' # numeric values greater than `5.0` for
 #' # the `rel` edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 3) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 3) |>
 #'   trav_out_edge(
-#'     conditions = values > 5.0) %>%
+#'     conditions = values > 5.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `1` to any outbound
 #' # edges, filtering to those edges that
 #' # have values equal to `A` for the `rel`
 #' # edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 1) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 1) |>
 #'   trav_out_edge(
-#'     conditions = rel == "A") %>%
+#'     conditions = rel == "A") |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any outbound
 #' # edges, filtering to those edges that
 #' # have values in the set `B` and `C` for
 #' # the `rel` edge attribute
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_out_edge(
-#'     conditions = rel %in% c("B", "C")) %>%
+#'     conditions = rel %in% c("B", "C")) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any
 #' # outbound edges, and use multiple
 #' # conditions for the traversal
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_out_edge(
 #'     conditions =
 #'       rel %in% c("B", "C") &
-#'       values >= 5.0) %>%
+#'       values >= 5.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any
 #' # outbound edges, and use multiple
 #' # conditions
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_out_edge(
 #'     conditions =
 #'       rel %in% c("B", "C") |
-#'       values > 6.0) %>%
+#'       values > 6.0) |>
 #'   get_selection()
 #'
 #' # Traverse from node `2` to any outbound
 #' # edges, and use a regular expression as
 #' # a filtering condition
-#' graph %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#' graph |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   trav_out_edge(
-#'     conditions = grepl("B|C", rel)) %>%
+#'     conditions = grepl("B|C", rel)) |>
 #'   get_selection()
 #'
 #' # Perform a traversal from all nodes to
@@ -164,14 +164,14 @@
 #' # so, copy the `label` node attribute
 #' # to any of the nodes' incoming edges
 #' graph <-
-#'   graph %>%
-#'   select_nodes() %>%
+#'   graph |>
+#'   select_nodes() |>
 #'   trav_out_edge(
 #'     copy_attrs_from = label)
 #'
 #' # Show the graph's internal edge
 #' # data frame after this change
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' @export
 trav_out_edge <- function(
@@ -201,11 +201,11 @@ trav_out_edge <- function(
 
   # Get the requested `copy_attrs_from`
   copy_attrs_from <-
-    rlang::enquo(copy_attrs_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `copy_attrs_as`
   copy_attrs_as <-
-    rlang::enquo(copy_attrs_as) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_as) |> rlang::get_expr() |> as.character()
 
   if (length(copy_attrs_from) == 0) {
     copy_attrs_from <- NULL
@@ -235,8 +235,8 @@ trav_out_edge <- function(
   # starting nodes and remove edges that
   # are loops
   valid_edges <-
-    edf %>%
-    dplyr::filter(from %in% starting_nodes) %>%
+    edf |>
+    dplyr::filter(from %in% starting_nodes) |>
     dplyr::filter(to != from)
 
   # If no rows returned, then there are no
@@ -267,8 +267,8 @@ trav_out_edge <- function(
   if (!is.null(copy_attrs_from)) {
 
     ndf_2 <-
-      ndf %>%
-      dplyr::filter(id %in% starting_nodes) %>%
+      ndf |>
+      dplyr::filter(id %in% starting_nodes) |>
       dplyr::select("id", !!enquo(copy_attrs_from))
 
     if (!is.null(copy_attrs_as)) {
@@ -286,9 +286,9 @@ trav_out_edge <- function(
     if (!(copy_attrs_from %in% colnames(edf))) {
 
       edges <-
-        ndf_2 %>%
-        dplyr::right_join(edf, c("id" = "from")) %>%
-        dplyr::rename(from = "id.y") %>%
+        ndf_2 |>
+        dplyr::right_join(edf, c("id" = "from")) |>
+        dplyr::rename(from = "id.y") |>
         dplyr::relocate("id", "from", "to", "rel")
     }
 
@@ -296,9 +296,9 @@ trav_out_edge <- function(
     if (copy_attrs_from %in% colnames(edf)) {
 
       edges <-
-        ndf_2 %>%
-        dplyr::right_join(edf, c("id" = "from")) %>%
-        dplyr::rename(from = "id") %>%
+        ndf_2 |>
+        dplyr::right_join(edf, c("id" = "from")) |>
+        dplyr::rename(from = "id") |>
         dplyr::rename(id = "id.y")
 
       # Get column numbers that end with ".x" or ".y"
@@ -324,7 +324,7 @@ trav_out_edge <- function(
 
       # Reorder columns
       edges <-
-        edges %>%
+        edges |>
         dplyr::relocate("id", "from", "to", "rel")
     }
 

--- a/R/trav_out_node.R
+++ b/R/trav_out_node.R
@@ -45,15 +45,15 @@
 #'
 #' # Create a simple graph
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_n_nodes(
 #'     n = 2,
 #'     type = "a",
-#'     label = c("asd", "iekd")) %>%
+#'     label = c("asd", "iekd")) |>
 #'   add_n_nodes(
 #'     n = 3,
 #'     type = "b",
-#'     label = c("idj", "edl", "ohd")) %>%
+#'     label = c("idj", "edl", "ohd")) |>
 #'   add_edges_w_string(
 #'     edges = "1->2 1->3 2->4 2->5 3->5",
 #'     rel = c(NA, "A", "B", "C", "D"))
@@ -78,40 +78,40 @@
 #' # Join the data frame to the graph's internal
 #' # edge data frame (edf)
 #' graph <-
-#'   graph %>%
-#'   join_edge_attrs(df = df_edges) %>%
+#'   graph |>
+#'   join_edge_attrs(df = df_edges) |>
 #'   join_node_attrs(df = df_nodes)
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Perform a simple traversal from the
 #' # edge `1`->`3` to the attached node
 #' # in the direction of the edge; here, no
 #' # conditions are placed on the nodes
 #' # traversed to
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 1,
-#'       to = 3) %>%
-#'   trav_out_node() %>%
+#'       to = 3) |>
+#'   trav_out_node() |>
 #'   get_selection()
 #'
 #' # Traverse from edges `2`->`5` and
 #' # `3`->`5` to the attached node along
 #' # the direction of the edge; here, the
 #' # traversals lead to different nodes
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 2,
-#'       to = 5) %>%
+#'       to = 5) |>
 #'   select_edges(
 #'     from = 3,
-#'       to = 5) %>%
-#'   trav_out_node() %>%
+#'       to = 5) |>
+#'   trav_out_node() |>
 #'   get_selection()
 #'
 #' # Traverse from the edge `1`->`3`
@@ -119,12 +119,12 @@
 #' # is outgoing, this time filtering
 #' # numeric values greater than `7.0` for
 #' # the `values` node attribute
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 1,
-#'       to = 3) %>%
+#'       to = 3) |>
 #'   trav_out_node(
-#'     conditions = values > 7.0) %>%
+#'     conditions = values > 7.0) |>
 #'   get_selection()
 #'
 #' # Traverse from the edge `1`->`3`
@@ -134,59 +134,59 @@
 #' # the `values` node attribute (the
 #' # condition is not met so the original
 #' # selection of edge `1`->`3` remains)
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 1,
-#'       to = 3) %>%
+#'       to = 3) |>
 #'   trav_out_node(
-#'     conditions = values < 7.0) %>%
+#'     conditions = values < 7.0) |>
 #'   get_selection()
 #'
 #' # Traverse from the edge `1`->`2`
 #' # to node `2`, using multiple conditions
-#' graph %>%
+#' graph |>
 #'   select_edges(
 #'     from = 1,
-#'       to = 2) %>%
+#'       to = 2) |>
 #'   trav_out_node(
 #'     conditions =
 #'       grepl(".*d$", label) |
-#'       values < 6.0) %>%
+#'       values < 6.0) |>
 #'   get_selection()
 #'
 #' # Create another simple graph to demonstrate
 #' # copying of edge attribute values to traversed
 #' # nodes
 #' graph <-
-#'   create_graph() %>%
-#'   add_node() %>%
-#'   select_nodes() %>%
+#'   create_graph() |>
+#'   add_node() |>
+#'   select_nodes() |>
 #'   add_n_nodes_ws(
 #'     n = 2,
-#'     direction = "from") %>%
-#'   clear_selection() %>%
-#'   select_nodes_by_id(nodes = 2) %>%
+#'     direction = "from") |>
+#'   clear_selection() |>
+#'   select_nodes_by_id(nodes = 2) |>
 #'   set_node_attrs_ws(
 #'     node_attr = value,
-#'     value = 8) %>%
-#'   clear_selection() %>%
-#'   select_edges_by_edge_id(edges = 1) %>%
+#'     value = 8) |>
+#'   clear_selection() |>
+#'   select_edges_by_edge_id(edges = 1) |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = value,
-#'     value = 5) %>%
-#'   clear_selection() %>%
-#'   select_edges_by_edge_id(edges = 2) %>%
+#'     value = 5) |>
+#'   clear_selection() |>
+#'   select_edges_by_edge_id(edges = 2) |>
 #'   set_edge_attrs_ws(
 #'     edge_attr = value,
-#'     value = 5) %>%
-#'   clear_selection() %>%
+#'     value = 5) |>
+#'   clear_selection() |>
 #'   select_edges()
 #'
 #' # Show the graph's internal edge data frame
-#' graph %>% get_edge_df()
+#' graph |> get_edge_df()
 #'
 #' # Show the graph's internal node data frame
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' # Perform a traversal from the edges to
 #' # the central node (`1`) while also applying
@@ -194,14 +194,14 @@
 #' # this case summing the `value` of 5 from
 #' # both edges before adding as a node attribute)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_out_node(
 #'     copy_attrs_from = value,
 #'     agg = "sum")
 #'
 #' # Show the graph's internal node data frame
 #' # after this change
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 trav_out_node <- function(
@@ -232,11 +232,11 @@ trav_out_node <- function(
 
   # Get the requested `copy_attrs_from`
   copy_attrs_from <-
-    rlang::enquo(copy_attrs_from) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_from) |> rlang::get_expr() |> as.character()
 
   # Get the requested `copy_attrs_as`
   copy_attrs_as <-
-    rlang::enquo(copy_attrs_as) %>% rlang::get_expr() %>% as.character()
+    rlang::enquo(copy_attrs_as) |> rlang::get_expr() |> as.character()
 
   if (length(copy_attrs_from) == 0) {
     copy_attrs_from <- NULL
@@ -264,8 +264,8 @@ trav_out_node <- function(
   # Find all nodes that are connected to the
   # starting edges
   valid_nodes <-
-    starting_edges %>%
-    dplyr::distinct(from) %>%
+    starting_edges |>
+    dplyr::distinct(from) |>
     dplyr::left_join(ndf, by = c("from" = "id"))
 
   # If traversal conditions are provided then
@@ -289,9 +289,9 @@ trav_out_node <- function(
   if (!is.null(copy_attrs_from)) {
 
     nodes <-
-      starting_edges %>%
-      dplyr::semi_join(valid_nodes, by = "from") %>%
-      dplyr::left_join(edf, by = c("edge" = "id")) %>%
+      starting_edges |>
+      dplyr::semi_join(valid_nodes, by = "from") |>
+      dplyr::left_join(edf, by = c("edge" = "id")) |>
       dplyr::select("from.y", !!enquo(copy_attrs_from))
 
     if (!is.null(copy_attrs_as)) {
@@ -306,14 +306,14 @@ trav_out_node <- function(
     }
 
     nodes <-
-      nodes %>%
-      dplyr::rename(id = "from.y") %>%
-      dplyr::group_by(id) %>%
+      nodes |>
+      dplyr::rename(id = "from.y") |>
+      dplyr::group_by(id) |>
       dplyr::summarize(!!copy_attrs_from :=
                          match.fun(!!agg)(!!as.name(copy_attrs_from),
-                                           na.rm = TRUE)) %>%
-      dplyr::right_join(ndf, by = "id") %>%
-      dplyr::relocate("id", "type", "label") %>%
+                                           na.rm = TRUE)) |>
+      dplyr::right_join(ndf, by = "id") |>
+      dplyr::relocate("id", "type", "label") |>
       as.data.frame(stringsAsFactors = FALSE)
 
     # If edge attribute exists as a column in the ndf
@@ -342,7 +342,7 @@ trav_out_node <- function(
 
       # Reorder columns
       nodes <-
-        nodes %>%
+        nodes |>
         dplyr::relocate("id", "type", "label")
     }
 

--- a/R/trav_out_until.R
+++ b/R/trav_out_until.R
@@ -44,11 +44,11 @@
 #' # nodes from beginning to end;
 #' # select the first path node
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_path(
 #'     n = 10,
 #'     node_data = node_data(
-#'       value = 1:10)) %>%
+#'       value = 1:10)) |>
 #'   select_nodes_by_id(
 #'     nodes = 1)
 #'
@@ -56,13 +56,13 @@
 #' # until stopping at a node where
 #' # the `value` attribute is 8
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_out_until(
 #'     conditions =
 #'       value == 8)
 #'
 #' # Get the graph's node selection
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Create two cycles in graph and
 #' # add values of 1 to 6 to the
@@ -70,15 +70,15 @@
 #' # 12 in the second; select nodes
 #' # `1` and `7`
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_cycle(
 #'     n = 6,
 #'     node_data = node_data(
-#'       value = 1:6)) %>%
+#'       value = 1:6)) |>
 #'   add_cycle(
 #'     n = 6,
 #'     node_data = node_data(
-#'       value = 7:12)) %>%
+#'       value = 7:12)) |>
 #'   select_nodes_by_id(
 #'     nodes = c(1, 7))
 #'
@@ -90,14 +90,14 @@
 #' # keep the finally traversed to
 #' # nodes that satisfy the conditions
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_out_until(
 #'     conditions =
 #'       value %in% c(5, 6, 9),
 #'     exclude_unmatched = TRUE)
 #'
 #' # Get the graph's node selection
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 trav_out_until <- function(
@@ -130,13 +130,13 @@ trav_out_until <- function(
 
   starting_nodes <-
     suppressMessages(
-      graph %>%
+      graph |>
         get_selection())
 
   # Determine which nodes satisfy the
   # conditions provided
   all_nodes_conditions_met <-
-    graph %>%
+    graph |>
     get_node_ids(conditions = {{ conditions }})
 
   if (exclude_unmatched && all(is.na(all_nodes_conditions_met))) {
@@ -144,7 +144,7 @@ trav_out_until <- function(
     # Clear the active selection
     graph <-
       suppressMessages(
-        graph %>%
+        graph |>
           clear_selection())
 
     # Remove action from graph log
@@ -179,7 +179,7 @@ trav_out_until <- function(
   repeat {
 
     # Perform traversal
-    graph <- graph %>% trav_out()
+    graph <- graph |> trav_out()
 
     # Remove action from graph log
     graph$graph_log <-
@@ -187,18 +187,18 @@ trav_out_until <- function(
 
     # If any nodes are `all_nodes_conditions_met` nodes
     # deselect that node and save the node in a stack
-    if (any(suppressMessages(graph %>% get_selection()) %in%
+    if (any(suppressMessages(graph |> get_selection()) %in%
             all_nodes_conditions_met)) {
 
       node_stack <-
         c(node_stack,
           intersect(
-            suppressMessages(graph %>% get_selection()),
+            suppressMessages(graph |> get_selection()),
             all_nodes_conditions_met))
 
       # Remove the node from the active selection
       graph <-
-        graph %>% deselect_nodes(nodes = node_stack)
+        graph |> deselect_nodes(nodes = node_stack)
 
       # Remove action from graph log
       graph$graph_log <-
@@ -222,28 +222,28 @@ trav_out_until <- function(
       }
 
       path_nodes <-
-        node_stack %>%
+        node_stack |>
         purrr::map(
           .f = function(x) {
-            graph %>%
-              to_igraph() %>%
+            graph |>
+              to_igraph() |>
               igraph::all_simple_paths(
                 from = x,
                 to = starting_nodes,
-                mode = "in") %>%
-              unlist() %>%
-              as.integer()}) %>%
-        unlist() %>%
+                mode = "in") |>
+              unlist() |>
+              as.integer()}) |>
+        unlist() |>
         unique()
 
       graph <-
-        graph %>%
+        graph |>
         select_nodes_by_id(unique(path_nodes))
 
     } else {
 
       graph <-
-        graph %>%
+        graph |>
         select_nodes_by_id(unique(node_stack))
     }
 
@@ -260,8 +260,8 @@ trav_out_until <- function(
 
       graph <-
         suppressMessages(
-          graph %>%
-            clear_selection() %>%
+          graph |>
+            clear_selection() |>
             select_nodes_by_id(
               intersect(new_selection, all_nodes_conditions_met)))
 

--- a/R/trav_reverse_edge.R
+++ b/R/trav_reverse_edge.R
@@ -52,26 +52,26 @@
 #' # Explicitly select the edges
 #' # `1`->`4` and `2`->`3`
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   select_edges(
 #'     from = 1,
-#'       to = 4) %>%
+#'       to = 4) |>
 #'   select_edges(
 #'     from = 2,
 #'       to = 3)
 #'
 #' # Get the inital edge selection
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' # Traverse to the reverse edges
 #' # (edges `2`: `4`->`1` and
 #' # `4`:`3`->`2`)
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trav_reverse_edge()
 #'
 #' # Get the current selection of edges
-#' graph %>% get_selection()
+#' graph |> get_selection()
 #'
 #' @export
 trav_reverse_edge <- function(
@@ -100,15 +100,15 @@ trav_reverse_edge <- function(
 
   # Get the available reverse edges
   reverse_edges_df <- data.frame(to = edges_from, from = edges_to)
-  reverse_edges <- edf %>% dplyr::inner_join(reverse_edges_df, by = c("from", "to"))
+  reverse_edges <- edf |> dplyr::inner_join(reverse_edges_df, by = c("from", "to"))
 
   # Add the reverse edges to the existing,
   # selected edges
   if (add_to_selection) {
     edges_df <- data.frame(to = edges_to, from = edges_from)
     edges <-
-      edf %>%
-      dplyr::inner_join(edges_df, by = c("from", "to")) %>%
+      edf |>
+      dplyr::inner_join(edges_df, by = c("from", "to")) |>
       dplyr::bind_rows(reverse_edges)
   } else {
     edges <- reverse_edges
@@ -116,8 +116,8 @@ trav_reverse_edge <- function(
 
   # Modify `edges` to create a correct esdf
   edges <-
-    edges %>%
-    dplyr::select(edge = "id", "from", "to") %>%
+    edges |>
+    dplyr::select(edge = "id", "from", "to") |>
     dplyr::arrange(edge)
 
   # Add the edge ID values to the active selection

--- a/R/trigger_graph_actions.R
+++ b/R/trigger_graph_actions.R
@@ -17,7 +17,7 @@
 #' # Create a random graph using the
 #' # `add_gnm_graph()` function
 #' graph <-
-#'   create_graph() %>%
+#'   create_graph() |>
 #'   add_gnm_graph(
 #'     n = 5,
 #'     m = 10,
@@ -29,7 +29,7 @@
 #' # to provide PageRank values in the
 #' # `pagerank` column
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_graph_action(
 #'     fcn = "set_node_attr_w_fcn",
 #'     node_attr_fcn = "get_pagerank",
@@ -42,7 +42,7 @@
 #' # column between 0 and 1, and, puts
 #' # these values in the `width` column
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_graph_action(
 #'     fcn = "rescale_node_attrs",
 #'     node_attr_from = "pagerank",
@@ -55,7 +55,7 @@
 #' # based on the numeric values from the
 #' # `width` column
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   add_graph_action(
 #'     fcn = "colorize_node_attrs",
 #'     node_attr_from = "width",
@@ -65,20 +65,20 @@
 #' # View the graph actions for the graph
 #' # object by using the `get_graph_actions()`
 #' # function
-#' graph %>% get_graph_actions()
+#' graph |> get_graph_actions()
 #'
 #' # Manually trigger to invocation of
 #' # the graph actions using the
 #' # `trigger_graph_actions()` function
 #' graph <-
-#'   graph %>%
+#'   graph |>
 #'   trigger_graph_actions()
 #'
 #' # Examine the graph's internal node
 #' # data frame (ndf) to verify that
 #' # the `pagerank`, `width`, and
 #' # `fillcolor` columns are present
-#' graph %>% get_node_df()
+#' graph |> get_node_df()
 #'
 #' @export
 trigger_graph_actions <- function(graph) {
@@ -125,8 +125,8 @@ trigger_graph_actions <- function(graph) {
       graph <- graph_previous
 
       action_name_at_error <-
-        graph$graph_actions %>%
-        dplyr::filter(action_index == expr_error_at_index) %>%
+        graph$graph_actions |>
+        dplyr::filter(action_index == expr_error_at_index) |>
         dplyr::pull("action_name")
 
       if (!is.na(action_name_at_error)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -152,7 +152,7 @@ replace_graph_edge_selection <- function(graph,
 create_empty_nsdf <- function() {
 
   # Create empty `nsdf`
-  dplyr::tibble(node = integer()) %>%
+  dplyr::tibble(node = integer()) |>
     as.data.frame(stringsAsFactors = FALSE)
 }
 
@@ -198,7 +198,7 @@ is_attr_unique_and_non_na <- function(graph,
 
   # Are all values distinct?
   all_values_distinct <-
-    dplyr::pull(df, !!enquo(attr)) %>% dplyr::n_distinct() ==
+    dplyr::pull(df, !!enquo(attr)) |> dplyr::n_distinct() ==
     nrow(df)
 
   all_is_not_na && all_values_distinct
@@ -390,7 +390,7 @@ get_col_selection <- function(col_selection_stmt) {
     column_selection <-
       stringr::str_split(
         string = col_selection_stmt,
-        pattern = " & ") %>%
+        pattern = " & ") |>
       unlist()
 
   } else if (any(stringr::str_detect(
@@ -404,13 +404,13 @@ get_col_selection <- function(col_selection_stmt) {
       seq(
         from = (stringr::str_split(
           string = col_selection_stmt,
-          pattern = ":") %>%
-            unlist())[1] %>%
+          pattern = ":") |>
+            unlist())[1] |>
           as.numeric(),
         to = (stringr::str_split(
           string = col_selection_stmt,
-          pattern = ":") %>%
-            unlist())[2] %>%
+          pattern = ":") |>
+            unlist())[2] |>
           as.numeric())
 
   } else if (any(
@@ -426,11 +426,11 @@ get_col_selection <- function(col_selection_stmt) {
       c(
         (stringr::str_split(
           string = col_selection_stmt,
-          pattern = ":") %>%
+          pattern = ":") |>
            unlist())[1],
         (stringr::str_split(
           string = col_selection_stmt,
-          pattern = ":") %>%
+          pattern = ":") |>
            unlist())[2])
   } else {
     return(list())
@@ -451,7 +451,7 @@ get_col_selection <- function(col_selection_stmt) {
 contrasting_text_color <- function(background_color) {
 
   rgb_colors <-
-    ((grDevices::col2rgb(background_color) %>%
+    ((grDevices::col2rgb(background_color) |>
         as.numeric()) / 255)^2.2
 
   luminance <-
@@ -484,8 +484,8 @@ contrasting_text_color <- function(background_color) {
 emit_message <- function(fcn_name,
                          message_body) {
 
-  glue::glue("`{fcn_name}()` INFO: {message_body}") %>%
-    as.character() %>%
+  glue::glue("`{fcn_name}()` INFO: {message_body}") |>
+    as.character() |>
     message()
 }
 
@@ -739,9 +739,9 @@ get_df_ids <- function(graph_df) {
 
     if ("df_id" %in% colnames(graph_df)) {
 
-      graph_df %>%
-        dplyr::select("df_id") %>%
-        dplyr::filter(!is.na(df_id)) %>%
+      graph_df |>
+        dplyr::select("df_id") |>
+        dplyr::filter(!is.na(df_id)) |>
         dplyr::pull("df_id")
     } else {
       return(NA_character_)
@@ -766,13 +766,13 @@ remove_linked_dfs <- function(graph) {
   }
 
   ndf_df_ids <-
-    graph %>%
-    get_node_df() %>%
+    graph |>
+    get_node_df() |>
     get_df_ids()
 
   edf_df_ids <-
-    graph %>%
-    get_edge_df() %>%
+    graph |>
+    get_edge_df() |>
     get_df_ids()
 
   # Determine if any of the stored
@@ -781,12 +781,12 @@ remove_linked_dfs <- function(graph) {
   if (length(graph$df_storage) > 0) {
 
     ndf_df_id_to_remove <-
-      graph$df_storage %>%
-      dplyr::bind_rows() %>%
-      dplyr::filter(node_edge__ == "node") %>%
-      dplyr::select("df_id__") %>%
-      dplyr::distinct() %>%
-      dplyr::pull("df_id__") %>%
+      graph$df_storage |>
+      dplyr::bind_rows() |>
+      dplyr::filter(node_edge__ == "node") |>
+      dplyr::select("df_id__") |>
+      dplyr::distinct() |>
+      dplyr::pull("df_id__") |>
       base::setdiff(ndf_df_ids)
 
     # If any stored data frames are associated
@@ -805,12 +805,12 @@ remove_linked_dfs <- function(graph) {
   # the graph's internal edge data frame
   if (length(graph$df_storage) > 0) {
     edf_df_id_to_remove <-
-      graph$df_storage %>%
-      dplyr::bind_rows() %>%
-      dplyr::filter(node_edge__ == "edge") %>%
-      dplyr::select("df_id__") %>%
-      dplyr::distinct() %>%
-      dplyr::pull("df_id__") %>%
+      graph$df_storage |>
+      dplyr::bind_rows() |>
+      dplyr::filter(node_edge__ == "edge") |>
+      dplyr::select("df_id__") |>
+      dplyr::distinct() |>
+      dplyr::pull("df_id__") |>
       base::setdiff(edf_df_ids)
 
 
@@ -882,33 +882,33 @@ get_svg_tbl <- function(svg_vec) {
     } else if (grepl("<!-- Title:", line)) {
       rec <- dplyr::tibble(index = i, type = "title_block")
     } else if (grepl("^<svg", line)) {
-      rec <- dplyr::tibble(index = i, type = "svg") %>% dplyr::bind_cols(get_attr_tbl(line))
+      rec <- dplyr::tibble(index = i, type = "svg") |> dplyr::bind_cols(get_attr_tbl(line))
     } else if (grepl(" viewBox", line)) {
       rec <- dplyr::tibble(index = i, type = "viewbox_info")
     } else if (grepl("^<g ", line)) {
-      rec <- dplyr::tibble(index = i, type = "g") %>% dplyr::bind_cols(get_attr_tbl(line))
+      rec <- dplyr::tibble(index = i, type = "g") |> dplyr::bind_cols(get_attr_tbl(line))
     } else if (grepl("^<title>", line)) {
-      rec <- dplyr::tibble(index = i, type = "title") %>% dplyr::bind_cols(get_inner_html(line))
+      rec <- dplyr::tibble(index = i, type = "title") |> dplyr::bind_cols(get_inner_html(line))
     } else if (grepl("^<polygon", line)) {
-      rec <- dplyr::tibble(index = i, type = "polygon") %>% dplyr::bind_cols(get_attr_tbl(line))
+      rec <- dplyr::tibble(index = i, type = "polygon") |> dplyr::bind_cols(get_attr_tbl(line))
     } else if (grepl("^<path", line)) {
-      rec <- dplyr::tibble(index = i, type = "path") %>% dplyr::bind_cols(get_attr_tbl(line))
+      rec <- dplyr::tibble(index = i, type = "path") |> dplyr::bind_cols(get_attr_tbl(line))
     } else if (grepl("^<ellipse", line)) {
-      rec <- dplyr::tibble(index = i, type = "ellipse") %>% dplyr::bind_cols(get_attr_tbl(line))
+      rec <- dplyr::tibble(index = i, type = "ellipse") |> dplyr::bind_cols(get_attr_tbl(line))
     } else if (grepl("<!-- [0-9]*? -->", line)) {
-      node_id <- gsub("(<!-- | -->)", "", line) %>% as.integer()
+      node_id <- gsub("(<!-- | -->)", "", line) |> as.integer()
       rec <- dplyr::tibble(index = i, type = "node_block", node_id = node_id)
     } else if (grepl("<!-- [0-9]*?&#45;&gt;[0-9]*? -->", line)) {
-      from_node_id <- gsub("(<!-- |?&#45;&gt;[0-9]*? -->)", "", line) %>% as.integer()
-      to_node_id <- gsub("(<!-- [0-9]*?&#45;&gt;| -->)", "", line) %>% as.integer()
+      from_node_id <- gsub("(<!-- |?&#45;&gt;[0-9]*? -->)", "", line) |> as.integer()
+      to_node_id <- gsub("(<!-- [0-9]*?&#45;&gt;| -->)", "", line) |> as.integer()
       rec <- dplyr::tibble(index = i, type = "edge_block", from = from_node_id, to = to_node_id)
     } else if (grepl("<!-- [0-9]*?&#45;&#45;[0-9]*? -->", line)) {
-      from_node_id <- gsub("(<!-- |?&#45;&#45;[0-9]*? -->)", "", line) %>% as.integer()
-      to_node_id <- gsub("(<!-- [0-9]*?&#45;&#45;| -->)", "", line) %>% as.integer()
+      from_node_id <- gsub("(<!-- |?&#45;&#45;[0-9]*? -->)", "", line) |> as.integer()
+      to_node_id <- gsub("(<!-- [0-9]*?&#45;&#45;| -->)", "", line) |> as.integer()
       rec <- dplyr::tibble(index = i, type = "edge_block", from = from_node_id, to = to_node_id)
     } else if (grepl("^<text ", line)) {
-      rec <- dplyr::tibble(index = i, type = "text") %>%
-        dplyr::bind_cols(get_attr_tbl(line)) %>%
+      rec <- dplyr::tibble(index = i, type = "text") |>
+        dplyr::bind_cols(get_attr_tbl(line)) |>
         dplyr::bind_cols(get_inner_html(line))
     } else if (grepl("</g>", line)) {
       rec <- dplyr::tibble(index = i, type = "g_close")
@@ -921,7 +921,7 @@ get_svg_tbl <- function(svg_vec) {
     svg_tbl <- dplyr::bind_rows(svg_tbl, rec)
   }
 
-  svg_tbl %>% tidyr::fill(node_id)
+  svg_tbl |> tidyr::fill(node_id)
 }
 
 #' Function to create a one-row table of attr-value pairs
@@ -929,18 +929,18 @@ get_svg_tbl <- function(svg_vec) {
 #' @noRd
 get_attr_tbl <- function(line) {
 
-  line <- gsub("<[a-z]*? ", "", line) %>% gsub("\"", "'", .) %>% gsub("(/>|>|>.*)", "", .)
+  line <- gsub("<[a-z]*? ", "", line) |> gsub("\"", "'", .) |> gsub("(/>|>|>.*)", "", .)
 
   el_attrs <-
-    strsplit(line, "' ") %>%
-    unlist() %>%
-    gsub("'", "", .) %>%
+    strsplit(line, "' ") |>
+    unlist() |>
+    gsub("'", "", .) |>
     strsplit("=")
 
   stats::setNames(
     sapply(el_attrs, `[[`, 2),
-    sapply(el_attrs, `[[`, 1)) %>%
-    as.list() %>%
+    sapply(el_attrs, `[[`, 1)) |>
+    as.list() |>
     dplyr::as_tibble()
 }
 

--- a/R/visnetwork.R
+++ b/R/visnetwork.R
@@ -42,8 +42,8 @@
 visnetwork <- function(graph) {
 
   # Extract node and edge data frames from the graph object
-  nodes <- graph %>% get_node_df()
-  edges <- graph %>% get_edge_df()
+  nodes <- graph |> get_node_df()
+  edges <- graph |> get_edge_df()
 
   # Render an empty graph if no nodes or edges exist
   if (is_graph_empty(graph)) {

--- a/man/add_balanced_tree.Rd
+++ b/man/add_balanced_tree.Rd
@@ -65,11 +65,11 @@ With a graph object of class \code{dgr_graph}, add a balanced tree to the graph.
 # 2 (branching twice) and
 # different branching ratios
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
     k = 2,
     h = 2,
-    type = "binary") \%>\%
+    type = "binary") |>
   add_balanced_tree(
     k = 3,
     h = 2,
@@ -77,8 +77,8 @@ graph <-
 
 # Get some node information
 # from this graph
-graph \%>\%
-  get_node_info() \%>\%
+graph |>
+  get_node_info() |>
   head(5)
 
 # Node and edge aesthetic and data
@@ -87,7 +87,7 @@ graph \%>\%
 # `node_data`, and `edge_data`
 # arguments
 graph_w_attrs <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
     k = 2,
     h = 2,
@@ -111,14 +111,14 @@ graph_w_attrs <-
 
 # Get the first three rows of
 # the graph's node data frame
-graph_w_attrs \%>\%
-  get_node_df() \%>\%
+graph_w_attrs |>
+  get_node_df() |>
   head(3)
 
 # Get the first three rows of
 # the graph's edge data frame
-graph_w_attrs \%>\%
-  get_edge_df() \%>\%
+graph_w_attrs |>
+  get_edge_df() |>
   head(3)
 
 }

--- a/man/add_cycle.Rd
+++ b/man/add_cycle.Rd
@@ -59,12 +59,12 @@ With a graph object of class \code{dgr_graph}, add a node cycle to the graph.
 # Create a new graph and
 # add a cycle of nodes to it
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 6)
 
 # Get node information
 # from this graph
-graph \%>\%
+graph |>
   get_node_info()
 
 # Node and edge aesthetic and data
@@ -77,7 +77,7 @@ suppressWarnings(RNGversion("3.5.0"))
 set.seed(23)
 
 graph_w_attrs <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(
     n = 3,
     label = c(
@@ -101,9 +101,9 @@ graph_w_attrs <-
           sd = 1.0)))
 
 # Get the graph's node data frame
-graph_w_attrs \%>\% get_node_df()
+graph_w_attrs |> get_node_df()
 
 # Get the graph's edge data frame
-graph_w_attrs \%>\% get_edge_df()
+graph_w_attrs |> get_edge_df()
 
 }

--- a/man/add_edge.Rd
+++ b/man/add_edge.Rd
@@ -43,10 +43,10 @@ graph.
 \examples{
 # Create a graph with 4 nodes
 graph <-
-  create_graph() \%>\%
-  add_node(label = "one") \%>\%
-  add_node(label = "two") \%>\%
-  add_node(label = "three") \%>\%
+  create_graph() |>
+  add_node(label = "one") |>
+  add_node(label = "two") |>
+  add_node(label = "three") |>
   add_node(label = "four")
 
 # Add an edge between those
@@ -62,13 +62,13 @@ graph <-
 # Use the `get_edge_info()`
 # function to verify that
 # the edge has been created
-graph \%>\%
+graph |>
   get_edge_info()
 
 # Add another node and
 # edge to the graph
 graph <-
-  graph \%>\%
+  graph |>
   add_edge(
     from = 3,
     to = 2,
@@ -77,7 +77,7 @@ graph <-
 # Verify that the edge
 # has been created by
 # counting graph edges
-graph \%>\% count_edges()
+graph |> count_edges()
 
 # Add edges by specifying
 # node `label` values; note
@@ -85,11 +85,11 @@ graph \%>\% count_edges()
 # unique `label` values to
 # use this option
 graph <-
-  graph \%>\%
+  graph |>
   add_edge(
     from = "three",
     to = "four",
-    rel = "L") \%>\%
+    rel = "L") |>
   add_edge(
     from = "four",
     to = "one",
@@ -97,13 +97,13 @@ graph <-
 
 # Use `get_edges()` to verify
 # that the edges were added
-graph \%>\% get_edges()
+graph |> get_edges()
 
 # Add edge aesthetic and data
 # attributes during edge creation
 graph_2 <-
-  create_graph() \%>\%
-  add_n_nodes(n = 2) \%>\%
+  create_graph() |>
+  add_n_nodes(n = 2) |>
   add_edge(
     from = 1,
     to = 2,
@@ -118,7 +118,7 @@ graph_2 <-
 # to verify that the attribute
 # values were bound to the
 # newly created edge
-graph_2 \%>\% get_edge_df()
+graph_2 |> get_edge_df()
 
 
 }

--- a/man/add_edge_clone.Rd
+++ b/man/add_edge_clone.Rd
@@ -29,19 +29,19 @@ edge already in the graph. All edge attributes are preserved.
 # in this path and then add a
 # `color` edge attribute
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 2,
-    rel = "a") \%>\%
-  select_last_edges_created() \%>\%
+    rel = "a") |>
+  select_last_edges_created() |>
   set_edge_attrs(
     edge_attr = color,
-    values = "steelblue") \%>\%
+    values = "steelblue") |>
   clear_selection()
 
 # Display the graph's internal
 # edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Create a new node (will have
 # node ID of `3`) and then
@@ -50,8 +50,8 @@ graph \%>\% get_edge_df()
 # attributes of edge `1` -> `2`
 # (edge ID `1`)
 graph_2 <-
-  graph \%>\%
-  add_node() \%>\%
+  graph |>
+  add_node() |>
   add_edge_clone(
     edge = 1,
     from = 3,
@@ -59,22 +59,25 @@ graph_2 <-
 
 # Display the graph's internal
 # edge data frame
-graph_2 \%>\% get_edge_df()
+graph_2 |> get_edge_df()
 
 # The same change can be performed
 # with some helper functions in the
 # `add_edge_clone()` function call
 graph_3 <-
-  graph \%>\%
-    add_node() \%>\%
+  graph |>
+    add_node()
+
+graph_3 <-
+  graph_3 |>
     add_edge_clone(
-      edge = get_last_edges_created(.),
-      from = get_last_nodes_created(.),
+      edge = get_last_edges_created(graph_3),
+      from = get_last_nodes_created(graph_3),
       to = 1)
 
 # Display the graph's internal
 # edge data frame
-graph_3 \%>\% get_edge_df()
+graph_3 |> get_edge_df()
 
 }
 \seealso{

--- a/man/add_edge_df.Rd
+++ b/man/add_edge_df.Rd
@@ -22,7 +22,7 @@ to that graph.
 # Create a graph with 4 nodes
 # and no edges
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(n = 4)
 
 # Create an edge data frame (edf)
@@ -36,14 +36,14 @@ edf <-
 # a graph with both nodes
 # and edges
 graph <-
-  graph \%>\%
+  graph |>
   add_edge_df(
     edge_df = edf)
 
 # Get the graph's edges to
 # verify that the edf had
 # been added
-graph \%>\%
+graph |>
   get_edges(
     return_type = "vector")
 

--- a/man/add_edges_from_table.Rd
+++ b/man/add_edges_from_table.Rd
@@ -54,7 +54,7 @@ file or a data frame.
 # `currencies` dataset available
 # in the package
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_nodes_from_table(
     table = currencies)
 
@@ -70,7 +70,7 @@ graph <-
 # `iso_4217_code` column of the
 # graph's internal node data frame
 graph_1 <-
-  graph \%>\%
+  graph |>
     add_edges_from_table(
       table = usd_exchange_rates,
       from_col = from_currency,
@@ -79,8 +79,8 @@ graph_1 <-
 
 # View part of the graph's
 # internal edge data frame
-graph_1 \%>\%
-  get_edge_df() \%>\%
+graph_1 |>
+  get_edge_df() |>
   head()
 
 # If you would like to assign
@@ -90,7 +90,7 @@ graph_1 \%>\%
 # set a static `rel` attribute for
 # all edges created, use `set_rel`
 graph_2 <-
-  graph \%>\%
+  graph |>
     add_edges_from_table(
       table = usd_exchange_rates,
       from_col = from_currency,
@@ -100,8 +100,8 @@ graph_2 <-
 
 # View part of the graph's internal
 # edge data frame (edf)
-graph_2 \%>\%
-  get_edge_df() \%>\%
+graph_2 |>
+  get_edge_df() |>
   head()
 
 }

--- a/man/add_edges_w_string.Rd
+++ b/man/add_edges_w_string.Rd
@@ -32,23 +32,23 @@ using a text string.
 \examples{
 # Create a graph with 4 nodes
 graph <-
-  create_graph() \%>\%
-  add_node(label = "one") \%>\%
-  add_node(label = "two") \%>\%
-  add_node(label = "three") \%>\%
+  create_graph() |>
+  add_node(label = "one") |>
+  add_node(label = "two") |>
+  add_node(label = "three") |>
   add_node(label = "four")
 
 # Add edges between nodes using
 # a character string with node
 # ID values
 graph_node_id <-
-  graph \%>\%
+  graph |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->3")
 
 # Show the graph's internal
 # edge data frame
-graph_node_id \%>\% get_edge_df()
+graph_node_id |> get_edge_df()
 
 # Add edges between nodes using
 # a character string with node
@@ -57,7 +57,7 @@ graph_node_id \%>\% get_edge_df()
 # all nodes must have unique
 # `label` values to use this
 graph_node_label <-
-  graph \%>\%
+  graph |>
   add_edges_w_string(
     edges =
       "one->two one->three
@@ -67,7 +67,7 @@ graph_node_label <-
 # Show the graph's internal
 # edge data frame (it's the
 # same as before)
-graph_node_label \%>\% get_edge_df()
+graph_node_label |> get_edge_df()
 
 }
 \seealso{

--- a/man/add_forward_edges_ws.Rd
+++ b/man/add_forward_edges_ws.Rd
@@ -38,30 +38,30 @@ Selections of edges can also be performed using the following traversal
 # Create an empty graph, add 2 nodes
 # to it, and create the edge `1->2`
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "type_a",
-    label = c("a_1", "a_2")) \%>\%
+    label = c("a_1", "a_2")) |>
   add_edge(
     from = 1, to = 2, rel = "a")
 
 # Get the graph's edges
-graph \%>\% get_edge_ids()
+graph |> get_edge_ids()
 
 # Select the edge and create 2
 # additional edges with the same
 # definition (`1->2`) but with
 # different `rel` values (`b` and `c`)
 graph <-
-  graph \%>\%
-  select_edges() \%>\%
-  add_forward_edges_ws(rel = "b") \%>\%
-  add_forward_edges_ws(rel = "c") \%>\%
+  graph |>
+  select_edges() |>
+  add_forward_edges_ws(rel = "b") |>
+  add_forward_edges_ws(rel = "c") |>
   clear_selection()
 
 # Get the graph's edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/add_full_graph.Rd
+++ b/man/add_full_graph.Rd
@@ -78,27 +78,27 @@ single edge will link each pair of nodes.
 # will also have edges from
 # and to themselves
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_full_graph(
     n = 3, keep_loops = TRUE
   )
 
 # Get node information
 # from this graph
-graph \%>\% get_node_info()
+graph |> get_node_info()
 
 # Using `keep_loops = FALSE`
 # (the default) will remove
 # the loops
-create_graph() \%>\%
-  add_full_graph(n = 3) \%>\%
+create_graph() |>
+  add_full_graph(n = 3) |>
   get_node_info()
 
 # Values can be set for
 # the node `label`, node
 # `type`, and edge `rel`
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_full_graph(
     n = 3,
     type = "connected",
@@ -108,11 +108,11 @@ graph <-
 
 # Show the graph's node
 # data frame (ndf)
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's edge
 # data frame (edf)
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Create a fully-connected and
 # directed graph with 3 nodes,
@@ -124,9 +124,9 @@ suppressWarnings(RNGversion("3.5.0"))
 set.seed(23)
 
 edge_wt_matrix <-
-  rnorm(100, 5, 2) \%>\%
-  sample(9, FALSE) \%>\%
-  round(2) \%>\%
+  rnorm(100, 5, 2) |>
+  sample(9, FALSE) |>
+  round(2) |>
   matrix(
     ncol = 3,
     nrow = 3,
@@ -136,7 +136,7 @@ edge_wt_matrix <-
 # Create the fully-connected
 # graph (without loops however)
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_full_graph(
     n = 3,
     type = "weighted",
@@ -148,18 +148,18 @@ graph <-
 
 # Show the graph's node
 # data frame (ndf)
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's edge
 # data frame (edf)
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # An undirected graph can
 # also use a matrix with
 # edge weights, but only
 # the lower triangle of
 # that matrix will be used
-create_graph(directed = FALSE) \%>\%
+create_graph(directed = FALSE) |>
   add_full_graph(
     n = 3,
     type = "weighted",
@@ -167,7 +167,7 @@ create_graph(directed = FALSE) \%>\%
     rel = "related_to",
     edge_wt_matrix = edge_wt_matrix,
     keep_loops = FALSE
-  ) \%>\%
+  ) |>
   get_edge_df()
 
 }

--- a/man/add_global_graph_attrs.Rd
+++ b/man/add_global_graph_attrs.Rd
@@ -31,7 +31,7 @@ or \code{edge_attrs} for a graph object of class \code{dgr_graph}).
 # add a global graph attribute
 graph <-
   create_graph(
-    attr_theme = NULL) \%>\%
+    attr_theme = NULL) |>
   add_global_graph_attrs(
     attr = "overlap",
     value = "true",
@@ -39,13 +39,13 @@ graph <-
 
 # Verify that the attribute
 # addition has been made
-graph \%>\%
+graph |>
   get_global_graph_attr_info()
 
 # Add another attribute with
 # `add_global_graph_attrs()`
 graph <-
-  graph \%>\%
+  graph |>
   add_global_graph_attrs(
     attr = "penwidth",
     value = 12,
@@ -53,18 +53,18 @@ graph <-
 
 # Verify that the attribute
 # addition has been made
-graph \%>\%
+graph |>
   get_global_graph_attr_info()
 
 # When adding an attribute where
 # `attr` and `attr_type` already
 # exists, the value provided will
 # serve as an update
-graph \%>\%
+graph |>
   add_global_graph_attrs(
     attr = "penwidth",
     value = 15,
-    attr_type = "node") \%>\%
+    attr_type = "node") |>
   get_global_graph_attr_info()
 
 }

--- a/man/add_gnm_graph.Rd
+++ b/man/add_gnm_graph.Rd
@@ -75,15 +75,15 @@ fixed number of edges. Thus for \code{n} nodes there will be \code{m} edges and,
 # 120 edges
 gnm_graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 100,
     m = 120)
 
 # Get a count of nodes
-gnm_graph \%>\% count_nodes()
+gnm_graph |> count_nodes()
 
 # Get a count of edges
-gnm_graph \%>\% count_edges()
+gnm_graph |> count_edges()
 
 }

--- a/man/add_gnp_graph.Rd
+++ b/man/add_gnp_graph.Rd
@@ -72,15 +72,15 @@ G(n, p) model, which uses a constant probability when creating edges.
 # a probability value of 0.05
 gnp_graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnp_graph(
     n = 100,
     p = 0.05)
 
 # Get a count of nodes
-gnp_graph \%>\% count_nodes()
+gnp_graph |> count_nodes()
 
 # Get a count of edges
-gnp_graph \%>\% count_edges()
+gnp_graph |> count_edges()
 
 }

--- a/man/add_graph_action.Rd
+++ b/man/add_graph_action.Rd
@@ -27,7 +27,7 @@ transformation step.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 22,
@@ -43,7 +43,7 @@ graph <-
 # called on the graph that modifies it
 # (e.g., `add_n_nodes()`)
 graph <-
-  graph \%>\%
+  graph |>
   add_graph_action(
     fcn = "set_node_attr_w_fcn",
     node_attr_fcn = "get_betweenness",
@@ -53,6 +53,6 @@ graph <-
 # To ensure that the action is
 # available in the graph, use the
 # `get_graph_actions()` function
-graph \%>\% get_graph_actions()
+graph |> get_graph_actions()
 
 }

--- a/man/add_graph_to_graph_series.Rd
+++ b/man/add_graph_to_graph_series.Rd
@@ -22,31 +22,31 @@ graphs across a sequential or temporal one-dimensional array.
 \examples{
 # Create three graphs
 graph_1 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 4)
 
 graph_2 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 graph_3 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_star(n = 6)
 
 # Create an empty graph series
 # and add the graphs
 series <-
-  create_graph_series() \%>\%
+  create_graph_series() |>
   add_graph_to_graph_series(
-    graph = graph_1) \%>\%
+    graph = graph_1) |>
   add_graph_to_graph_series(
-    graph = graph_2) \%>\%
+    graph = graph_2) |>
   add_graph_to_graph_series(
     graph = graph_3)
 
 # Count the number of graphs
 # in the graph series
-series \%>\%
+series |>
   count_graphs_in_graph_series()
 
 }

--- a/man/add_grid_2d.Rd
+++ b/man/add_grid_2d.Rd
@@ -63,14 +63,14 @@ graph.
 # Create a new graph and add
 # a 3 x 3 grid
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_grid_2d(
     x = 3, y = 3,
     type = "grid")
 
 # Get node information
 # from this graph
-graph \%>\%
+graph |>
   get_node_info()
 
 # Attributes can be specified
@@ -82,7 +82,7 @@ graph \%>\%
 # attribute will apply to the
 # edges
 graph_w_attrs <-
-  create_graph() \%>\%
+  create_graph() |>
   add_grid_2d(
     x = 3, y = 2,
     label = c("one", "two",
@@ -98,9 +98,9 @@ graph_w_attrs <-
         5.2, 6.1, 2.6)))
 
 # Get the graph's node data frame
-graph_w_attrs \%>\% get_node_df()
+graph_w_attrs |> get_node_df()
 
 # Get the graph's edge data frame
-graph_w_attrs \%>\% get_edge_df()
+graph_w_attrs |> get_edge_df()
 
 }

--- a/man/add_grid_3d.Rd
+++ b/man/add_grid_3d.Rd
@@ -66,14 +66,14 @@ graph.
 # Create a new graph and add
 # a 2 x 2 x 2 grid
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_grid_3d(
     x = 2, y = 2, z = 2,
     type = "grid")
 
 # Get node information
 # from this graph
-graph \%>\%
+graph |>
   get_node_info()
 
 # Attributes can be specified
@@ -85,7 +85,7 @@ graph \%>\%
 # attribute will apply to the
 # edges
 graph_w_attrs <-
-  create_graph() \%>\%
+  create_graph() |>
   add_grid_3d(
     x = 2, y = 2, z = 2,
     label = c(
@@ -104,9 +104,9 @@ graph_w_attrs <-
         6.3, 9.3)))
 
 # Get the graph's node data frame
-graph_w_attrs \%>\% get_node_df()
+graph_w_attrs |> get_node_df()
 
 # Get the graph's edge data frame
-graph_w_attrs \%>\% get_edge_df()
+graph_w_attrs |> get_edge_df()
 
 }

--- a/man/add_growing_graph.Rd
+++ b/man/add_growing_graph.Rd
@@ -70,7 +70,7 @@ each time step (where a node is added).
 # nodes, adding an edge after
 # each node addition
 growing_graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_growing_graph(
     n = 100,
     m = 1,
@@ -78,9 +78,9 @@ growing_graph <-
     set_seed = 23)
 
 # Get a count of nodes
-growing_graph \%>\% count_nodes()
+growing_graph |> count_nodes()
 
 # Get a count of edges
-growing_graph \%>\% count_edges()
+growing_graph |> count_edges()
 
 }

--- a/man/add_islands_graph.Rd
+++ b/man/add_islands_graph.Rd
@@ -69,7 +69,7 @@ number of edges.
 \examples{
 # Create a graph of islands
 islands_graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_islands_graph(
     n_islands = 4,
     island_size = 10,
@@ -78,9 +78,9 @@ islands_graph <-
     set_seed = 23)
 
 # Get a count of nodes
-islands_graph \%>\% count_nodes()
+islands_graph |> count_nodes()
 
 # Get a count of edges
-islands_graph \%>\% count_edges()
+islands_graph |> count_edges()
 
 }

--- a/man/add_n_node_clones.Rd
+++ b/man/add_n_node_clones.Rd
@@ -31,7 +31,7 @@ cloned nodes.
 # nodes; supply `label`, `type`,
 # and `value` node attributes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 3,
     label = c("d", "g", "r"),
@@ -39,14 +39,14 @@ graph <-
 
 # Display the graph's internal
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create 3 clones of node `1`
 # but assign new node label
 # values (leaving `label` as
 # NULL yields NA values)
 graph <-
-  graph \%>\%
+  graph |>
   add_n_node_clones(
     n = 3,
     node = 1,
@@ -55,7 +55,7 @@ graph <-
 # Display the graph's internal
 # node data frame: nodes `4`,
 # `5`, and `6` are clones of `1`
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/add_n_nodes.Rd
+++ b/man/add_n_nodes.Rd
@@ -46,11 +46,11 @@ node \code{type} values for the new nodes.
 # will be assigned ID values
 # from `1` to `5`
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(n = 5)
 
 # Get the graph's node IDs
-graph \%>\% get_node_ids()
+graph |> get_node_ids()
 
 }
 \seealso{

--- a/man/add_n_nodes_ws.Rd
+++ b/man/add_n_nodes_ws.Rd
@@ -84,36 +84,36 @@ Selections of nodes can also be performed using the following traversal
 # with edges from the original node to all of the
 # new nodes
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 1) \%>\%
-  select_last_nodes_created() \%>\%
+  create_graph() |>
+  add_n_nodes(n = 1) |>
+  select_last_nodes_created() |>
   add_n_nodes_ws(
     n = 5,
     direction = "from")
 
 # Get the graph's nodes
-graph \%>\% get_node_ids()
+graph |> get_node_ids()
 
 # Get the graph's edges
-graph \%>\% get_edges()
+graph |> get_edges()
 
 # Create an empty graph, add a node to it, select
 # that node, and then add 5 more nodes to the graph
 # with edges toward the original node from all of
 # the new nodes
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 1) \%>\%
-  select_last_nodes_created() \%>\%
+  create_graph() |>
+  add_n_nodes(n = 1) |>
+  select_last_nodes_created() |>
   add_n_nodes_ws(
     n = 5,
     direction = "to")
 
 # Get the graph's nodes
-graph \%>\% get_node_ids()
+graph |> get_node_ids()
 
 # Get the graph's edges
-graph \%>\% get_edges()
+graph |> get_edges()
 
 }
 \seealso{

--- a/man/add_node.Rd
+++ b/man/add_node.Rd
@@ -62,28 +62,28 @@ to set edge attributes for any new graph edges.
 # Create an empty graph and add 2 nodes by using
 # the `add_node()` function twice
 graph <-
-  create_graph() \%>\%
-  add_node() \%>\%
+  create_graph() |>
+  add_node() |>
   add_node()
 
 # Get a count of all nodes
 # in the graph
-graph \%>\% count_nodes()
+graph |> count_nodes()
 
 # The nodes added were given
 # ID values `1` and `2`; obtain
 # the graph's node IDs
-graph \%>\% get_node_ids()
+graph |> get_node_ids()
 
 # Add a node with a `type`
 # value defined
 graph <-
-  graph \%>\%
+  graph |>
   add_node(type = "person")
 
 # View the graph's internal
 # node data frame (ndf)
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/add_node_clones_ws.Rd
+++ b/man/add_node_clones_ws.Rd
@@ -48,16 +48,16 @@ Selections of nodes can also be performed using the following traversal
 # and `value` node attributes,
 # and select the created nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 3,
     label = c("d", "g", "r"),
-    type = c("a", "b", "c")) \%>\%
+    type = c("a", "b", "c")) |>
   select_last_nodes_created()
 
 # Display the graph's internal
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create clones of all nodes
 # in the selection but assign
@@ -65,7 +65,7 @@ graph \%>\% get_node_df()
 # (leaving `label` as NULL
 # yields NA values)
 graph <-
-  graph \%>\%
+  graph |>
   add_node_clones_ws(
     label = c("a", "b", "v"))
 
@@ -73,7 +73,7 @@ graph <-
 # node data frame: nodes `4`,
 # `5`, and `6` are clones of
 # `1`, `2`, and `3`
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Select the last nodes
 # created (`4`, `5`, and `6`)
@@ -82,8 +82,8 @@ graph \%>\% get_node_df()
 # creating new edges between
 # the new and existing nodes
 graph <-
-  graph \%>\%
-  select_last_nodes_created() \%>\%
+  graph |>
+  select_last_nodes_created() |>
   add_node_clones_ws(
     add_edges = TRUE,
     direction = "to",
@@ -93,7 +93,7 @@ graph <-
 # edge data frame; there are
 # edges between the selected
 # nodes and their clones
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/add_node_df.Rd
+++ b/man/add_node_df.Rd
@@ -30,12 +30,12 @@ ndf <-
 # the graph object to create
 # a graph with nodes
 graph <-
-  graph \%>\%
+  graph |>
   add_node_df(
     node_df = ndf)
 
 # Inspect the graph's ndf
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create another ndf
 ndf_2 <-
@@ -46,14 +46,14 @@ ndf_2 <-
 # to add more nodes with
 # attributes to the graph
 graph <-
-  graph \%>\%
+  graph |>
   add_node_df(
     node_df = ndf_2)
 
 # View the graph's internal
 # node data frame using the
 # `get_node_df()` function
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/add_nodes_from_df_cols.Rd
+++ b/man/add_nodes_from_df_cols.Rd
@@ -57,7 +57,7 @@ df <-
 # and `col_2` from the data frame
 # to the graph object
 graph <-
-  graph \%>\%
+  graph |>
   add_nodes_from_df_cols(
     df = df,
     columns = c("col_1", "col_2"))
@@ -66,13 +66,13 @@ graph <-
 # frame; duplicate labels are
 # prevented with `keep_duplicates =
 # FALSE`)
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Add new nodes from columns 3 and 4;
 # We can specify the columns by their
 # numbers as well
 graph <-
-  graph \%>\%
+  graph |>
   add_nodes_from_df_cols(
     df = df,
     columns = 3:4)
@@ -81,7 +81,7 @@ graph <-
 # frame; note that nodes didn't
 # get made with columns that
 # are not character class columns
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/add_nodes_from_table.Rd
+++ b/man/add_nodes_from_table.Rd
@@ -50,16 +50,15 @@ file or a data frame.
 # node ID values will be created as
 # monotonically-increasing values
 graph_1 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_nodes_from_table(
     table = currencies)
 
 # View part of the graph's internal
 # node data frame (ndf)
-graph_1 \%>\%
-  get_node_df() \%>\%
-  .[, 1:5] \%>\%
-  head()
+ndf_1 <- graph_1 |> get_node_df()
+
+ndf_1[, 1:5] |> head()
 
 # If you would like to assign
 # any of the table's columns as
@@ -69,17 +68,16 @@ graph_1 \%>\%
 # a static `type` attribute for all
 # of the table records, use `set_type`
 graph_2 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_nodes_from_table(
     table = currencies,
     label_col = iso_4217_code,
     set_type = currency)
 
 # View part of the graph's internal ndf
-graph_2 \%>\%
-  get_node_df() \%>\%
-  .[, 1:5] \%>\%
-  head()
+ndf_2 <- graph_2 |> get_node_df()
+
+ndf_2[, 1:5] |> head()
 
 # Suppose we would like to not
 # include certain columns from the
@@ -88,7 +86,7 @@ graph_2 \%>\%
 # argument to choose which columns
 # to not include as attributes
 graph_3 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_nodes_from_table(
     table = currencies,
     label_col = iso_4217_code,
@@ -100,8 +98,8 @@ graph_3 <-
 # `exponent` and `currency_name`
 # columns are not attributes in the
 # graph's internal node data frame
-graph_3 \%>\%
-  get_node_df() \%>\%
+graph_3 |>
+  get_node_df() |>
   colnames()
 
 }

--- a/man/add_pa_graph.Rd
+++ b/man/add_pa_graph.Rd
@@ -95,15 +95,15 @@ algorithm.
 # 2 edges at every time step
 pa_graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_pa_graph(
     n = 100,
     m = 1)
 
 # Get a count of nodes
-pa_graph \%>\% count_nodes()
+pa_graph |> count_nodes()
 
 # Get a count of edges
-pa_graph \%>\% count_edges()
+pa_graph |> count_edges()
 
 }

--- a/man/add_path.Rd
+++ b/man/add_path.Rd
@@ -59,17 +59,17 @@ With a graph object of class \code{dgr_graph}, add a node path to the graph.
 # Create a new graph and add
 # 2 paths of varying lengths
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 4,
-    type = "path") \%>\%
+    type = "path") |>
   add_path(
     n = 5,
     type = "path")
 
 # Get node information
 # from this graph
-graph \%>\% get_node_info()
+graph |> get_node_info()
 
 # Node and edge aesthetic and data
 # attributes can be specified in
@@ -81,7 +81,7 @@ suppressWarnings(RNGversion("3.5.0"))
 set.seed(23)
 
 graph_w_attrs <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 3,
     label = c(
@@ -105,9 +105,9 @@ graph_w_attrs <-
           sd = 1.0)))
 
 # Get the graph's node data frame
-graph_w_attrs \%>\% get_node_df()
+graph_w_attrs |> get_node_df()
 
 # Get the graph's edge data frame
-graph_w_attrs \%>\% get_edge_df()
+graph_w_attrs |> get_edge_df()
 
 }

--- a/man/add_prism.Rd
+++ b/man/add_prism.Rd
@@ -62,18 +62,18 @@ With a graph object of class \code{dgr_graph}, add a node prism to the graph.
 # Create a new graph and
 # add 2 prisms
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_prism(
     n = 3,
     type = "prism",
-    label = "a") \%>\%
+    label = "a") |>
   add_prism(
     n = 3,
     type = "prism",
     label = "b")
 
 # Get node information from this graph
-graph \%>\% get_node_info()
+graph |> get_node_info()
 
 # Node and edge aesthetic and data
 # attributes can be specified in
@@ -85,7 +85,7 @@ suppressWarnings(RNGversion("3.5.0"))
 set.seed(23)
 
 graph_w_attrs <-
-  create_graph() \%>\%
+  create_graph() |>
   add_prism(
     n = 3,
     label = c(
@@ -114,9 +114,9 @@ graph_w_attrs <-
           sd = 1.0)))
 
 # Get the graph's node data frame
-graph_w_attrs \%>\% get_node_df()
+graph_w_attrs |> get_node_df()
 
 # Get the graph's edge data frame
-graph_w_attrs \%>\% get_edge_df()
+graph_w_attrs |> get_edge_df()
 
 }

--- a/man/add_reverse_edges_ws.Rd
+++ b/man/add_reverse_edges_ws.Rd
@@ -48,32 +48,32 @@ Selections of edges can also be performed using the following traversal
 # Create an empty graph, add 2 nodes to it,
 # and create the edge `1->2`
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "type_a",
-    label = c("a_1", "a_2")) \%>\%
+    label = c("a_1", "a_2")) |>
   add_edge(
     from = 1,
     to = 2,
     rel = "a")
 
 # Get the graph's edges
-graph \%>\% get_edge_ids()
+graph |> get_edge_ids()
 
 # Select the edge and create 2 additional edges
 # with the opposite definition of `1->2`, which
 # is `2->1`; also, apply, different `rel` values
 # (`b` and `c`)
 graph <-
-  graph \%>\%
-  select_edges() \%>\%
-  add_reverse_edges_ws(rel = "b") \%>\%
-  add_reverse_edges_ws(rel = "c") \%>\%
+  graph |>
+  select_edges() |>
+  add_reverse_edges_ws(rel = "b") |>
+  add_reverse_edges_ws(rel = "c") |>
   clear_selection()
 
 # Get the graph's edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/add_smallworld_graph.Rd
+++ b/man/add_smallworld_graph.Rd
@@ -84,7 +84,7 @@ probability to randomly modify edge definitions.
 # a probability value of 0.05
 smallworld_graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_smallworld_graph(
     dimension = 1,
     size = 50,
@@ -93,9 +93,9 @@ smallworld_graph <-
     set_seed = 23)
 
 # Get a count of nodes
-smallworld_graph \%>\% count_nodes()
+smallworld_graph |> count_nodes()
 
 # Get a count of edges
-smallworld_graph \%>\% count_edges()
+smallworld_graph |> count_edges()
 
 }

--- a/man/add_star.Rd
+++ b/man/add_star.Rd
@@ -60,16 +60,16 @@ With a graph object of class \code{dgr_graph}, add a node star to the graph.
 # Create a new graph and add 2
 # stars of varying numbers of nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_star(
     n = 4,
-    type = "four_star") \%>\%
+    type = "four_star") |>
   add_star(
     n = 5,
     type = "five_star")
 
 # Get node information from this graph
-graph \%>\% get_node_info()
+graph |> get_node_info()
 
 # Node and edge aesthetic and data
 # attributes can be specified in
@@ -81,7 +81,7 @@ suppressWarnings(RNGversion("3.5.0"))
 set.seed(23)
 
 graph_w_attrs <-
-  create_graph() \%>\%
+  create_graph() |>
   add_star(
     n = 4,
     label = c(
@@ -106,9 +106,9 @@ graph_w_attrs <-
           sd = 1.0)))
 
 # Get the graph's node data frame
-graph_w_attrs \%>\% get_node_df()
+graph_w_attrs |> get_node_df()
 
 # Get the graph's edge data frame
-graph_w_attrs \%>\% get_edge_df()
+graph_w_attrs |> get_edge_df()
 
 }

--- a/man/clear_selection.Rd
+++ b/man/clear_selection.Rd
@@ -19,28 +19,28 @@ Clear the selection of nodes or edges within a graph object.
 # Create a graph with
 # a single path
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 5)
 
 # Select nodes with IDs `1`
 # and `3`
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes(
     nodes = c(1, 3))
 
 # Verify that a node selection
 # has been made
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Clear the selection with
 # `clear_selection()`
 graph <-
-  graph \%>\%
+  graph |>
   clear_selection()
 
 # Verify that the node
 # selection has been cleared
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/colorize_edge_attrs.Rd
+++ b/man/colorize_edge_attrs.Rd
@@ -54,8 +54,8 @@ attribute to generate a new edge attribute with color values.
 # Create a graph with 5
 # nodes and 4 edges
 graph <-
-  create_graph() \%>\%
-  add_path(n = 5) \%>\%
+  create_graph() |>
+  add_path(n = 5) |>
   set_edge_attrs(
     edge_attr = weight,
     values = c(3.7, 6.3, 9.2, 1.6))
@@ -68,7 +68,7 @@ graph <-
 # part of any bucket, a gray color
 # is assigned by default)
 graph <-
-  graph \%>\%
+  graph |>
   colorize_edge_attrs(
     edge_attr_from = weight,
     edge_attr_to = color,
@@ -79,6 +79,6 @@ graph <-
 # edge attribute with distinct
 # colors (from the RColorBrewer
 # Red-Yellow-Green palette)
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }

--- a/man/colorize_node_attrs.Rd
+++ b/man/colorize_node_attrs.Rd
@@ -54,8 +54,8 @@ attribute to generate a new node attribute with color values.
 # Create a graph with 8
 # nodes and 7 edges
 graph <-
-  create_graph() \%>\%
-  add_path(n = 8) \%>\%
+  create_graph() |>
+  add_path(n = 8) |>
   set_node_attrs(
     node_attr = weight,
     values = c(
@@ -68,15 +68,15 @@ graph <-
 # to the graph's internal node data frame (ndf)
 # with the `join_node_attrs()` function
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_cmty_walktrap(.))
+    df = get_cmty_walktrap(graph))
 
 # Inspect the number of distinct communities
-graph \%>\%
+graph |>
   get_node_attrs(
-    node_attr = walktrap_group) \%>\%
-  unique() \%>\%
+    node_attr = walktrap_group) |>
+  unique() |>
   sort()
 
 # Visually distinguish the nodes in the different
@@ -86,12 +86,12 @@ graph \%>\%
 # value of 90 and apply opaque colors to the node
 # border (with the `color` node attribute)
 graph <-
-  graph \%>\%
+  graph |>
   colorize_node_attrs(
     node_attr_from = walktrap_group,
     node_attr_to = fillcolor,
     palette = "Greens",
-    alpha = 90) \%>\%
+    alpha = 90) |>
   colorize_node_attrs(
     node_attr_from = walktrap_group,
     node_attr_to = color,
@@ -99,12 +99,12 @@ graph <-
     alpha = 80)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create a graph with 8 nodes and 7 edges
 graph <-
-  create_graph() \%>\%
-  add_path(n = 8) \%>\%
+  create_graph() |>
+  add_path(n = 8) |>
   set_node_attrs(
     node_attr = weight,
     values = c(
@@ -116,7 +116,7 @@ graph <-
 # bucketed ranges (for values not part of any
 # bucket, a gray color is assigned by default)
 graph <-
-  graph \%>\%
+  graph |>
   colorize_node_attrs(
     node_attr_from = weight,
     node_attr_to = fillcolor,
@@ -125,7 +125,7 @@ graph <-
 # Now there will be a `fillcolor` node attribute
 # with distinct colors (the `#D9D9D9` color is
 # the default `gray85` color)
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/combine_graphs.Rd
+++ b/man/combine_graphs.Rd
@@ -24,14 +24,14 @@ Combine two graphs in order to make a new graph.
 # Create a graph with a cycle
 # containing 6 nodes
 graph_cycle <-
- create_graph() \%>\%
+ create_graph() |>
    add_cycle(n = 6)
 
 # Create a random graph with
 # 8 nodes and 15 edges using the
 # `add_gnm_graph()` function
 graph_random <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 8,
     m = 15,
@@ -46,13 +46,13 @@ combined_graph <-
 
 # Get the number of nodes in
 # the combined graph
-combined_graph \%>\% count_nodes()
+combined_graph |> count_nodes()
 
 # The `combine_graphs()`
 # function will renumber
 # node ID values in graph `y`
 # during the union; this ensures
 # that node ID values are unique
-combined_graph \%>\% get_node_ids()
+combined_graph |> get_node_ids()
 
 }

--- a/man/copy_edge_attrs.Rd
+++ b/man/copy_edge_attrs.Rd
@@ -27,11 +27,11 @@ with a different attribute name.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 8,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_edge_attrs(
     edge_attr = color,
     values = "green")
@@ -39,13 +39,13 @@ graph <-
 # Get the graph's internal
 # edf to show which edge
 # attributes are available
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Make a copy the `color`
 # edge attribute as the
 # `color_2` edge attribute
 graph <-
-  graph \%>\%
+  graph |>
   copy_edge_attrs(
     edge_attr_from = color,
     edge_attr_to = color_2)
@@ -53,7 +53,7 @@ graph <-
 # Get the graph's internal
 # edf to show that the edge
 # attribute had been copied
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/copy_node_attrs.Rd
+++ b/man/copy_node_attrs.Rd
@@ -27,31 +27,34 @@ with a different attribute name.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 10,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = shape,
-    values = "circle") \%>\%
+    values = "circle")
+
+graph <-
+  graph |>
   set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 5,
       mean = 5,
-      sd = 1) \%>\% round(1))
+      sd = 1) |> round(1))
 
 # Get the graph's internal
 # ndf to show which node
 # attributes are available
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Make a copy the `value`
 # node attribute as the
 # `width` node attribute
 graph <-
-  graph \%>\%
+  graph |>
   copy_node_attrs(
     node_attr_from = value,
     node_attr_to = size)
@@ -59,7 +62,7 @@ graph <-
 # Get the graph's internal
 # ndf to show that the node
 # attribute had been copied
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/count_asymmetric_node_pairs.Rd
+++ b/man/count_asymmetric_node_pairs.Rd
@@ -20,19 +20,19 @@ directed graphs.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Get a count of asymmetrically-
 # connected node pairs
-graph \%>\%
+graph |>
   count_asymmetric_node_pairs()
 
 # Create a full graph and then
 # count the asymmetrically-
 # connected node pairs
-create_graph() \%>\%
-  add_full_graph(n = 10) \%>\%
+create_graph() |>
+  add_full_graph(n = 10) |>
   count_asymmetric_node_pairs()
 
 }

--- a/man/count_automorphisms.Rd
+++ b/man/count_automorphisms.Rd
@@ -21,17 +21,17 @@ preserving edge-node connectivity.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Get a count of automorphisms
-graph \%>\%
+graph |>
   count_automorphisms()
 
 # Create a full graph and then
 # count the automorphisms
-create_graph() \%>\%
-  add_full_graph(n = 10) \%>\%
+create_graph() |>
+  add_full_graph(n = 10) |>
   count_automorphisms()
 
 }

--- a/man/count_edges.Rd
+++ b/man/count_edges.Rd
@@ -20,13 +20,13 @@ From a graph object of class \code{dgr_graph}, get a count of edges in the graph
 # path of nodes and 3
 # unconnected nodes
 graph <-
-  create_graph() \%>\%
-  add_path(n = 3) \%>\%
+  create_graph() |>
+  add_path(n = 3) |>
   add_n_nodes(n = 3)
 
 # Get a count of all edges
 # in the graph
-graph \%>\%
+graph |>
   count_edges()
 
 }

--- a/man/count_graphs_in_graph_series.Rd
+++ b/man/count_graphs_in_graph_series.Rd
@@ -19,31 +19,31 @@ Counts the total number of graphs in a graph series object.
 \examples{
 # Create three graphs
 graph_1 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 4)
 
 graph_2 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 graph_3 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_star(n = 6)
 
 # Create an empty graph series
 # and add the graphs
 series <-
-  create_graph_series() \%>\%
+  create_graph_series() |>
   add_graph_to_graph_series(
-    graph = graph_1) \%>\%
+    graph = graph_1) |>
   add_graph_to_graph_series(
-    graph = graph_2) \%>\%
+    graph = graph_2) |>
   add_graph_to_graph_series(
     graph = graph_3)
 
 # Count the number of graphs
 # in the graph series
-series \%>\%
+series |>
   count_graphs_in_graph_series()
 
 }

--- a/man/count_loop_edges.Rd
+++ b/man/count_loop_edges.Rd
@@ -22,13 +22,13 @@ the graph.
 # edges, including loop edges
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_full_graph(
     n = 3,
     keep_loops = TRUE)
 
 # Get a count of all loop edges
 # in the graph
-graph \%>\% count_loop_edges()
+graph |> count_loop_edges()
 
 }

--- a/man/count_mutual_node_pairs.Rd
+++ b/man/count_mutual_node_pairs.Rd
@@ -20,18 +20,18 @@ graphs.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Get a count of mutually-connected
 # node pairs
-graph \%>\% count_mutual_node_pairs()
+graph |> count_mutual_node_pairs()
 
 # Create a full graph and then
 # count the mutually-connected
 # node pairs
-create_graph() \%>\%
-  add_full_graph(n = 10) \%>\%
+create_graph() |>
+  add_full_graph(n = 10) |>
   count_mutual_node_pairs()
 
 }

--- a/man/count_nodes.Rd
+++ b/man/count_nodes.Rd
@@ -20,13 +20,13 @@ From a graph object of class \code{dgr_graph}, get a count of nodes in the graph
 # path of nodes and 3
 # unconnected nodes
 graph <-
-  create_graph() \%>\%
-  add_path(n = 3) \%>\%
+  create_graph() |>
+  add_path(n = 3) |>
   add_n_nodes(n = 3)
 
 # Get a count of all nodes
 # in the graph
-graph \%>\%
+graph |>
   count_nodes()
 
 }

--- a/man/count_s_connected_cmpts.Rd
+++ b/man/count_s_connected_cmpts.Rd
@@ -20,7 +20,7 @@ Get the number of strongly-connected components in the graph.
 # Create a graph and add
 # several graph islands
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_islands_graph(
     n_islands = 4,
     island_size = 10,
@@ -30,6 +30,6 @@ graph <-
 
 # Get a count of strongly-connected
 # components in the graph
-graph \%>\% count_s_connected_cmpts()
+graph |> count_s_connected_cmpts()
 
 }

--- a/man/count_unconnected_node_pairs.Rd
+++ b/man/count_unconnected_node_pairs.Rd
@@ -19,18 +19,18 @@ Get the number of unconnected node pairs. This works for directed graphs.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Get a count of unconnected node
 # pairs in the graph
-graph \%>\%
+graph |>
   count_unconnected_node_pairs()
 
 # Create a full graph and then
 # count all unconnected node pairs
-create_graph() \%>\%
-  add_full_graph(n = 10) \%>\%
+create_graph() |>
+  add_full_graph(n = 10) |>
   count_unconnected_node_pairs()
 
 }

--- a/man/count_unconnected_nodes.Rd
+++ b/man/count_unconnected_nodes.Rd
@@ -21,18 +21,18 @@ that are not connected to any other node.
 # path of nodes and 3
 # unconnected nodes
 graph <-
-  create_graph() \%>\%
-  add_path(n = 3) \%>\%
+  create_graph() |>
+  add_path(n = 3) |>
   add_n_nodes(n = 3)
 
 # Get a count of all nodes
 # in the graph
-graph \%>\% count_nodes()
+graph |> count_nodes()
 
 # Get a count of all
 # unconnected nodes in the
 # graph
-graph \%>\%
+graph |>
   count_unconnected_nodes()
 
 }

--- a/man/count_w_connected_cmpts.Rd
+++ b/man/count_w_connected_cmpts.Rd
@@ -19,12 +19,12 @@ Get the number of weakly-connected components in the graph.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
-  add_cycle(n = 5) \%>\%
+  create_graph() |>
+  add_cycle(n = 5) |>
   add_cycle(n = 5)
 
 # Get a count of weakly-connected
 # components in the graph
-graph \%>\% count_w_connected_cmpts()
+graph |> count_w_connected_cmpts()
 
 }

--- a/man/create_graph.Rd
+++ b/man/create_graph.Rd
@@ -74,7 +74,7 @@ graph <-
     nodes_df = ndf)
 
 # Get information on the graph's nodes
-graph \%>\%
+graph |>
   get_node_info()
 
 # You can create a similar graph with
@@ -97,7 +97,7 @@ graph <-
 
 # Get information on the graph's
 # internal node data frame (ndf)
-graph \%>\%
+graph |>
   get_node_df()
 
 # A graph can also be created by
@@ -122,10 +122,10 @@ graph <-
 
 # Get information on the graph's
 # internal edge data frame (edf)
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Get information on the graph's
 # internal node data frame (ndf)
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/create_graph_series.Rd
+++ b/man/create_graph_series.Rd
@@ -28,31 +28,31 @@ sequential or temporal one-dimensional array.
 \examples{
 # Create three graphs
 graph_1 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 4)
 
 graph_2 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 graph_3 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_star(n = 6)
 
 # Create an empty graph series
 # and add the graphs
 series <-
-  create_graph_series() \%>\%
+  create_graph_series() |>
   add_graph_to_graph_series(
-    graph = graph_1) \%>\%
+    graph = graph_1) |>
   add_graph_to_graph_series(
-    graph = graph_2) \%>\%
+    graph = graph_2) |>
   add_graph_to_graph_series(
     graph = graph_3)
 
 # Count the number of graphs
 # in the graph series
-series \%>\%
+series |>
   count_graphs_in_graph_series()
 
 }

--- a/man/delete_cache.Rd
+++ b/man/delete_cache.Rd
@@ -26,25 +26,25 @@ graph <-
 # Cache 3 different vectors inside
 # the graph object
 graph <-
-  graph \%>\%
+  graph |>
   set_cache(
     name = "a",
-    to_cache = 1:4) \%>\%
+    to_cache = 1:4) |>
   set_cache(
     name = "b",
-    to_cache = 5:9) \%>\%
+    to_cache = 5:9) |>
   set_cache(
     name = "c",
     to_cache = 10:14)
 
 # Delete cache `b`
 graph <-
-  graph \%>\%
+  graph |>
   delete_cache(name = "b")
 
 # Delete remaining cached vectors
 graph <-
-  graph \%>\%
+  graph |>
   delete_cache()
 
 }

--- a/man/delete_edge.Rd
+++ b/man/delete_edge.Rd
@@ -37,31 +37,31 @@ edge ID.
 \examples{
 # Create a graph with 2 nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(n = 2)
 
 # Add an edge
 graph <-
-  graph \%>\%
+  graph |>
   add_edge(
     from = 1,
     to = 2)
 
 # Delete the edge
 graph <-
-  graph \%>\%
+  graph |>
   delete_edge(
     from = 1,
     to = 2)
 
 # Get the count of edges in the graph
-graph \%>\% count_edges()
+graph |> count_edges()
 
 # Create an undirected graph with
 # 2 nodes and an edge
 graph_undirected <-
-  create_graph(directed = FALSE) \%>\%
-  add_n_nodes(n = 2) \%>\%
+  create_graph(directed = FALSE) |>
+  add_n_nodes(n = 2) |>
   add_edge(
     from = 1,
     to = 2)
@@ -69,26 +69,26 @@ graph_undirected <-
 # Delete the edge; the order of node ID
 # values provided in `from` and `to`
 # don't matter for the undirected case
-graph_undirected \%>\%
+graph_undirected |>
   delete_edge(
     from = 2,
-    to = 1) \%>\%
+    to = 1) |>
   count_edges()
 
 # The undirected graph has a single
 # edge with ID `1`; it can be
 # deleted by specifying `id`
-graph_undirected \%>\%
-  delete_edge(id = 1) \%>\%
+graph_undirected |>
+  delete_edge(id = 1) |>
   count_edges()
 
 # Create a directed graph with 2
 # labeled nodes and an edge
 graph_labeled_nodes <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
-    label = c("one", "two")) \%>\%
+    label = c("one", "two")) |>
   add_edge(
     from = "one",
     to = "two")
@@ -97,10 +97,10 @@ graph_labeled_nodes <-
 # labels in `from` and `to`; this
 # is analogous to creating the
 # edge using node labels
-graph_labeled_nodes \%>\%
+graph_labeled_nodes |>
   delete_edge(
     from = "one",
-    to = "two") \%>\%
+    to = "two") |>
   count_edges()
 
 }

--- a/man/delete_edges_ws.Rd
+++ b/man/delete_edges_ws.Rd
@@ -30,8 +30,8 @@ Selections of edges can also be performed using the following traversal
 \examples{
 # Create a graph
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 3) \%>\%
+  create_graph() |>
+  add_n_nodes(n = 3) |>
   add_edges_w_string(
     edges = "1->3 1->2 2->3")
 
@@ -39,16 +39,16 @@ graph <-
 # node with ID `3` (these are
 # `1`->`3` and `2`->`3`)
 graph <-
-  graph \%>\%
+  graph |>
   select_edges_by_node_id(nodes = 3)
 
 # Delete edges in selection
 graph <-
-  graph \%>\%
+  graph |>
   delete_edges_ws()
 
 # Get a count of edges in the graph
-graph \%>\% count_edges()
+graph |> count_edges()
 
 }
 \seealso{

--- a/man/delete_global_graph_attrs.Rd
+++ b/man/delete_global_graph_attrs.Rd
@@ -26,15 +26,15 @@ Delete one of the global attributes stored within a graph object of class
 # Create a new graph and add
 # some extra global graph attrs
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_global_graph_attrs(
     attr = "overlap",
     value = "true",
-    attr_type = "graph") \%>\%
+    attr_type = "graph") |>
   add_global_graph_attrs(
     attr = "penwidth",
     value = 3,
-    attr_type = "node") \%>\%
+    attr_type = "node") |>
   add_global_graph_attrs(
     attr = "penwidth",
     value = 3,
@@ -42,21 +42,21 @@ graph <-
 
 # Inspect the graph's global
 # attributes
-graph \%>\%
+graph |>
   get_global_graph_attr_info()
 
 # Delete the `penwidth` attribute
 # for the graph's nodes using the
 # `delete_global_graph_attrs()` fcn
 graph <-
-  graph \%>\%
+  graph |>
   delete_global_graph_attrs(
     attr = "penwidth",
     attr_type = "node")
 
 # View the remaining set of global
 # attributes for the graph
-graph \%>\%
+graph |>
   get_global_graph_attr_info()
 
 }

--- a/man/delete_graph_actions.Rd
+++ b/man/delete_graph_actions.Rd
@@ -24,7 +24,7 @@ Delete one or more graph actions stored within a graph object of class
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 8,
@@ -33,17 +33,17 @@ graph <-
 # Add three graph actions to the
 # graph
 graph <-
-  graph \%>\%
+  graph |>
   add_graph_action(
     fcn = "set_node_attr_w_fcn",
     node_attr_fcn = "get_pagerank",
     column_name = "pagerank",
-    action_name = "get_pagerank") \%>\%
+    action_name = "get_pagerank") |>
   add_graph_action(
     fcn = "rescale_node_attrs",
     node_attr_from = "pagerank",
     node_attr_to = "width",
-    action_name = "pagerank_to_width") \%>\%
+    action_name = "pagerank_to_width") |>
   add_graph_action(
     fcn = "colorize_node_attrs",
     node_attr_from = "width",
@@ -53,18 +53,18 @@ graph <-
 # View the graph actions for the graph
 # object by using the `get_graph_actions()`
 # function
-graph \%>\% get_graph_actions()
+graph |> get_graph_actions()
 
 # Delete the second and third graph
 # actions using `delete_graph_actions()`
 graph <-
-  graph \%>\%
+  graph |>
   delete_graph_actions(
     actions = c(2, 3))
 
 # Verify that these last two graph
 # actions were deleted by again using
 # the `get_graph_actions()` function
-graph \%>\% get_graph_actions()
+graph |> get_graph_actions()
 
 }

--- a/man/delete_loop_edges_ws.Rd
+++ b/man/delete_loop_edges_ws.Rd
@@ -33,7 +33,7 @@ Selections of nodes can also be performed using the following traversal
 # of 5 nodes with loops retained
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_full_graph(
     n = 5,
     keep_loops = TRUE)
@@ -42,14 +42,14 @@ graph <-
 # and remove the loop edges
 # associated with those nodes
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_by_id(
-    nodes = 3:4) \%>\%
+    nodes = 3:4) |>
   delete_loop_edges_ws()
 
 # Count the number of loop
 # edges remaining in the graph
-graph \%>\% count_loop_edges()
+graph |> count_loop_edges()
 
 }
 \seealso{

--- a/man/delete_node.Rd
+++ b/man/delete_node.Rd
@@ -22,7 +22,7 @@ specifying its node ID.
 # Create a graph with 5 nodes and
 # edges between each in a path
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 5)
 
 # Delete node with ID `3`
@@ -30,12 +30,12 @@ graph <- delete_node(graph, node = 3)
 
 # Verify that the node with ID `3`
 # is no longer in the graph
-graph \%>\% get_node_ids()
+graph |> get_node_ids()
 
 # Also note that edges are removed
 # since there were edges between the
 # removed node to and from other nodes
-graph \%>\% get_edges()
+graph |> get_edges()
 }
 \seealso{
 Other node creation and removal: 

--- a/man/delete_nodes_ws.Rd
+++ b/man/delete_nodes_ws.Rd
@@ -32,24 +32,24 @@ Selections of nodes can also be performed using the following traversal
 \examples{
 # Create a graph with 3 nodes
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 3) \%>\%
+  create_graph() |>
+  add_n_nodes(n = 3) |>
   add_edges_w_string(
     edges = "1->3 1->2 2->3")
 
 # Select node with ID `1`
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_by_id(nodes = 1)
 
 # Delete node in selection (this
 # also deletes any attached edges)
 graph <-
-  graph \%>\%
+  graph |>
   delete_nodes_ws()
 
 # Get a count of nodes in the graph
-graph \%>\% count_nodes()
+graph |> count_nodes()
 
 }
 \seealso{

--- a/man/deselect_edges.Rd
+++ b/man/deselect_edges.Rd
@@ -21,31 +21,31 @@ Deselect edges in a graph object of class \code{dgr_graph}.
 # Create a graph with
 # a single path
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 5)
 
 # Select edges with IDs `1`
 # and `3`
 graph <-
-  graph \%>\%
+  graph |>
   select_edges_by_edge_id(
     edges = c(1, 3))
 
 # Verify that an edge selection
 # has been made
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Deselect edge `1`
 graph <-
-  graph \%>\%
+  graph |>
   select_edges_by_edge_id(
-    edges = c(1, 3)) \%>\%
+    edges = c(1, 3)) |>
   deselect_edges(edges = 1)
 
 # Verify that the edge selection
 # has been made for edges `1` and
 # `3` and that edge `1` has been
 # deselected (leaving only `3`)
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/deselect_nodes.Rd
+++ b/man/deselect_nodes.Rd
@@ -41,14 +41,14 @@ graph <-
 
 # Explicitly select nodes `1` and `3`
 graph <-
-  graph \%>\%
-  select_nodes(nodes = c(1, 3)) \%>\%
+  graph |>
+  select_nodes(nodes = c(1, 3)) |>
   deselect_nodes(nodes = 1)
 
 # Verify that the node selection
 # has been made for nodes `1` and
 # `3` and that node `1` has been
 # deselected (leaving only `3`)
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/display_metagraph.Rd
+++ b/man/display_metagraph.Rd
@@ -24,55 +24,61 @@ verified by using the \code{\link[=is_property_graph]{is_property_graph()}} func
 # Create a randomized property
 # graph with 1000 nodes and 1350 edges
 property_graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 1000,
     m = 1350,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   select_nodes_by_degree(
-    expressions = "deg >= 3") \%>\%
+    expressions = "deg >= 3") |>
   set_node_attrs_ws(
     node_attr = type,
-    value = "a") \%>\%
-  clear_selection() \%>\%
+    value = "a") |>
+  clear_selection() |>
   select_nodes_by_degree(
-    expressions = "deg < 3") \%>\%
+    expressions = "deg < 3") |>
   set_node_attrs_ws(
     node_attr = type,
-    value = "b") \%>\%
-  clear_selection() \%>\%
+    value = "b") |>
+  clear_selection() |>
   select_nodes_by_degree(
-    expressions = "deg == 0") \%>\%
+    expressions = "deg == 0") |>
   set_node_attrs_ws(
     node_attr = type,
-    value = "c") \%>\%
+    value = "c") |>
   set_node_attr_to_display(
-    attr = type) \%>\%
+    attr = type)
+
+# Select a random subset of edges
+# for setting edge attributes
+node_ids <- get_node_ids(property_graph)
+sampled_nodes <- sample(
+  node_ids,
+  size = floor(0.15 * length(node_ids)))
+
+property_graph <-
+  property_graph |>
   select_edges_by_node_id(
-    nodes =
-      get_node_ids(.) \%>\%
-      sample(
-        size = 0.15 * length(.) \%>\%
-          floor())) \%>\%
+    nodes = sampled_nodes) |>
   set_edge_attrs_ws(
     edge_attr = rel,
-    value = "r_1") \%>\%
-  invert_selection() \%>\%
+    value = "r_1") |>
+  invert_selection() |>
   set_edge_attrs_ws(
     edge_attr = rel,
-    value = "r_2") \%>\%
-  clear_selection() \%>\%
+    value = "r_2") |>
+  clear_selection() |>
   copy_edge_attrs(
     edge_attr_from = rel,
-    edge_attr_to = label) \%>\%
+    edge_attr_to = label) |>
   add_global_graph_attrs(
     attr = "fontname",
     value = "Helvetica",
-    attr_type = "edge") \%>\%
+    attr_type = "edge") |>
   add_global_graph_attrs(
     attr = "fontcolor",
     value = "gray50",
-    attr_type = "edge") \%>\%
+    attr_type = "edge") |>
   add_global_graph_attrs(
     attr = "fontsize",
     value = 10,

--- a/man/do_bfs.Rd
+++ b/man/do_bfs.Rd
@@ -32,9 +32,9 @@ leaf node (dfs traverses branches as far as possible).
 # Create a graph containing
 # two balanced trees
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
-    k = 2, h = 2) \%>\%
+    k = 2, h = 2) |>
   add_balanced_tree(
     k = 3, h = 2)
 
@@ -45,14 +45,14 @@ graph <-
 # `direction = "all"` doesn't
 # take edge direction into
 # account)
-graph \%>\%
+graph |>
   do_bfs(node = 1)
 
 # If not specifying a
 # starting node, the function
 # will begin the search from
 # a random node
-graph \%>\%
+graph |>
   do_bfs()
 
 # It's also possible to
@@ -61,7 +61,7 @@ graph \%>\%
 # using `direction = "in"`
 # causes the bfs routine to
 # visit nodes along inward edges
-graph \%>\%
+graph |>
   do_bfs(
     node = 1,
     direction = "in")
@@ -69,7 +69,7 @@ graph \%>\%
 # Using `direction = "out"`
 # results in the bfs moving
 # along solely outward edges
-graph \%>\%
+graph |>
   do_bfs(
     node = 1,
     direction = "out")

--- a/man/do_dfs.Rd
+++ b/man/do_dfs.Rd
@@ -32,9 +32,9 @@ traverses branches one level at a time).
 # Create a graph containing
 # two balanced trees
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
-    k = 2, h = 2) \%>\%
+    k = 2, h = 2) |>
   add_balanced_tree(
   k = 3, h = 2)
 
@@ -45,14 +45,14 @@ graph <-
 # `direction = "all"`
 # doesn't take edge
 # direction into account)
-graph \%>\%
+graph |>
   do_dfs(node = 1)
 
 # If not specifying a
 # starting node, the function
 # will begin the search
 # from a random node
-graph \%>\%
+graph |>
   do_dfs()
 
 # It's also possible to
@@ -61,7 +61,7 @@ graph \%>\%
 # using `direction = "in"`
 # causes the dfs routine to
 # visit nodes along inward edges
-graph \%>\%
+graph |>
   do_dfs(
     node = 1,
     direction = "in")
@@ -69,7 +69,7 @@ graph \%>\%
 # Using `direction = "out"`
 # results in the dfs moving
 # along solely outward edges
-graph \%>\%
+graph |>
   do_dfs(
     node = 1,
     direction = "out")

--- a/man/drop_edge_attrs.Rd
+++ b/man/drop_edge_attrs.Rd
@@ -22,26 +22,26 @@ attribute.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 6,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_edge_attrs(
     edge_attr = value,
-    values = 3) \%>\%
+    values = 3) |>
   mutate_edge_attrs(
     penwidth = value * 2)
 
 # Get the graph's internal
 # edf to show which edge
 # attributes are available
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Drop the `value` edge
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   drop_edge_attrs(
     edge_attr = value)
 
@@ -49,7 +49,7 @@ graph <-
 # edf to show that the edge
 # attribute `value` had been
 # removed
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/drop_node_attrs.Rd
+++ b/man/drop_node_attrs.Rd
@@ -20,27 +20,30 @@ attribute.
 }
 \examples{
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 10,
-    set_seed = 23) \%>\%
+    set_seed = 23)
+
+graph <-
+  graph |>
  set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 5,
       mean = 5,
-      sd = 1) \%>\% round(1))
+      sd = 1) |> round(1))
 
 # Get the graph's internal
 # ndf to show which node
 # attributes are available
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Drop the `value` node
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   drop_node_attrs(
     node_attr = value)
 
@@ -48,7 +51,7 @@ graph <-
 # ndf to show that the node
 # attribute `value` had been
 # removed
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/edge_aes.Rd
+++ b/man/edge_aes.Rd
@@ -175,7 +175,7 @@ created.
 # a path with several edge
 # aesthetic attributes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 3,
     type = "path",
@@ -187,7 +187,7 @@ graph <-
 # node data frame; the node
 # aesthetic attributes have
 # been inserted
-graph \%>\%
+graph |>
   get_edge_df()
 
 }

--- a/man/edge_data.Rd
+++ b/man/edge_data.Rd
@@ -20,7 +20,7 @@ created.
 # a path with several edge
 # data attributes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 3,
     type = "path",
@@ -32,7 +32,7 @@ graph <-
 # edge data frame; the edge
 # data attributes have
 # been inserted
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 }
 
 }

--- a/man/export_csv.Rd
+++ b/man/export_csv.Rd
@@ -60,6 +60,6 @@ graph <-
 
 # Create separate `nodes.csv` and
 # `edges.csv` files
-# graph \%>\% export_csv()
+# graph |> export_csv()
 
 }

--- a/man/export_graph.Rd
+++ b/man/export_graph.Rd
@@ -36,7 +36,7 @@ PostScript.
 \examples{
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
     add_path(
       n = 5,
       edge_aes = edge_aes(
@@ -53,7 +53,7 @@ graph <-
 
 # Create a PDF file for
 # the graph (`graph.pdf`)
-# graph \%>\%
+# graph |>
 #   export_graph(
 #     file_name = "graph.pdf",
 #     title = "Simple Graph"
@@ -61,7 +61,7 @@ graph <-
 
 # Create a PNG file for
 # the graph (`mypng.png`)
-# graph \%>\%
+# graph |>
 #   export_graph(
 #     file_name = "mypng.png",
 #     file_type = "PNG"

--- a/man/filter_graph_series.Rd
+++ b/man/filter_graph_series.Rd
@@ -32,21 +32,21 @@ or through selection via graphs' date-time attributes.
 # Create three graphs
 graph_time_1 <-
   create_graph(
-    graph_name = "graph_with_time_1") \%>\%
+    graph_name = "graph_with_time_1") |>
   set_graph_time(
     time = "2015-03-25 03:00",
     tz = "GMT")
 
 graph_time_2 <-
   create_graph(
-    graph_name = "graph_with_time_2") \%>\%
+    graph_name = "graph_with_time_2") |>
   set_graph_time(
     time = "2015-03-26 03:00",
     tz = "GMT")
 
 graph_time_3 <-
   create_graph(
-    graph_name = "graph_with_time_3") \%>\%
+    graph_name = "graph_with_time_3") |>
   set_graph_time(
     time = "2015-03-27 15:00",
     tz = "GMT")
@@ -55,11 +55,11 @@ graph_time_3 <-
 # the graphs
 series_temporal <-
   create_graph_series(
-    series_type = "temporal") \%>\%
+    series_type = "temporal") |>
   add_graph_to_graph_series(
-    graph = graph_time_1) \%>\%
+    graph = graph_time_1) |>
   add_graph_to_graph_series(
-    graph = graph_time_2) \%>\%
+    graph = graph_time_2) |>
   add_graph_to_graph_series(
     graph = graph_time_3)
 
@@ -72,7 +72,7 @@ series_sequence_subset <-
 
 # Get a count of graphs in
 # the series
-series_sequence_subset \%>\%
+series_sequence_subset |>
   count_graphs_in_graph_series()
 
 # Subset graph series by date-time
@@ -86,7 +86,7 @@ series_time_subset <-
 
 # Get a count of graphs in
 # the series
-series_time_subset \%>\%
+series_time_subset |>
   count_graphs_in_graph_series()
 
 }

--- a/man/from_adj_matrix.Rd
+++ b/man/from_adj_matrix.Rd
@@ -51,7 +51,7 @@ adj_matrix <-
     0:1, 100,
     replace = TRUE,
     prob = c(0.9,0.1)
-  ) \%>\%
+  ) |>
   matrix(ncol = 10)
 
 # Create a graph from the adjacency matrix

--- a/man/from_igraph.Rd
+++ b/man/from_igraph.Rd
@@ -33,7 +33,7 @@ Convert an igraph graph to a DiagrammeR graph object.
 \examples{
 # Create a DiagrammeR graph object
 dgr_graph_orig <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 36,
     m = 50,
@@ -42,17 +42,19 @@ dgr_graph_orig <-
 # Convert the DiagrammeR
 # graph to an igraph object
 ig_graph <-
-  dgr_graph_orig \%>\%
+  dgr_graph_orig |>
   to_igraph()
 
 # Convert the igraph graph
 # back to a DiagrammeR graph
 dgr_graph_new <-
-  ig_graph \%>\%
+  ig_graph |>
   from_igraph()
 
 # Get some graph information
-(dgr_graph_new \%>\%
-  get_graph_info())[, 1:6]
+graph_info <- dgr_graph_new |>
+  get_graph_info()
+
+graph_info[, 1:6]
 
 }

--- a/man/fully_connect_nodes_ws.Rd
+++ b/man/fully_connect_nodes_ws.Rd
@@ -34,8 +34,8 @@ Selections of nodes can also be performed using the following traversal
 # then add a path of 3 nodes
 # and two isolated nodes
 graph <-
-  create_graph() \%>\%
-  add_path(n = 3) \%>\%
+  create_graph() |>
+  add_path(n = 3) |>
   add_n_nodes(n = 2)
 
 # Select a node in the path
@@ -44,21 +44,21 @@ graph <-
 # and `5`); then, and fully
 # connect these nodes together
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_by_id(
-    nodes = 3:5) \%>\%
+    nodes = 3:5) |>
   fully_connect_nodes_ws()
 
 # Get the graph's edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Create an undirected, empty
 # graph; add a path of 3 nodes
 # and two isolated nodes
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
-  add_path(n = 3) \%>\%
+    directed = FALSE) |>
+  add_path(n = 3) |>
   add_n_nodes(n = 2)
 
 # Select a node in the path
@@ -67,15 +67,15 @@ graph <-
 # and `5`); then, and fully
 # connect these nodes together
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_by_id(
-    nodes = 3:5) \%>\%
+    nodes = 3:5) |>
   fully_connect_nodes_ws()
 
 # Get the graph's edge data
 # frame; in the undirected
 # case, reverse edges aren't
 # added
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }

--- a/man/fully_disconnect_nodes_ws.Rd
+++ b/man/fully_disconnect_nodes_ws.Rd
@@ -34,19 +34,19 @@ Selections of nodes can also be performed using the following traversal
 # Create an empty graph and
 # add a path of 6 nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 6)
 
 # Select nodes `3` and `4`
 # and fully disconnect them
 # from the graph
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_by_id(
-    nodes = 3:4) \%>\%
+    nodes = 3:4) |>
   fully_disconnect_nodes_ws()
 
 # Get the graph's edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }

--- a/man/get_adhesion.Rd
+++ b/man/get_adhesion.Rd
@@ -21,16 +21,16 @@ the edge connectivity of the graph.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Determine the graph's adhesion
-graph \%>\% get_adhesion()
+graph |> get_adhesion()
 
 # Create a full graph and then
 # get the adhesion for that
-create_graph() \%>\%
-  add_full_graph(n = 8) \%>\%
+create_graph() |>
+  add_full_graph(n = 8) |>
   get_adhesion()
 
 }

--- a/man/get_agg_degree_in.Rd
+++ b/man/get_agg_degree_in.Rd
@@ -27,21 +27,24 @@ graph, or, a subset of graph nodes.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 20,
     m = 35,
-    set_seed = 23) \%>\%
+    set_seed = 23)
+
+graph <-
+  graph |>
   set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 20,
       mean = 5,
-      sd = 1) \%>\% round(1))
+      sd = 1) |> round(1))
 
 # Get the mean indegree value
 # from all nodes in the graph
-graph \%>\%
+graph |>
   get_agg_degree_in(
     agg = "mean")
 
@@ -49,7 +52,7 @@ graph \%>\%
 # can be used (`min`, `max`,
 # `median`, `sum`); let's get
 # the median in this example
-graph \%>\%
+graph |>
   get_agg_degree_in(
     agg = "median")
 
@@ -58,7 +61,7 @@ graph \%>\%
 # graph nodes and this is made
 # possible by specifying
 # `conditions` for the nodes
-graph \%>\%
+graph |>
   get_agg_degree_in(
     agg = "mean",
     conditions = value > 5.0)

--- a/man/get_agg_degree_out.Rd
+++ b/man/get_agg_degree_out.Rd
@@ -27,28 +27,28 @@ graph, or, a subset of graph nodes.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 20,
     m = 35,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 20,
       mean = 5,
-      sd = 1) \%>\% round(1))
+      sd = 1) |> round(1))
 
 # Get the mean outdegree value from all
 # nodes in the graph
-graph \%>\%
+graph |>
   get_agg_degree_out(
     agg = "mean")
 
 # Other aggregation functions can be used
 # (`min`, `max`, `median`, `sum`); let's
 # get the median in this example
-graph \%>\%
+graph |>
   get_agg_degree_out(
     agg = "median")
 
@@ -56,7 +56,7 @@ graph \%>\%
 # for a subset of the graph nodes and this
 # is made possible by specifying `conditions`
 # for the nodes
-graph \%>\%
+graph |>
   get_agg_degree_out(
     agg = "mean",
     conditions = value < 5.0)

--- a/man/get_agg_degree_total.Rd
+++ b/man/get_agg_degree_total.Rd
@@ -27,22 +27,22 @@ graph, or, a subset of graph nodes.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 20,
     m = 35,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 20,
       mean = 5,
-      sd = 1) \%>\% round(1))
+      sd = 1) |> round(1))
 
 # Get the mean total degree
 # value from all nodes in
 # the graph
-graph \%>\%
+graph |>
   get_agg_degree_total(
     agg = "mean")
 
@@ -50,7 +50,7 @@ graph \%>\%
 # can be used (`min`, `max`,
 # `median`, `sum`); let's get
 # the median in this example
-graph \%>\%
+graph |>
   get_agg_degree_total(
     agg = "median")
 
@@ -60,7 +60,7 @@ graph \%>\%
 # and this is made possible
 # by specifying `conditions`
 # for the nodes
-graph \%>\%
+graph |>
   get_agg_degree_total(
     agg = "mean",
     conditions = value < 5.0)

--- a/man/get_all_connected_nodes.Rd
+++ b/man/get_all_connected_nodes.Rd
@@ -23,7 +23,7 @@ With a single node serving as the starting point get all nodes connected
 # `add_gnm_graph()` function; it
 # has an unconnected node (`6`)
 graph_1 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 20,
     m = 32,
@@ -33,14 +33,14 @@ graph_1 <-
 # nodes to `6` so when specifying
 # this node with `get_all_connected_nodes()`
 # we get NA back
-graph_1 \%>\%
+graph_1 |>
   get_all_connected_nodes(
     node = 6)
 
 # Any other node in `graph_1` will
 # provide a vector of all the nodes
 # other than `6`
-graph_1 \%>\%
+graph_1 |>
   get_all_connected_nodes(
     node = 1)
 
@@ -48,21 +48,21 @@ graph_1 \%>\%
 # clusters of nodes (i.e., the
 # graph has two connected components)
 graph_2 <-
-  create_graph() \%>\%
-  add_path(n = 6) \%>\%
+  create_graph() |>
+  add_path(n = 6) |>
   add_path(n = 4)
 
 # In `graph_2`, node `1` is in
 # the larger of the two
 # connected components
-graph_2 \%>\%
+graph_2 |>
   get_all_connected_nodes(
     node = 1)
 
 # Also in `graph_2`, node `8`
 # is in the smaller of the two
 # connected components
-graph_2 \%>\%
+graph_2 |>
   get_all_connected_nodes(
     node = 8)
 

--- a/man/get_alpha_centrality.Rd
+++ b/man/get_alpha_centrality.Rd
@@ -40,7 +40,7 @@ Get the alpha centrality values for all nodes in the graph.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 12,
@@ -48,19 +48,19 @@ graph <-
 
 # Get the alpha centrality scores
 # for all nodes
-graph \%>\%
+graph |>
   get_alpha_centrality()
 
 # Add the alpha centrality
 # scores to the graph as a node
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_alpha_centrality(.))
+    df = get_alpha_centrality(graph))
 
 # Display the graph's node
 # data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_articulation_points.Rd
+++ b/man/get_articulation_points.Rd
@@ -19,11 +19,11 @@ Get the nodes in the graph that are identified as articulation points.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 12,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = shape,
     values = "square")
@@ -33,16 +33,16 @@ graph <-
 # nodes that if any were to be
 # removed, the graph would
 # become disconnected)
-graph \%>\%
+graph |>
   get_articulation_points()
 
 # For the articulation points,
 # change the node shape to
 # a `circle`
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_by_id(
-    nodes = get_articulation_points(.)) \%>\%
+    nodes = get_articulation_points(graph)) |>
   set_node_attrs_ws(
     node_attr = shape,
     value = "circle")

--- a/man/get_authority_centrality.Rd
+++ b/man/get_authority_centrality.Rd
@@ -23,7 +23,7 @@ Get the Kleinberg authority centrality scores for all nodes in the graph.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -31,18 +31,18 @@ graph <-
 
 # Get the authority centrality scores
 # for all nodes in the graph
-graph \%>\%
+graph |>
   get_authority_centrality()
 
 # Add the authority centrality
 # scores to the graph as a node
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_authority_centrality(.))
+    df = get_authority_centrality(graph))
 
 # Display the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_betweenness.Rd
+++ b/man/get_betweenness.Rd
@@ -19,7 +19,7 @@ Get the betweenness centrality scores for all nodes in a graph.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 12,
@@ -27,18 +27,18 @@ graph <-
 
 # Get the betweenness scores
 # for nodes in the graph
-graph \%>\% get_betweenness()
+graph |> get_betweenness()
 
 # Add the betweenness
 # values to the graph
 # as a node attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_betweenness(.))
+    df = get_betweenness(graph))
 
 # Display the graph's node
 # data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_cache.Rd
+++ b/man/get_cache.Rd
@@ -25,28 +25,28 @@ set.seed(23)
 
 # Create a graph with 5 nodes and 5 edges
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 5) \%>\%
+  create_graph() |>
+  add_n_nodes(n = 5) |>
   set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 5,
       mean = 8,
-      sd = 2)) \%>\%
+      sd = 2)) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->2")
 
 # Cache all values from the node attribute `value`
 # as a numeric vector
 graph <-
-  graph \%>\%
+  graph |>
   set_cache(
     name = "value",
     to_cache = get_node_attrs(
-      graph = .,
+      graph = graph,
       node_attr = value))
 
 # Return the cached vector
-graph \%>\% get_cache()
+graph |> get_cache()
 
 }

--- a/man/get_closeness.Rd
+++ b/man/get_closeness.Rd
@@ -24,7 +24,7 @@ Get the closeness centrality values for all nodes in a graph.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 12,
@@ -32,16 +32,16 @@ graph <-
 
 # Get closeness values for all nodes
 # in the graph
-graph \%>\% get_closeness()
+graph |> get_closeness()
 
 # Add the closeness values to
 # the graph as a node attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_closeness(.))
+    df = get_closeness(graph))
 
 # Display the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_closeness_vitality.Rd
+++ b/man/get_closeness_vitality.Rd
@@ -19,7 +19,7 @@ Get the closeness vitality values for all nodes in the graph.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 12,
@@ -27,18 +27,18 @@ graph <-
 
 # Get closeness vitality values
 # for all nodes in the graph
-graph \%>\% get_closeness_vitality()
+graph |> get_closeness_vitality()
 
 # Add the closeness vitality
 # values to the graph as a
 # node attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_closeness_vitality(.))
+    df = get_closeness_vitality(graph))
 
 # Display the graph's
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_cmty_edge_btwns.Rd
+++ b/man/get_cmty_edge_btwns.Rd
@@ -21,7 +21,7 @@ nodes in the graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -33,19 +33,19 @@ graph <-
 # the leading non-negative
 # eigenvector of the modularity
 # matrix of the graph
-graph \%>\%
+graph |>
   get_cmty_edge_btwns()
 
 # Add the group membership
 # values to the graph
 # as a node attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-     df = get_cmty_edge_btwns(.))
+     df = get_cmty_edge_btwns(graph))
 
 # Display the graph's
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_cmty_fast_greedy.Rd
+++ b/man/get_cmty_fast_greedy.Rd
@@ -21,7 +21,7 @@ method only works on graphs without multiple edges.
 # Create a graph with a
 # balanced tree
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
     k = 2,
     h = 2)
@@ -31,19 +31,19 @@ graph <-
 # the graph through the greedy
 # optimization of modularity
 # algorithm
-graph \%>\%
+graph |>
   get_cmty_fast_greedy()
 
 # Add the group membership
 # values to the graph as a
 # node attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_cmty_fast_greedy(.))
+    df = get_cmty_fast_greedy(graph))
 
 # Display the graph's
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_cmty_l_eigenvec.Rd
+++ b/man/get_cmty_l_eigenvec.Rd
@@ -22,7 +22,7 @@ of the nodes in the graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -34,18 +34,18 @@ graph <-
 # the leading non-negative
 # eigenvector of the modularity
 # matrix of the graph
-graph \%>\%
+graph |>
   get_cmty_l_eigenvec()
 
 # Add the group membership
 # values to the graph as a node
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_cmty_l_eigenvec(.))
+    df = get_cmty_l_eigenvec(graph))
 
 # Display the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_cmty_louvain.Rd
+++ b/man/get_cmty_louvain.Rd
@@ -21,7 +21,7 @@ group membership values for each of the nodes in the graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -32,19 +32,19 @@ graph <-
 # through the multi-level
 # optimization of modularity
 # algorithm
-graph \%>\%
+graph |>
   get_cmty_louvain()
 
 # Add the group membership
 # values to the graph as a
 # node attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_cmty_louvain(.))
+    df = get_cmty_louvain(graph))
 
 # Display the graph's
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_cmty_walktrap.Rd
+++ b/man/get_cmty_walktrap.Rd
@@ -23,7 +23,7 @@ values for each of the nodes in the graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -33,19 +33,19 @@ graph <-
 # values for all nodes in the
 # graph through the Walktrap
 # community finding algorithm
-graph \%>\%
+graph |>
   get_cmty_walktrap()
 
 # Add the group membership
 # values to the graph as a
 # node attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_cmty_walktrap(.))
+    df = get_cmty_walktrap(graph))
 
 # Display the graph's
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_common_nbrs.Rd
+++ b/man/get_common_nbrs.Rd
@@ -20,19 +20,19 @@ With two or more nodes, get the set of common neighboring nodes.
 \examples{
 # Create a directed graph with 5 nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 5)
 
 # Find all common neighbor nodes
 # for nodes `1` and `2` (there are no
 # common neighbors amongst them)
-graph \%>\%
+graph |>
   get_common_nbrs(
     nodes = c(1, 2))
 
 # Find all common neighbor nodes for
 # nodes `1` and `3`
-graph \%>\%
+graph |>
   get_common_nbrs(
     nodes = c(1, 3))
 

--- a/man/get_coreness.Rd
+++ b/man/get_coreness.Rd
@@ -25,7 +25,7 @@ Get the coreness values for all nodes in a graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -33,17 +33,17 @@ graph <-
 
 # Get coreness values for
 # all nodes in the graph
-graph \%>\% get_coreness()
+graph |> get_coreness()
 
 # Add the coreness values
 # to the graph as a node
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_coreness(.))
+    df = get_coreness(graph))
 
 # Display the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_degree_distribution.Rd
+++ b/man/get_degree_distribution.Rd
@@ -25,7 +25,7 @@ frequency of total degree values over all nodes in the graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -33,7 +33,7 @@ graph <-
 
 # Get the total degree
 # distribution for the graph
-graph \%>\%
+graph |>
   get_degree_distribution(
     mode = "total")
 

--- a/man/get_degree_histogram.Rd
+++ b/man/get_degree_histogram.Rd
@@ -25,7 +25,7 @@ and zero-value degrees are omitted from the output.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -33,7 +33,7 @@ graph <-
 
 # Get degree histogram data for
 # the graph (reporting total degree)
-graph \%>\%
+graph |>
   get_degree_histogram(
     mode = "total")
 

--- a/man/get_degree_in.Rd
+++ b/man/get_degree_in.Rd
@@ -25,7 +25,7 @@ Get the indegree values for all nodes in a graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -33,19 +33,19 @@ graph <-
 
 # Get the indegree values for
 # all nodes in the graph
-graph \%>\%
+graph |>
   get_degree_in()
 
 # Add the indegree values
 # to the graph as a node
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_degree_in(.))
+    df = get_degree_in(graph))
 
 # Display the graph's
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_degree_out.Rd
+++ b/man/get_degree_out.Rd
@@ -25,7 +25,7 @@ Get the outdegree values for all nodes in a graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -33,19 +33,19 @@ graph <-
 
 # Get the outdegree values
 # for all nodes in the graph
-graph \%>\%
+graph |>
   get_degree_out()
 
 # Add the outdegree values
 # to the graph as a node
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_degree_out(.))
+    df = get_degree_out(graph))
 
 # Display the graph's
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_degree_total.Rd
+++ b/man/get_degree_total.Rd
@@ -25,7 +25,7 @@ Get the total degree values for all nodes in a graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -33,19 +33,19 @@ graph <-
 
 # Get the total degree values
 # for all nodes in the graph
-graph \%>\%
+graph |>
   get_degree_total()
 
 # Add the total degree values
 # to the graph as a node
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_degree_total(.))
+    df = get_degree_total(graph))
 
 # Display the graph's
 # node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_dice_similarity.Rd
+++ b/man/get_dice_similarity.Rd
@@ -33,7 +33,7 @@ Get the Dice similarity coefficient scores for one or more nodes in a graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -42,7 +42,7 @@ graph <-
 # Get the Dice similarity
 # values for nodes `5`, `6`,
 # and `7`
-graph \%>\%
+graph |>
   get_dice_similarity(
     nodes = 5:7)
 

--- a/man/get_eccentricity.Rd
+++ b/man/get_eccentricity.Rd
@@ -27,7 +27,7 @@ Get a data frame with node eccentricity values.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -35,6 +35,6 @@ graph <-
 
 # Get the eccentricity values for
 # all nodes in the graph
-graph \%>\% get_eccentricity()
+graph |> get_eccentricity()
 
 }

--- a/man/get_edge_attrs.Rd
+++ b/man/get_edge_attrs.Rd
@@ -30,33 +30,34 @@ or more edges.
 # edges have an edge attribute
 # named `value`
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 4) \%>\%
-  {
-    edges <-
-      create_edge_df(
-        from = c(1, 2, 1, 4),
-          to = c(2, 3, 4, 3),
-         rel = "rel")
-    add_edge_df(
-      graph = .,
-      edge_df = edges)
-  } \%>\%
+  create_graph() |>
+  add_n_nodes(n = 4)
+
+edges <-
+  create_edge_df(
+    from = c(1, 2, 1, 4),
+      to = c(2, 3, 4, 3),
+     rel = "rel")
+
+graph <-
+  add_edge_df(
+    graph = graph,
+    edge_df = edges) |>
   set_edge_attrs(
     edge_attr = value,
     values = 1.6,
     from = 1,
-      to = 2) \%>\%
+      to = 2) |>
   set_edge_attrs(
     edge_attr = value,
     values = 4.3,
     from = 1,
-      to = 4) \%>\%
+      to = 4) |>
   set_edge_attrs(
     edge_attr = value,
     values = 2.9,
     from = 2,
-      to = 3) \%>\%
+      to = 3) |>
   set_edge_attrs(
     edge_attr = value,
     values = 8.4,
@@ -65,14 +66,14 @@ graph <-
 
 # Get the values for the
 # `value` edge attribute
-graph \%>\%
+graph |>
   get_edge_attrs(
     edge_attr = value)
 
 # To only return edge attribute
 # values for specified edges, use
 # the `from` and `to` arguments
-graph \%>\%
+graph |>
   get_edge_attrs(
     edge_attr = value,
     from = c(1, 2),

--- a/man/get_edge_attrs_ws.Rd
+++ b/man/get_edge_attrs_ws.Rd
@@ -35,33 +35,34 @@ Selections of edges can also be performed using the following traversal
 # edges have an edge attribute
 # named `value`
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 4) \%>\%
-  {
-    edges <-
-      create_edge_df(
-        from = c(1, 2, 1, 4),
-          to = c(2, 3, 4, 3),
-         rel = "rel")
-    add_edge_df(
-      graph = .,
-      edge_df = edges)
-  } \%>\%
+  create_graph() |>
+  add_n_nodes(n = 4)
+
+edges <-
+  create_edge_df(
+    from = c(1, 2, 1, 4),
+      to = c(2, 3, 4, 3),
+     rel = "rel")
+
+graph <-
+  add_edge_df(
+    graph = graph,
+    edge_df = edges) |>
   set_edge_attrs(
     edge_attr = value,
     values = 1.6,
     from = 1,
-      to = 2) \%>\%
+      to = 2) |>
   set_edge_attrs(
     edge_attr = value,
     values = 4.3,
     from = 1,
-      to = 4) \%>\%
+      to = 4) |>
   set_edge_attrs(
     edge_attr = value,
     values = 2.9,
     from = 2,
-      to = 3) \%>\%
+      to = 3) |>
   set_edge_attrs(
     edge_attr = value,
     values = 8.4,
@@ -71,7 +72,7 @@ graph <-
 # Select the edges defined as
 # `1`->`3` and `2`->`3`
 graph <-
-  graph \%>\%
+  graph |>
   select_edges(
     from = c(1, 2),
     to = c(2, 3))
@@ -79,7 +80,7 @@ graph <-
 # Get the edge attribute values
 # for the `value` attribute, limited
 # to the current edge selection
-graph \%>\%
+graph |>
   get_edge_attrs_ws(
     edge_attr = value)
 

--- a/man/get_edge_count_w_multiedge.Rd
+++ b/man/get_edge_count_w_multiedge.Rd
@@ -43,6 +43,6 @@ graph <-
 # there are multiple edges (i.e.,
 # distinct edges with separate edge
 # ID values)
-graph \%>\% get_edge_count_w_multiedge()
+graph |> get_edge_count_w_multiedge()
 
 }

--- a/man/get_edge_df.Rd
+++ b/man/get_edge_df.Rd
@@ -18,34 +18,34 @@ From a graph, obtain an edge data frame with all current edge attributes.
 \examples{
 # Create a graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 1,
-    type = "a") \%>\%
-  select_last_nodes_created() \%>\%
+    type = "a") |>
+  select_last_nodes_created() |>
   add_n_nodes_ws(
     n = 5,
     direction = "from",
-    type = "b") \%>\%
+    type = "b") |>
   select_edges_by_node_id(
-    nodes = 3:5) \%>\%
+    nodes = 3:5) |>
   set_edge_attrs_ws(
     edge_attr = color,
-    value = "green") \%>\%
+    value = "green") |>
   set_edge_attrs_ws(
     edge_attr = rel,
-    value = "a") \%>\%
-  invert_selection \%>\%
+    value = "a") |>
+  invert_selection() |>
   set_edge_attrs_ws(
     edge_attr = color,
-    value = "blue") \%>\%
+    value = "blue") |>
   set_edge_attrs_ws(
     edge_attr = rel,
-    value = "b") \%>\%
+    value = "b") |>
   clear_selection()
 
 # Get the graph's internal
 # edge data frame (edf)
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }

--- a/man/get_edge_df_ws.Rd
+++ b/man/get_edge_df_ws.Rd
@@ -31,11 +31,11 @@ Selections of edges can also be performed using the following traversal
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 4,
     m = 4,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_edge_attrs(
     edge_attr = value,
     values = c(2.5, 8.2, 4.2, 2.4))
@@ -43,13 +43,13 @@ graph <-
 # Select edges with ID values
 # `1` and `3`
 graph <-
-  graph \%>\%
+  graph |>
   select_edges_by_edge_id(
     edges = c(1, 3))
 
 # Get the edge data frame that's
 # limited to the rows that correspond
 # to the edge selection
-graph \%>\% get_edge_df_ws()
+graph |> get_edge_df_ws()
 
 }

--- a/man/get_edge_ids.Rd
+++ b/man/get_edge_ids.Rd
@@ -44,7 +44,7 @@ graph <-
     edges_df = edf)
 
 # Get a vector of all edges in a graph
-graph \%>\% get_edge_ids()
+graph |> get_edge_ids()
 
 # Get a vector of edge ID values using a
 # numeric comparison (i.e., all edges with

--- a/man/get_edge_info.Rd
+++ b/man/get_edge_info.Rd
@@ -20,13 +20,13 @@ interrelationships within the graph.
 \examples{
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5, m = 10,
     set_seed = 23)
 
 # Get information on the
 # graph's edges
-graph \%>\% get_edge_info()
+graph |> get_edge_info()
 
 }

--- a/man/get_edges.Rd
+++ b/man/get_edges.Rd
@@ -62,18 +62,18 @@ graph <-
     edges_df = edf)
 
 # Get all edges within a graph, returned as a list
-graph \%>\%
+graph |>
   get_edges(
     return_type = "vector")
 
 # Get all edges within a graph, returned as a
 # data frame
-graph \%>\%
+graph |>
   get_edges(
     return_type = "df")
 
 # Get all edges returned as a list
-graph \%>\%
+graph |>
   get_edges(
     return_type = "list")
 
@@ -81,14 +81,14 @@ graph \%>\%
 # a numeric comparison (i.e.,
 # all edges with a `value`
 # attribute greater than 3)
-graph \%>\%
+graph |>
   get_edges(
     conditions = value > 3,
     return_type = "vector")
 
 # Get a vector of edges using
 # a matching condition
-graph \%>\%
+graph |>
   get_edges(
     conditions = color == "pink",
     return_type = "vector")
@@ -96,7 +96,7 @@ graph \%>\%
 # Use multiple conditions to
 # return edges with the
 # desired attribute values
-graph \%>\%
+graph |>
   get_edges(
     conditions =
       color == "blue" &
@@ -106,7 +106,7 @@ graph \%>\%
 # Use `return_values = "label"`
 # to return the labels of the
 # connected nodes
-graph \%>\%
+graph |>
   get_edges(
     conditions =
       color == "blue" &

--- a/man/get_eigen_centrality.Rd
+++ b/man/get_eigen_centrality.Rd
@@ -24,13 +24,13 @@ Get the eigen centrality values for all nodes in the graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10, m = 15,
     set_seed = 23)
 
 # Get the eigen centrality scores
 # for nodes in the graph
-graph \%>\% get_eigen_centrality()
+graph |> get_eigen_centrality()
 
 }

--- a/man/get_girth.Rd
+++ b/man/get_girth.Rd
@@ -21,16 +21,16 @@ contains no cycles then zero is returned.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Determine the graph's girth
-graph \%>\% get_girth()
+graph |> get_girth()
 
 # Create a full graph and then
 # get the girth for that
-create_graph() \%>\%
-  add_full_graph(n = 10) \%>\%
+create_graph() |>
+  add_full_graph(n = 10) |>
   get_girth()
 
 }

--- a/man/get_global_graph_attr_info.Rd
+++ b/man/get_global_graph_attr_info.Rd
@@ -21,7 +21,7 @@ graph <- create_graph()
 
 # View the graph's set of
 # global attributes
-graph \%>\%
+graph |>
   get_global_graph_attr_info()
 
 }

--- a/man/get_graph_actions.Rd
+++ b/man/get_graph_actions.Rd
@@ -22,7 +22,7 @@ or, when manually invoked with the \code{\link[=trigger_graph_actions]{trigger_g
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -35,7 +35,7 @@ graph <-
 # to provide betweenness values in the
 # `btwns` column
 graph <-
-  graph \%>\%
+  graph |>
   add_graph_action(
     fcn = "set_node_attr_w_fcn",
     node_attr_fcn = "get_betweenness",
@@ -45,6 +45,6 @@ graph <-
 # To ensure that the action is
 # available in the graph, use the
 # `get_graph_actions()` function
-graph \%>\% get_graph_actions()
+graph |> get_graph_actions()
 
 }

--- a/man/get_graph_from_graph_series.Rd
+++ b/man/get_graph_from_graph_series.Rd
@@ -17,31 +17,31 @@ Using a graph series object of type \code{dgr_graph_1D}, get a graph object.
 \examples{
 # Create three graphs
 graph_1 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 4)
 
 graph_2 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 graph_3 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_star(n = 6)
 
 # Create an empty graph series
 # and add the graphs
 series <-
-  create_graph_series() \%>\%
+  create_graph_series() |>
   add_graph_to_graph_series(
-    graph = graph_1) \%>\%
+    graph = graph_1) |>
   add_graph_to_graph_series(
-    graph = graph_2) \%>\%
+    graph = graph_2) |>
   add_graph_to_graph_series(
     graph = graph_3)
 
 # Get the second graph in the series
 extracted_graph <-
-  series \%>\%
+  series |>
   get_graph_from_graph_series(
     graph_no = 2)
 

--- a/man/get_graph_info.Rd
+++ b/man/get_graph_info.Rd
@@ -22,13 +22,13 @@ Get a data frame with metrics for a graph.
 karate_club <-
   system.file(
     "extdata", "karate.gml",
-    package = "DiagrammeR") \%>\%
-  import_graph() \%>\%
+    package = "DiagrammeR") |>
+  import_graph() |>
   set_graph_name("karate")
 
 # Display a data frame with
 # graph information
-karate_club \%>\%
+karate_club |>
   get_graph_info()
 }
 

--- a/man/get_graph_log.Rd
+++ b/man/get_graph_log.Rd
@@ -22,16 +22,16 @@ called on the graph that resulted in some transformation of the graph.
 # delete 2 nodes from the graph
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
-    set_seed = 23) \%>\%
-  delete_node(node = 5) \%>\%
+    set_seed = 23) |>
+  delete_node(node = 5) |>
   delete_node(node = 7)
 
 # Get the graph log, which is a
 # record of all graph transformations
-graph \%>\% get_graph_log()
+graph |> get_graph_log()
 
 }

--- a/man/get_graph_name.Rd
+++ b/man/get_graph_name.Rd
@@ -27,6 +27,6 @@ graph <-
     name = "the_name")
 
 # Get the graph's name
-graph \%>\% get_graph_name()
+graph |> get_graph_name()
 
 }

--- a/man/get_graph_series_info.Rd
+++ b/man/get_graph_series_info.Rd
@@ -19,29 +19,29 @@ Obtain a data frame with information on the graphs within a graph series.
 \examples{
 # Create three graphs
 graph_1 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 4)
 
 graph_2 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 graph_3 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_star(n = 6)
 
 # Create an empty graph series
 # and add the graphs
 series <-
-  create_graph_series() \%>\%
+  create_graph_series() |>
   add_graph_to_graph_series(
-    graph = graph_1) \%>\%
+    graph = graph_1) |>
   add_graph_to_graph_series(
-    graph = graph_2) \%>\%
+    graph = graph_2) |>
   add_graph_to_graph_series(
     graph = graph_3)
 
 # Get information on the graphs in the series
-series \%>\% get_graph_series_info()
+series |> get_graph_series_info()
 
 }

--- a/man/get_graph_time.Rd
+++ b/man/get_graph_time.Rd
@@ -21,12 +21,12 @@ Get the time and timezone for a graph object of class \code{dgr_graph}.
 # is supplied for the `tz` argument,
 # `GMT` is used as the time zone
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
     set_graph_time(
       time = "2015-10-25 15:23:00")
 
 # Get the graph's time as a POSIXct
 # object using `get_graph_time()`
-graph \%>\% get_graph_time()
+graph |> get_graph_time()
 
 }

--- a/man/get_jaccard_similarity.Rd
+++ b/man/get_jaccard_similarity.Rd
@@ -33,7 +33,7 @@ graph.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -42,7 +42,7 @@ graph <-
 # Get the Jaccard similarity
 # values for nodes `5`, `6`,
 # and `7`
-graph \%>\%
+graph |>
   get_jaccard_similarity(
     nodes = 5:7)
 

--- a/man/get_last_edges_created.Rd
+++ b/man/get_last_edges_created.Rd
@@ -20,16 +20,16 @@ This function should ideally be used just after creating the edges.
 # Create a graph and add a cycle and then
 # a tree in 2 separate function calls
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(
     n = 3,
-    rel = "a") \%>\%
+    rel = "a") |>
   add_balanced_tree(
     k = 2, h = 2,
     rel = "b")
 
 # Get the last edges created (all edges
 # from the tree)
-graph \%>\% get_last_edges_created()
+graph |> get_last_edges_created()
 
 }

--- a/man/get_last_nodes_created.Rd
+++ b/man/get_last_nodes_created.Rd
@@ -21,11 +21,11 @@ just after creating the nodes.
 # Create a graph and add 4 nodes
 # in 2 separate function calls
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("a_1", "a_2")) \%>\%
+    label = c("a_1", "a_2")) |>
   add_n_nodes(
     n = 2,
     type = "b",
@@ -33,6 +33,6 @@ graph <-
 
 # Get the last nodes created (2 nodes
 # from the last function call)
-graph \%>\% get_last_nodes_created()
+graph |> get_last_nodes_created()
 
 }

--- a/man/get_leverage_centrality.Rd
+++ b/man/get_leverage_centrality.Rd
@@ -26,7 +26,7 @@ far fewer connections.
 # `add_gnm_graph()` function
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -34,18 +34,18 @@ graph <-
 
 # Get leverage centrality values
 # for all nodes in the graph
-graph \%>\%
+graph |>
   get_leverage_centrality()
 
 # Add the leverage centrality
 # values to the graph as a
 # node attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_leverage_centrality(.))
+    df = get_leverage_centrality(graph))
 
 # Display the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/get_max_eccentricity.Rd
+++ b/man/get_max_eccentricity.Rd
@@ -21,19 +21,19 @@ node in the graph.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Determine the graph's maximum
 # eccentricity
-graph \%>\%
+graph |>
   get_max_eccentricity()
 
 # Create a full graph and then
 # get the maximum eccentricity
 # value for that
-create_graph() \%>\%
-  add_full_graph(n = 10) \%>\%
+create_graph() |>
+  add_full_graph(n = 10) |>
   get_max_eccentricity()
 
 }

--- a/man/get_mean_distance.Rd
+++ b/man/get_mean_distance.Rd
@@ -20,17 +20,17 @@ pairs of nodes.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Determine the mean distance
-graph \%>\%
+graph |>
   get_mean_distance()
 
 # Create a full graph and then
 # get the mean distance value
-create_graph() \%>\%
-  add_full_graph(n = 10) \%>\%
+create_graph() |>
+  add_full_graph(n = 10) |>
   get_mean_distance()
 
 }

--- a/man/get_min_cut_between.Rd
+++ b/man/get_min_cut_between.Rd
@@ -29,12 +29,12 @@ set.seed(23)
 
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Determine the minimum cut
 # between nodes `1` and `4`
-graph \%>\%
+graph |>
   get_min_cut_between(
     from = 1,
     to = 2)
@@ -43,23 +43,23 @@ graph \%>\%
 # randomized values given to all
 # edges as the `capacity` attribute
 graph_capacity <-
-  create_graph() \%>\%
-  add_cycle(n = 5) \%>\%
-  select_edges() \%>\%
+  create_graph() |>
+  add_cycle(n = 5) |>
+  select_edges() |>
   set_edge_attrs_ws(
     edge_attr = capacity,
     value =
       rnorm(
-        n = count_edges(.),
+        n = 5,
         mean = 5,
-        sd = 1)) \%>\%
+        sd = 1)) |>
   clear_selection()
 
 # Determine the minimum cut
 # between nodes `1` and `4` for
 # this graph, where `capacity`is
 # set as an edge attribute
-graph_capacity \%>\%
+graph_capacity |>
   get_min_cut_between(
     from = 1,
     to = 2)
@@ -67,8 +67,8 @@ graph_capacity \%>\%
 # Create a full graph and then
 # get the minimum cut requirement
 # between nodes `2` and `8`
-create_graph() \%>\%
-  add_full_graph(n = 10) \%>\%
+create_graph() |>
+  add_full_graph(n = 10) |>
   get_min_cut_between(
     from = 2,
     to = 8)

--- a/man/get_min_eccentricity.Rd
+++ b/man/get_min_eccentricity.Rd
@@ -26,19 +26,19 @@ node in the graph.
 \examples{
 # Create a cycle graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Determine the graph's minimum
 # eccentricity
-graph \%>\%
+graph |>
   get_min_eccentricity()
 
 # Create a full graph and then
 # get the minimum eccentricity
 # value for that
-create_graph() \%>\%
-  add_full_graph(n = 10) \%>\%
+create_graph() |>
+  add_full_graph(n = 10) |>
   get_min_eccentricity()
 
 }

--- a/man/get_multiedge_count.Rd
+++ b/man/get_multiedge_count.Rd
@@ -41,6 +41,6 @@ graph <-
 # Get the total number of multiple
 # edges (those edges that share an
 # edge definition) in the graph
-graph \%>\% get_multiedge_count()
+graph |> get_multiedge_count()
 
 }

--- a/man/get_nbrs.Rd
+++ b/man/get_nbrs.Rd
@@ -21,29 +21,29 @@ With one or more nodes, get the set of all neighboring nodes.
 # Create a simple, directed graph with 5
 # nodes and 4 edges
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 5)
 
 # Find all neighbor nodes for node `2`
-graph \%>\% get_nbrs(nodes = 2)
+graph |> get_nbrs(nodes = 2)
 
 # Find all neighbor nodes for nodes `1`
 # and `5`
-graph \%>\% get_nbrs(nodes = c(1, 5))
+graph |> get_nbrs(nodes = c(1, 5))
 
 # Color node `3` with purple, get its
 # neighbors and color those nodes green
 graph <-
-  graph \%>\%
-  select_nodes_by_id(nodes = 3) \%>\%
+  graph |>
+  select_nodes_by_id(nodes = 3) |>
   set_node_attrs_ws(
     node_attr = color,
-    value = "purple") \%>\%
-  clear_selection() \%>\%
+    value = "purple") |>
+  clear_selection() |>
   select_nodes_by_id(
     nodes = get_nbrs(
-      graph = .,
-      nodes = 3)) \%>\%
+      graph = graph,
+      nodes = 3)) |>
   set_node_attrs_ws(
     node_attr = color,
     value = "green")

--- a/man/get_node_attrs.Rd
+++ b/man/get_node_attrs.Rd
@@ -26,11 +26,11 @@ or more nodes.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 4,
     m = 4,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = value,
     values = c(2.5, 8.2, 4.2, 2.4))
@@ -38,14 +38,14 @@ graph <-
 # Get all of the values from
 # the `value` node attribute
 # as a named vector
-graph \%>\%
+graph |>
   get_node_attrs(
     node_attr = value)
 
 # To only return node attribute
 # values for specified nodes,
 # use the `nodes` argument
-graph \%>\%
+graph |>
   get_node_attrs(
     node_attr = value,
     nodes = c(1, 3))

--- a/man/get_node_attrs_ws.Rd
+++ b/man/get_node_attrs_ws.Rd
@@ -36,11 +36,11 @@ Selections of nodes can also be performed using the following traversal
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 4,
     m = 4,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = value,
     values = c(2.5, 8.2, 4.2, 2.4))
@@ -48,14 +48,14 @@ graph <-
 # Select nodes with ID values
 # `1` and `3`
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_by_id(
     nodes = c(1, 3))
 
 # Get the node attribute values
 # for the `value` attribute, limited
 # to the current node selection
-graph \%>\%
+graph |>
   get_node_attrs_ws(
     node_attr = value)
 

--- a/man/get_node_df.Rd
+++ b/man/get_node_df.Rd
@@ -18,35 +18,35 @@ From a graph, obtain a node data frame with all current node attributes.
 \examples{
 # Create a graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 1,
-    type = "a") \%>\%
-  select_last_nodes_created() \%>\%
+    type = "a") |>
+  select_last_nodes_created() |>
   add_n_nodes_ws(
     n = 5,
     direction = "from",
-    type = "b") \%>\%
+    type = "b") |>
   select_nodes_by_id(
-    nodes = 1) \%>\%
+    nodes = 1) |>
   set_node_attrs_ws(
     node_attr = value,
-    value = 25.3) \%>\%
-  clear_selection() \%>\%
+    value = 25.3) |>
+  clear_selection() |>
   select_nodes_by_id(
-    nodes = 2:4) \%>\%
+    nodes = 2:4) |>
   set_node_attrs_ws(
     node_attr = color,
-    value = "grey70") \%>\%
-  invert_selection() \%>\%
+    value = "grey70") |>
+  invert_selection() |>
   set_node_attrs_ws(
     node_attr = color,
-    value = "grey80") \%>\%
+    value = "grey80") |>
   clear_selection()
 
 # Get the graph's internal node
 # data frame (ndf)
-graph \%>\%
+graph |>
   get_node_df()
 
 }

--- a/man/get_node_df_ws.Rd
+++ b/man/get_node_df_ws.Rd
@@ -33,11 +33,11 @@ Selections of nodes can also be performed using the following traversal
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 4,
     m = 4,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = value,
     values = c(2.5, 8.2, 4.2, 2.4))
@@ -45,13 +45,13 @@ graph <-
 # Select nodes with ID values
 # `1` and `3`
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_by_id(
     nodes = c(1, 3))
 
 # Get the node data frame that's
 # limited to the rows that correspond
 # to the node selection
-graph \%>\% get_node_df_ws()
+graph |> get_node_df_ws()
 
 }

--- a/man/get_node_ids.Rd
+++ b/man/get_node_ids.Rd
@@ -39,25 +39,25 @@ graph <-
     nodes_df = ndf)
 
 # Get a vector of all nodes in a graph
-graph \%>\% get_node_ids()
+graph |> get_node_ids()
 
 # Get a vector of node ID values using a
 # numeric comparison (i.e., all nodes with
 # `value` attribute greater than 3)
-graph \%>\%
+graph |>
   get_node_ids(
     conditions = value > 3)
 
 # Get a vector of node ID values using
 # a match pattern (i.e., all nodes with
 # `color` attribute of `green`)
-graph \%>\%
+graph |>
   get_node_ids(
     conditions = color == "green")
 
 # Use multiple conditions to return nodes
 # with the desired attribute values
-graph \%>\%
+graph |>
   get_node_ids(
     conditions =
       color == "blue" &

--- a/man/get_node_info.Rd
+++ b/man/get_node_info.Rd
@@ -20,12 +20,12 @@ interrelationships within the graph.
 \examples{
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5, m = 10,
     set_seed = 23)
 
 # Get information on the graph's nodes
-graph \%>\% get_node_info()
+graph |> get_node_info()
 
 }

--- a/man/get_non_nbrs.Rd
+++ b/man/get_non_nbrs.Rd
@@ -21,10 +21,10 @@ Get the set of all nodes not neighboring a single graph node.
 # Create a simple, directed graph with 5
 # nodes and 4 edges
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 5)
 
 # Find all non-neighbors of node `2`
-graph \%>\% get_non_nbrs(node = 2)
+graph |> get_non_nbrs(node = 2)
 
 }

--- a/man/get_pagerank.Rd
+++ b/man/get_pagerank.Rd
@@ -24,7 +24,7 @@ Get the PageRank values for all nodes in the graph.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -32,15 +32,15 @@ graph <-
 
 # Get the PageRank scores
 # for all nodes in the graph
-graph \%>\%
+graph |>
   get_pagerank()
 
 # Colorize nodes according to their
 # PageRank scores
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_pagerank(graph = .)) \%>\%
+    df = get_pagerank(graph)) |>
   colorize_node_attrs(
     node_attr_from = pagerank,
     node_attr_to = fillcolor,

--- a/man/get_paths.Rd
+++ b/man/get_paths.Rd
@@ -40,34 +40,34 @@ graph.
 \examples{
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 8) \%>\%
-  add_edge(from = 1, to = 2) \%>\%
-  add_edge(from = 1, to = 3) \%>\%
-  add_edge(from = 3, to = 4) \%>\%
-  add_edge(from = 3, to = 5) \%>\%
-  add_edge(from = 4, to = 6) \%>\%
-  add_edge(from = 2, to = 7) \%>\%
-  add_edge(from = 7, to = 5) \%>\%
+  create_graph() |>
+  add_n_nodes(n = 8) |>
+  add_edge(from = 1, to = 2) |>
+  add_edge(from = 1, to = 3) |>
+  add_edge(from = 3, to = 4) |>
+  add_edge(from = 3, to = 5) |>
+  add_edge(from = 4, to = 6) |>
+  add_edge(from = 2, to = 7) |>
+  add_edge(from = 7, to = 5) |>
   add_edge(from = 4, to = 8)
 
 # Get a list of all paths outward from node `1`
-graph \%>\%
+graph |>
   get_paths(from = 1)
 
 # Get a list of all paths leading to node `6`
-graph \%>\%
+graph |>
   get_paths(to = 6)
 
 # Get a list of all paths from `1` to `5`
-graph \%>\%
+graph |>
   get_paths(
    from = 1,
    to = 5)
 
 # Get a list of all paths from `1` up to a distance
 # of 2 node traversals
-graph \%>\%
+graph |>
   get_paths(
     from = 1,
     distance = 2)

--- a/man/get_periphery.Rd
+++ b/man/get_periphery.Rd
@@ -20,11 +20,11 @@ eccentricity in the graph).
 # Create a random graph using the
 # `add_gnm_graph()` function and
 # get the nodes in the graph periphery
-create_graph() \%>\%
+create_graph() |>
   add_gnm_graph(
     n = 28,
     m = 35,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   get_periphery()
 
 }

--- a/man/get_predecessors.Rd
+++ b/man/get_predecessors.Rd
@@ -44,13 +44,13 @@ graph <-
 
 # Get predecessors for node
 # `23` in the graph
-graph \%>\%
+graph |>
   get_predecessors(
     node = 23)
 
 # If there are no predecessors,
 # `NA` is returned
-graph \%>\%
+graph |>
   get_predecessors(
     node = 26)
 

--- a/man/get_radiality.Rd
+++ b/man/get_radiality.Rd
@@ -25,26 +25,26 @@ the ease to which nodes can reach other nodes.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 15,
     set_seed = 23)
 
 # Get the radiality scores for nodes in the graph
-graph \%>\%
+graph |>
   get_radiality()
 
 # Add the radiality values
 # to the graph as a node
 # attribute
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_radiality(.))
+    df = get_radiality(graph))
 
 # Display the graph's node data frame
-graph \%>\%
+graph |>
   get_node_df()
 
 }

--- a/man/get_reciprocity.Rd
+++ b/man/get_reciprocity.Rd
@@ -23,11 +23,11 @@ reciprocal. This function does not consider loop edges (e.g., \code{1} -> \code{
 # Define a graph where 2 edge definitions
 # have pairs of reciprocal edges
 graph <-
-  create_graph() \%>\%
-  add_cycle(n = 3) \%>\%
+  create_graph() |>
+  add_cycle(n = 3) |>
   add_node(
     from = 1,
-      to = 1) \%>\%
+      to = 1) |>
   add_node(
     from = 1,
       to = 1)
@@ -37,22 +37,22 @@ graph <-
 # 4 is the number reciprocating edges
 # and 7 is the total number of edges
 # in the graph)
-graph \%>\%
+graph |>
   get_reciprocity()
 
 # For an undirected graph, all edges
 # are reciprocal, so the ratio will
 # always be 1
-graph \%>\%
-  set_graph_undirected() \%>\%
+graph |>
+  set_graph_undirected() |>
   get_reciprocity()
 
 # For a graph with no edges, the graph
 # reciprocity cannot be determined (and
 # the same NA result is obtained from an
 # empty graph)
-create_graph() \%>\%
-  add_n_nodes(n = 5) \%>\%
+create_graph() |>
+  add_n_nodes(n = 5) |>
   get_reciprocity()
 
 }

--- a/man/get_s_connected_cmpts.Rd
+++ b/man/get_s_connected_cmpts.Rd
@@ -25,30 +25,33 @@ set.seed(23)
 # connection between 2 different
 # node cycles
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(
     n = 3,
-    type = "cycle_1") \%>\%
+    type = "cycle_1") |>
   add_cycle(
     n = 4,
-    type = "cycle_2") \%>\%
+    type = "cycle_2")
+
+graph <-
+  graph |>
   add_edge(
     from =
       get_node_ids(
-        graph = .,
+        graph = graph,
         conditions =
-          type == "cycle_1") \%>\%
+          type == "cycle_1") |>
         sample(size = 1),
     to =
       get_node_ids(
-        graph = .,
+        graph = graph,
         conditions =
-          type == "cycle_2") \%>\%
+          type == "cycle_2") |>
         sample(size = 1))
 
 # Get the strongly connected
 # components as a data frame of
 # nodes and their groupings
-graph \%>\% get_s_connected_cmpts()
+graph |> get_s_connected_cmpts()
 
 }

--- a/man/get_selection.Rd
+++ b/man/get_selection.Rd
@@ -19,7 +19,7 @@ class \code{dgr_graph}.
 \examples{
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 6)
 
 # Select node `4`, then select
@@ -27,19 +27,19 @@ graph <-
 # from node `4`, and finally
 # return the selection of nodes as
 # a vector object
-graph \%>\%
-  select_nodes(nodes = 4) \%>\%
+graph |>
+  select_nodes(nodes = 4) |>
   select_nodes_in_neighborhood(
     node = 4,
-    distance = 1) \%>\%
+    distance = 1) |>
   get_selection()
 
 # Select edges associated with
 # node `4` and return the
 # selection of edges
-graph \%>\%
+graph |>
   select_edges_by_node_id(
-    nodes = 4) \%>\%
+    nodes = 4) |>
   get_selection()
 
 }

--- a/man/get_similar_nbrs.Rd
+++ b/man/get_similar_nbrs.Rd
@@ -41,23 +41,23 @@ node.
 # graph with 18 nodes and 22 edges
 # using the `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 18,
     m = 25,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 18,
       mean = 5,
-      sd = 1) \%>\% round(0))
+      sd = 1) |> round(0))
 
 # Starting with node `10`, we
 # can test whether any nodes
 # adjacent and beyond are
 # numerically equivalent in `value`
-graph \%>\%
+graph |>
   get_similar_nbrs(
     node = 10,
     node_attr = value)
@@ -73,7 +73,7 @@ graph \%>\%
 # with a fairly large range to
 # determine if several nodes can be
 # selected
-graph \%>\%
+graph |>
   get_similar_nbrs(
     node = 10,
     node_attr = value,
@@ -85,11 +85,11 @@ graph \%>\%
 # to be very large will effectively
 # return all nodes in the graph
 # except for the starting node
-graph \%>\%
+graph |>
   get_similar_nbrs(
     node = 10,
     node_attr = value,
-    tol_abs = c(10, 10)) \%>\%
+    tol_abs = c(10, 10)) |>
     length()
 
 }

--- a/man/get_successors.Rd
+++ b/man/get_successors.Rd
@@ -44,13 +44,13 @@ graph <-
 
 # Get sucessors for node
 # `4` in the graph
-graph \%>\%
+graph |>
   get_successors(
     node = 4)
 
 # If there are no successors,
 # NA is returned
-graph \%>\%
+graph |>
   get_successors(
     node = 1)
 

--- a/man/get_w_connected_cmpts.Rd
+++ b/man/get_w_connected_cmpts.Rd
@@ -21,16 +21,16 @@ each node in the set).
 \examples{
 # Create a graph with 2 cycles
 graph <-
-  create_graph() \%>\%
-  add_cycle(n = 4) \%>\%
+  create_graph() |>
+  add_cycle(n = 4) |>
   add_cycle(n = 3)
 
 # Check if the graph is connected
-graph \%>\%
+graph |>
   is_graph_connected()
 
 # Get the graph's weakly-connected
 # components
-graph \%>\% get_w_connected_cmpts()
+graph |> get_w_connected_cmpts()
 
 }

--- a/man/import_graph.Rd
+++ b/man/import_graph.Rd
@@ -72,11 +72,11 @@ gml_graph <-
       package = "DiagrammeR"))
 
 # Get a count of the graph's nodes
-gml_graph \%>\%
+gml_graph |>
   count_nodes()
 
 # Get a count of the graph's edges
-gml_graph \%>\%
+gml_graph |>
   count_edges()
 }
 

--- a/man/invert_selection.Rd
+++ b/man/invert_selection.Rd
@@ -39,21 +39,21 @@ graph <-
 # Select nodes with ID
 # values `1` and `3`
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes(
     nodes = c(1, 3))
 
 # Verify that a node
 # selection has been made
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Invert the selection
 graph <-
-  graph \%>\%
+  graph |>
   invert_selection()
 
 # Verify that the node
 # selection has been changed
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/is_edge_loop.Rd
+++ b/man/is_edge_loop.Rd
@@ -21,25 +21,25 @@ Determines whether an edge definition is a loop edge.
 # Create a graph that has multiple
 # loop edges
 graph <-
-  create_graph() \%>\%
-  add_path(n = 4) \%>\%
+  create_graph() |>
+  add_path(n = 4) |>
   add_edge(
     from = 1,
-    to = 1) \%>\%
+    to = 1) |>
   add_edge(
     from = 3,
     to = 3)
 
 # Get the graph's internal
 # edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Determine if edge `4` is
 # a loop edge
-graph \%>\% is_edge_loop(edge = 4)
+graph |> is_edge_loop(edge = 4)
 
 # Determine if edge `2` is
 # a loop edge
-graph \%>\% is_edge_loop(edge = 2)
+graph |> is_edge_loop(edge = 2)
 
 }

--- a/man/is_edge_multiple.Rd
+++ b/man/is_edge_multiple.Rd
@@ -22,27 +22,27 @@ the same node pair.
 # Create a graph that has multiple
 # edges across some node pairs
 graph <-
-  create_graph() \%>\%
-  add_path(n = 4) \%>\%
+  create_graph() |>
+  add_path(n = 4) |>
   add_edge(
     from = 1,
-    to = 2) \%>\%
+    to = 2) |>
   add_edge(
     from = 3,
     to = 4)
 
 # Get the graph's internal
 # edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Determine if edge `1` is
 # a multiple edge
-graph \%>\%
+graph |>
   is_edge_multiple(edge = 1)
 
 # Determine if edge `2` is
 # a multiple edge
-graph \%>\%
+graph |>
   is_edge_multiple(edge = 2)
 
 }

--- a/man/is_edge_mutual.Rd
+++ b/man/is_edge_mutual.Rd
@@ -22,27 +22,27 @@ node pair.
 # Create a graph that has mutual
 # edges across some node pairs
 graph <-
-  create_graph() \%>\%
-  add_path(n = 4) \%>\%
+  create_graph() |>
+  add_path(n = 4) |>
   add_edge(
     from = 4,
-    to = 3) \%>\%
+    to = 3) |>
   add_edge(
     from = 2,
     to = 1)
 
 # Get the graph's internal
 # edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Determine if edge `1` has
 # a mutual edge
-graph \%>\%
+graph |>
   is_edge_mutual(edge = 1)
 
 # Determine if edge `2` has
 # a mutual edge
-graph \%>\%
+graph |>
   is_edge_mutual(edge = 2)
 
 }

--- a/man/is_edge_present.Rd
+++ b/man/is_edge_present.Rd
@@ -32,7 +32,7 @@ by a pair of node IDs or node label values) is present.
 # Create a simple graph with
 # a path of four nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 4,
     type = "path",
@@ -41,19 +41,19 @@ graph <-
 
 # Find out if edge ID `3`
 # is present in the graph
-graph \%>\%
+graph |>
   is_edge_present(edge = 3)
 
 # Determine if there are any edges
 # with the definition `1` -> `2`
-graph \%>\%
+graph |>
   is_edge_present(
     from = 1,
     to = 2)
 
 # Determine if there are any edges
 # with the definition `4` -> `5`
-graph \%>\%
+graph |>
   is_edge_present(
     from = 4,
     to = 5)
@@ -62,7 +62,7 @@ graph \%>\%
 # defined by its labels as
 # `two` -> `three`, exists in
 # the graph
-graph \%>\%
+graph |>
   is_edge_present(
     from = "two",
     to = "three")
@@ -71,8 +71,8 @@ graph \%>\%
 # and determine whether an
 # edge between nodes with labels
 # `three` and `two` exists
-graph \%>\%
-  set_graph_undirected() \%>\%
+graph |>
+  set_graph_undirected() |>
   is_edge_present(
     from = "three",
     to = "two")

--- a/man/is_graph_connected.Rd
+++ b/man/is_graph_connected.Rd
@@ -19,20 +19,20 @@ Determines whether a graph is a connected graph.
 # Create a random graph using the
 # `add_gnm_graph()` function; this
 # graph is not connected
-create_graph() \%>\%
+create_graph() |>
   add_gnm_graph(
     n = 15,
     m = 10,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   is_graph_connected()
 
 # Create another random graph;
 # this graph is connected
-create_graph() \%>\%
+create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 15,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   is_graph_connected()
 
 }

--- a/man/is_graph_dag.Rd
+++ b/man/is_graph_dag.Rd
@@ -21,37 +21,37 @@ directed graph and it should not contain any cycles.
 # Create a directed graph containing
 # only a balanced tree
 graph_tree <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
     k = 2, h = 3)
 
 # Determine whether this graph
 # is a DAG
-graph_tree \%>\%
+graph_tree |>
   is_graph_dag()
 
 # Create a directed graph containing
 # a single cycle
 graph_cycle <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Determine whether this graph
 # is a DAG
-graph_cycle \%>\%
+graph_cycle |>
   is_graph_dag()
 
 # Create an undirected graph
 # containing a balanced tree
 graph_tree_undirected <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_balanced_tree(
     k = 2, h = 2)
 
 # Determine whether this graph
 # is a DAG
-graph_tree_undirected \%>\%
+graph_tree_undirected |>
   is_graph_dag()
 
 }

--- a/man/is_graph_directed.Rd
+++ b/man/is_graph_directed.Rd
@@ -24,13 +24,13 @@ graph <- create_graph()
 
 # Determine whether the graph
 # is directed
-graph \%>\% is_graph_directed()
+graph |> is_graph_directed()
 
 # Use the `set_graph_undirected()`
 # function and check again whether
 # the graph is directed
-graph \%>\%
-  set_graph_undirected() \%>\%
+graph |>
+  set_graph_undirected() |>
   is_graph_directed()
 
 }

--- a/man/is_graph_empty.Rd
+++ b/man/is_graph_empty.Rd
@@ -21,14 +21,14 @@ nodes).
 graph <- create_graph()
 
 # Determine whether the graph is empty
-graph \%>\% is_graph_empty()
+graph |> is_graph_empty()
 
 # Create a non-empty graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(n = 3)
 
 # Determine whether this graph is empty
-graph \%>\% is_graph_empty()
+graph |> is_graph_empty()
 
 }

--- a/man/is_graph_simple.Rd
+++ b/man/is_graph_simple.Rd
@@ -19,11 +19,11 @@ does not contain any loops nor any multiple edges.
 \examples{
 # Create a graph with 2 cycles
 graph <-
-  create_graph() \%>\%
-  add_cycle(n = 4) \%>\%
+  create_graph() |>
+  add_cycle(n = 4) |>
   add_cycle(n = 3)
 
 # Check if the graph is simple
-graph \%>\% is_graph_simple()
+graph |> is_graph_simple()
 
 }

--- a/man/is_graph_undirected.Rd
+++ b/man/is_graph_undirected.Rd
@@ -29,14 +29,14 @@ graph <-
 
 # Determine whether the
 # graph is undirected
-graph \%>\% is_graph_undirected()
+graph |> is_graph_undirected()
 
 # Use the `set_graph_directed()`
 # function and check again
 # as to whether the graph is
 # undirected
-graph \%>\%
-  set_graph_directed() \%>\%
+graph |>
+  set_graph_directed() |>
   is_graph_undirected()
 
 }

--- a/man/is_graph_weighted.Rd
+++ b/man/is_graph_weighted.Rd
@@ -21,26 +21,26 @@ considered to be weighted when it contains edges that all have a edge
 # Create a graph where the edges have
 # a `weight` attribute
 graph <-
-  create_graph() \%>\%
-  add_cycle(n = 5) \%>\%
-  select_edges() \%>\%
+  create_graph() |>
+  add_cycle(n = 5) |>
+  select_edges() |>
   set_edge_attrs_ws(
     edge_attr = weight,
-    value = c(3, 5, 2, 9, 6)) \%>\%
+    value = c(3, 5, 2, 9, 6)) |>
   clear_selection()
 
 # Determine whether the graph
 # is a weighted graph
-graph \%>\% is_graph_weighted()
+graph |> is_graph_weighted()
 
 # Create graph where the edges do
 # not have a `weight` attribute
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 # Determine whether this graph
 # is weighted
-graph \%>\% is_graph_weighted()
+graph |> is_graph_weighted()
 
 }

--- a/man/is_node_present.Rd
+++ b/man/is_node_present.Rd
@@ -23,7 +23,7 @@ is present.
 # Create a simple graph with
 # a path of four nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 4,
     type = "path",
@@ -33,16 +33,16 @@ graph <-
 
 # Determine if there is a node
 # with ID `1` in the graph
-graph \%>\%
+graph |>
   is_node_present(node = 1)
 
 # Determine if there is a node
 # with ID `5` in the graph
-graph \%>\%
+graph |>
   is_node_present(node = 5)
 
 # Determine if there is a node
 # with label `two` in the graph
-graph \%>\%
+graph |>
   is_node_present(node = "two")
 }

--- a/man/is_property_graph.Rd
+++ b/man/is_property_graph.Rd
@@ -22,13 +22,13 @@ value).
 # (with `type` values) and a
 # single edge (with a `rel`)
 simple_property_graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_node(
     type = "a",
-    label = "first") \%>\%
+    label = "first") |>
   add_node(
     type = "b",
-    label = "second") \%>\%
+    label = "second") |>
   add_edge(
     from = "first",
     to = "second",
@@ -42,15 +42,15 @@ is_property_graph(simple_property_graph)
 # If a `type` attribute is
 # removed, then this graph will
 # no longer be a property graph
-simple_property_graph \%>\%
+simple_property_graph |>
   set_node_attrs(
     node_attr = type,
     values = NA,
-    nodes = 1) \%>\%
+    nodes = 1) |>
   is_property_graph()
 
 # An empty graph will return FALSE
-create_graph() \%>\%
+create_graph() |>
   is_property_graph()
 
 }

--- a/man/join_edge_attrs.Rd
+++ b/man/join_edge_attrs.Rd
@@ -36,8 +36,8 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 5) \%>\%
+  create_graph() |>
+  add_n_nodes(n = 5) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5")
 
@@ -55,13 +55,13 @@ df <-
 # identically-named columns in the graph and the df
 # (in this case `from` and `to` are common to both)
 graph <-
-  graph \%>\%
+  graph |>
   join_edge_attrs(
     df = df)
 
 # Get the graph's internal edf to show that the
 # join has been made
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 }
 \seealso{
 Other edge creation and removal: 

--- a/man/join_node_attrs.Rd
+++ b/man/join_node_attrs.Rd
@@ -36,8 +36,8 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
-  add_n_nodes(n = 5) \%>\%
+  create_graph() |>
+  add_n_nodes(n = 5) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5")
 
@@ -53,26 +53,26 @@ df <-
 # identically-named columns in the graph and the df
 # (in this case the `id` column is common to both)
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
     df = df)
 
 # Get the graph's internal ndf to show that the
 # join has been made
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Get betweenness values for each node and
 # add them as a node attribute (Note the
 # common column name `id` in the different
 # tables results in a natural join)
 graph <-
-  graph \%>\%
+  graph |>
   join_node_attrs(
-    df = get_betweenness(.))
+    df = get_betweenness(graph))
 
 # Get the graph's internal ndf to show that
 # this join has been made
-graph \%>\% get_node_df()
+graph |> get_node_df()
 }
 \seealso{
 Other node creation and removal: 

--- a/man/layout_nodes_w_string.Rd
+++ b/man/layout_nodes_w_string.Rd
@@ -53,13 +53,13 @@ option is available to apply sorting to each of the groups.
 # Create a graph with unique labels and
 # several node `type` groupings
 graph <-
-  create_graph() \%>\%
-  add_node(type = "a", label = "a") \%>\%
-  add_node(type = "a", label = "b") \%>\%
-  add_node(type = "b", label = "c") \%>\%
-  add_node(type = "b", label = "d") \%>\%
-  add_node(type = "b", label = "e") \%>\%
-  add_node(type = "c", label = "f") \%>\%
+  create_graph() |>
+  add_node(type = "a", label = "a") |>
+  add_node(type = "a", label = "b") |>
+  add_node(type = "b", label = "c") |>
+  add_node(type = "b", label = "d") |>
+  add_node(type = "b", label = "e") |>
+  add_node(type = "c", label = "f") |>
   add_node(type = "c", label = "g")
 
 # Define a 'layout' for groups of nodes
@@ -84,7 +84,7 @@ layout <-
 # we should sort the collection of node
 # before adding position information
 graph <-
-  graph \%>\%
+  graph |>
   layout_nodes_w_string(
     layout = layout,
     nodes = c("1" = "type:a",
@@ -97,7 +97,7 @@ graph <-
 # Show the graph's node data frame
 # to confirm that `x` and `y` values
 # were added to each of the nodes
-graph \%>\% get_node_df()
+graph |> get_node_df()
 }
 \seealso{
 Other node creation and removal: 

--- a/man/mutate_edge_attrs.Rd
+++ b/man/mutate_edge_attrs.Rd
@@ -25,8 +25,8 @@ attribute values using one or more expressions.
 \examples{
 # Create a graph with 3 edges
 graph <-
-  create_graph() \%>\%
-  add_path(n = 4) \%>\%
+  create_graph() |>
+  add_path(n = 4) |>
   set_edge_attrs(
     edge_attr = width,
     values = c(3.4, 2.3, 7.2))
@@ -34,13 +34,13 @@ graph <-
 # Get the graph's internal edf
 # to show which edge attributes
 # are available
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Mutate the `width` edge
 # attribute, dividing each
 # value by 2
 graph <-
-  graph \%>\%
+  graph |>
   mutate_edge_attrs(
     width = width / 2)
 
@@ -48,7 +48,7 @@ graph <-
 # edf to show that the edge
 # attribute `width` had its
 # values changed
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Create a new edge attribute,
 # called `length`, that is the
@@ -56,22 +56,22 @@ graph \%>\% get_edge_df()
 # 2 (and, also, round all values
 # to 2 decimal places)
 graph <-
-  graph \%>\%
+  graph |>
   mutate_edge_attrs(
-    length = (log(width) + 2) \%>\%
+    length = (log(width) + 2) |>
                round(2))
 
 # Get the graph's internal edf
 # to show that the edge attribute
 # values had been mutated
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Create a new edge attribute
 # called `area`, which is the
 # product of the `width` and
 # `length` attributes
 graph <-
-  graph \%>\%
+  graph |>
   mutate_edge_attrs(
     area = width * length)
 
@@ -79,7 +79,7 @@ graph <-
 # to show that the edge attribute
 # values had been multiplied
 # together (with new attr `area`)
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/mutate_edge_attrs_ws.Rd
+++ b/man/mutate_edge_attrs_ws.Rd
@@ -37,17 +37,17 @@ Selections of edges can also be performed using the following traversal
 # Create a graph with 3 edges
 # and then select edge `1`
 graph <-
-  create_graph() \%>\%
-  add_path(n = 4) \%>\%
+  create_graph() |>
+  add_path(n = 4) |>
   set_edge_attrs(
     edge_attr = width,
-    values = c(3.4, 2.3, 7.2)) \%>\%
+    values = c(3.4, 2.3, 7.2)) |>
   select_edges(edges = 1)
 
 # Get the graph's internal edf
 # to show which edge attributes
 # are available
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Mutate the `width` edge
 # attribute for the edges
@@ -56,7 +56,7 @@ graph \%>\% get_edge_df()
 # we divide each value in the
 # selection by 2
 graph <-
-  graph \%>\%
+  graph |>
   mutate_edge_attrs_ws(
     width = width / 2)
 
@@ -64,7 +64,7 @@ graph <-
 # edf to show that the edge
 # attribute `width` had its
 # values changed
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Create a new edge attribute,
 # called `length`, that is the
@@ -72,11 +72,11 @@ graph \%>\% get_edge_df()
 # 2 (and, also, round all values
 # to 2 decimal places)
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
-  select_edges(edges = 2:3) \%>\%
+  graph |>
+  clear_selection() |>
+  select_edges(edges = 2:3) |>
   mutate_edge_attrs_ws(
-    length = (log(width) + 2) \%>\%
+    length = (log(width) + 2) |>
                round(2))
 
 # Get the graph's internal edf
@@ -85,14 +85,14 @@ graph <-
 # for edges `2` and `3` (since
 # edge `1` is excluded, an NA
 # value is applied)
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Create a new edge attribute
 # called `area`, which is the
 # product of the `width` and
 # `length` attributes
 graph <-
-  graph \%>\%
+  graph |>
   mutate_edge_attrs_ws(
     area = width * length)
 
@@ -101,17 +101,17 @@ graph <-
 # values had been multiplied
 # together (with new attr `area`)
 # for nodes `2` and `3`
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # We can invert the selection
 # and mutate edge `1` several
 # times to get an `area` value
 # for that edge
 graph <-
-  graph \%>\%
-  invert_selection() \%>\%
+  graph |>
+  invert_selection() |>
   mutate_edge_attrs_ws(
-    length = (log(width) + 5) \%>\%
+    length = (log(width) + 5) |>
                round(2),
     area = width * length)
 
@@ -121,7 +121,7 @@ graph <-
 # non-NA values for its edge
 # attributes without changing
 # those of the other edges
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/mutate_node_attrs.Rd
+++ b/man/mutate_node_attrs.Rd
@@ -25,8 +25,8 @@ attribute values using one or more expressions.
 \examples{
 # Create a graph with 3 nodes
 graph <-
-  create_graph() \%>\%
-  add_path(n = 3) \%>\%
+  create_graph() |>
+  add_path(n = 3) |>
   set_node_attrs(
     node_attr = width,
     values = c(1.4, 0.3, 1.1))
@@ -34,13 +34,13 @@ graph <-
 # Get the graph's internal ndf
 # to show which node attributes
 # are available
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Mutate the `width` node
 # attribute, dividing each
 # value by 2
 graph <-
-  graph \%>\%
+  graph |>
   mutate_node_attrs(
     width = width / 2)
 
@@ -48,7 +48,7 @@ graph <-
 # ndf to show that the node
 # attribute `width` had its
 # values changed
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create a new node attribute,
 # called `length`, that is the
@@ -56,22 +56,22 @@ graph \%>\% get_node_df()
 # 2 (and, also, round all values
 # to 2 decimal places)
 graph <-
-  graph \%>\%
+  graph |>
   mutate_node_attrs(
-    length = (log(width) + 2) \%>\%
+    length = (log(width) + 2) |>
                round(2))
 
 # Get the graph's internal ndf
 # to show that the node attribute
 # values had been mutated
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create a new node attribute
 # called `area`, which is the
 # product of the `width` and
 # `length` attributes
 graph <-
-  graph \%>\%
+  graph |>
   mutate_node_attrs(
     area = width * length)
 
@@ -79,7 +79,7 @@ graph <-
 # to show that the node attribute
 # values had been multiplied
 # together (with new attr `area`)
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/mutate_node_attrs_ws.Rd
+++ b/man/mutate_node_attrs_ws.Rd
@@ -39,17 +39,17 @@ Selections of nodes can also be performed using the following traversal
 # Create a graph with 3 nodes
 # and then select node `1`
 graph <-
-  create_graph() \%>\%
-  add_path(n = 3) \%>\%
+  create_graph() |>
+  add_path(n = 3) |>
   set_node_attrs(
     node_attr = width,
-    values = c(1.4, 0.3, 1.1)) \%>\%
+    values = c(1.4, 0.3, 1.1)) |>
   select_nodes(nodes = 1)
 
 # Get the graph's internal ndf
 # to show which node attributes
 # are available
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Mutate the `width` node
 # attribute for the nodes
@@ -58,7 +58,7 @@ graph \%>\% get_node_df()
 # we divide each value in the
 # selection by 2
 graph <-
-  graph \%>\%
+  graph |>
   mutate_node_attrs_ws(
     width = width / 2)
 
@@ -66,7 +66,7 @@ graph <-
 # ndf to show that the node
 # attribute `width` was
 # mutated only for node `1`
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create a new node attribute,
 # called `length`, that is the
@@ -74,11 +74,11 @@ graph \%>\% get_node_df()
 # 2 (and, also, round all values
 # to 2 decimal places)
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
-  select_nodes(nodes = 2:3) \%>\%
+  graph |>
+  clear_selection() |>
+  select_nodes(nodes = 2:3) |>
   mutate_node_attrs_ws(
-    length = (log(width) + 2) \%>\%
+    length = (log(width) + 2) |>
                round(2))
 
 # Get the graph's internal ndf
@@ -87,14 +87,14 @@ graph <-
 # for nodes `2` and `3` (since
 # node `1` is excluded, an NA
 # value is applied)
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create a new node attribute
 # called `area`, which is the
 # product of the `width` and
 # `length` attributes
 graph <-
-  graph \%>\%
+  graph |>
   mutate_node_attrs_ws(
     area = width * length)
 
@@ -103,17 +103,17 @@ graph <-
 # values had been multiplied
 # together (with new attr `area`)
 # for nodes `2` and `3`
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # We can invert the selection
 # and mutate node `1` several
 # times to get an `area` value
 # for that node
 graph <-
-  graph \%>\%
-  invert_selection() \%>\%
+  graph |>
+  invert_selection() |>
   mutate_node_attrs_ws(
-    length = (log(width) + 5) \%>\%
+    length = (log(width) + 5) |>
                round(2),
     area = width * length)
 
@@ -123,7 +123,7 @@ graph <-
 # non-NA values for its node
 # attributes without changing
 # those of the other nodes
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/node_aes.Rd
+++ b/man/node_aes.Rd
@@ -145,7 +145,7 @@ created.
 # a path with several node
 # aesthetic attributes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 3,
     type = "path",
@@ -160,12 +160,12 @@ graph <-
 # node data frame; the node
 # aesthetic attributes have
 # been inserted
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create a new graph which is
 # fully connected
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_full_graph(
     n = 4,
     node_data = node_data(value = 1:4),

--- a/man/node_data.Rd
+++ b/man/node_data.Rd
@@ -19,7 +19,7 @@ created.
 # a path with several node
 # data attributes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 3,
     type = "path",
@@ -31,7 +31,7 @@ graph <-
 # node data frame; the node
 # data attributes have been
 # inserted
-graph \%>\% get_node_df()
+graph |> get_node_df()
 }
 \seealso{
 Other node creation and removal: 

--- a/man/nudge_node_positions_ws.Rd
+++ b/man/nudge_node_positions_ws.Rd
@@ -42,16 +42,16 @@ Selections of nodes can also be performed using the following traversal
 \examples{
 # Create a simple graph with 4 nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_node(
     type = "a",
-    label = "one") \%>\%
+    label = "one") |>
   add_node(
     type = "a",
-    label = "two") \%>\%
+    label = "two") |>
   add_node(
     type = "b",
-    label = "three") \%>\%
+    label = "three") |>
   add_node(
     type = "b",
     label = "four")
@@ -59,13 +59,13 @@ graph <-
 # Add position information to each of
 # the graph's nodes
 graph <-
-  graph \%>\%
+  graph |>
   set_node_position(
-    node = 1, x = 1, y = 1) \%>\%
+    node = 1, x = 1, y = 1) |>
   set_node_position(
-    node = 2, x = 2, y = 2) \%>\%
+    node = 2, x = 2, y = 2) |>
   set_node_position(
-    node = 3, x = 3, y = 3) \%>\%
+    node = 3, x = 3, y = 3) |>
   set_node_position(
     node = 4, x = 4, y = 4)
 
@@ -77,26 +77,26 @@ graph <- select_nodes(graph)
 # Move the selected nodes (all the nodes,
 # in this case) 5 units to the right
 graph <-
-  graph \%>\%
+  graph |>
   nudge_node_positions_ws(
     dx = 5, dy = 0)
 
 # View the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Now select nodes that have `type == "b"`
 # and move them in the `y` direction 2 units
 # (the graph still has an active selection
 # and so it must be cleared first)
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
+  graph |>
+  clear_selection() |>
   select_nodes(
-    conditions = type == "b") \%>\%
+    conditions = type == "b") |>
   nudge_node_positions_ws(
     dx = 0, dy = 2)
 
 # View the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/open_graph.Rd
+++ b/man/open_graph.Rd
@@ -19,7 +19,7 @@ Load a graph or a graph series object from disk.
 # a probability value of 0.05
 gnp_graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnp_graph(
     n = 100,
     p = 0.05

--- a/man/print.dgr_graph.Rd
+++ b/man/print.dgr_graph.Rd
@@ -17,7 +17,7 @@ This function will provide a summary of the graph.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 15,

--- a/man/recode_edge_attrs.Rd
+++ b/man/recode_edge_attrs.Rd
@@ -40,11 +40,11 @@ any unmatched mappings.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 4,
     m = 6,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_edge_attrs(
     edge_attr = rel,
     values = c("a", "b", "a",
@@ -53,7 +53,7 @@ graph <-
 # Get the graph's internal edf
 # to show which edge attributes
 # are available
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Recode the `rel` node
 # attribute, creating a new edge
@@ -62,7 +62,7 @@ graph \%>\% get_edge_df()
 # `b` maps to `1.5`, and all
 # other values become `0.5`
 graph <-
-  graph \%>\%
+  graph |>
   recode_edge_attrs(
     edge_attr_from = rel,
     "a -> 1.0",
@@ -75,7 +75,7 @@ graph <-
 # attribute values had been
 # recoded and copied into a
 # new node attribute
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/recode_node_attrs.Rd
+++ b/man/recode_node_attrs.Rd
@@ -40,11 +40,11 @@ any unmatched mappings.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 10,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = shape,
     values =
@@ -55,14 +55,14 @@ graph <-
 # Get the graph's internal ndf
 # to show which node
 # attributes are available
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Recode the `shape` node
 # attribute, so that `circle`
 # is recoded to `square` and that
 # `rectangle` becomes `triangle`
 graph <-
-  graph \%>\%
+  graph |>
   recode_node_attrs(
     node_attr_from = shape,
     "circle -> square",
@@ -71,7 +71,7 @@ graph <-
 # Get the graph's internal
 # ndf to show that the node
 # attribute values had been recoded
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Create a new node attribute,
 # called `color`, that is based
@@ -80,7 +80,7 @@ graph \%>\% get_node_df()
 # color and map all other shapes
 # to a `green` color
 graph <-
-  graph \%>\%
+  graph |>
   recode_node_attrs(
     node_attr_from = shape,
     "square -> red",
@@ -89,7 +89,7 @@ graph <-
 
 # Get the graph's internal ndf
 # to see the change
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/remove_graph_from_graph_series.Rd
+++ b/man/remove_graph_from_graph_series.Rd
@@ -23,39 +23,39 @@ graph series object.
 \examples{
 # Create three graphs
 graph_1 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 4)
 
 graph_2 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 graph_3 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_star(n = 6)
 
 # Create an empty graph series
 # and add the graphs
 series <-
-  create_graph_series() \%>\%
+  create_graph_series() |>
   add_graph_to_graph_series(
-    graph = graph_1) \%>\%
+    graph = graph_1) |>
   add_graph_to_graph_series(
-    graph = graph_2) \%>\%
+    graph = graph_2) |>
   add_graph_to_graph_series(
     graph = graph_3)
 
 # Remove the second graph
 # from the graph series
 series <-
-  series \%>\%
+  series |>
   remove_graph_from_graph_series(
     index = 2)
 
 # With `get_graph_series_info()`,
 # we can ensure that a graph
 # was removed
-series \%>\%
+series |>
   get_graph_series_info()
 
 }

--- a/man/rename_edge_attrs.Rd
+++ b/man/rename_edge_attrs.Rd
@@ -25,11 +25,11 @@ attribute.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 8,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_edge_attrs(
     edge_attr = color,
     values = "green")
@@ -37,12 +37,12 @@ graph <-
 # Get the graph's internal edf
 # to show which edge attributes
 # are available
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Rename the `color` node
 # attribute as `weight`
 graph <-
-  graph \%>\%
+  graph |>
   rename_edge_attrs(
     edge_attr_from = color,
     edge_attr_to = labelfontcolor)
@@ -50,7 +50,7 @@ graph <-
 # Get the graph's internal
 # edf to show that the edge
 # attribute had been renamed
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/rename_node_attrs.Rd
+++ b/man/rename_node_attrs.Rd
@@ -25,30 +25,30 @@ attribute.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 8,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = shape,
-    values = "circle") \%>\%
+    values = "circle") |>
   set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 5,
       mean = 5,
-      sd = 1) \%>\% round(1))
+      sd = 1) |> round(1))
 
 # Get the graph's internal ndf
 # to show which node attributes
 # are available
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Rename the `value` node
 # attribute as `weight`
 graph <-
-  graph \%>\%
+  graph |>
   rename_node_attrs(
     node_attr_from = value,
     node_attr_to = weight)
@@ -56,7 +56,7 @@ graph <-
 # Get the graph's internal
 # ndf to show that the node
 # attribute had been renamed
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/render_graph.Rd
+++ b/man/render_graph.Rd
@@ -43,47 +43,47 @@ if (interactive()) {
 
   # Render a graph that's a
   # balanced tree
-  create_graph() \%>\%
+  create_graph() |>
     add_balanced_tree(
       k = 2, h = 3
-    ) \%>\%
+    ) |>
     render_graph()
 
   # Use the `tree` layout for
   # better node placement in this
   # hierarchical graph
-  create_graph() \%>\%
+  create_graph() |>
     add_balanced_tree(
       k = 2, h = 3
-    ) \%>\%
+    ) |>
     render_graph(layout = "tree")
 
   # Plot the same tree graph but
   # don't show the node ID values
-  create_graph() \%>\%
+  create_graph() |>
     add_balanced_tree(
       k = 2, h = 3
-    ) \%>\%
-    set_node_attr_to_display() \%>\%
+    ) |>
+    set_node_attr_to_display() |>
     render_graph(layout = "tree")
 
   # Create a circle graph
-  create_graph() \%>\%
+  create_graph() |>
     add_gnm_graph(
       n = 55,
       m = 75,
       set_seed = 23
-    ) \%>\%
+    ) |>
     render_graph(
       layout = "circle"
     )
 
   # Render the graph using the
   # `visNetwork` output option
-  create_graph() \%>\%
+  create_graph() |>
     add_balanced_tree(
       k = 2, h = 3
-    ) \%>\%
+    ) |>
     render_graph(
       output = "visNetwork"
     )

--- a/man/render_graph_from_graph_series.Rd
+++ b/man/render_graph_from_graph_series.Rd
@@ -35,25 +35,25 @@ the Viewer or output in various formats.
 \dontrun{
 # Create three graphs
 graph_1 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 4)
 
 graph_2 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 5)
 
 graph_3 <-
-  create_graph() \%>\%
+  create_graph() |>
   add_star(n = 6)
 
 # Create an empty graph series
 # and add the graphs
 series <-
-  create_graph_series() \%>\%
+  create_graph_series() |>
   add_graph_to_graph_series(
-    graph = graph_1) \%>\%
+    graph = graph_1) |>
   add_graph_to_graph_series(
-    graph = graph_2) \%>\%
+    graph = graph_2) |>
   add_graph_to_graph_series(
     graph = graph_3)
 

--- a/man/reorder_graph_actions.Rd
+++ b/man/reorder_graph_actions.Rd
@@ -26,7 +26,7 @@ order via the \code{\link[=trigger_graph_actions]{trigger_graph_actions()}} func
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 4,
     m = 4,
@@ -35,17 +35,17 @@ graph <-
 # Add three graph actions to the
 # graph
 graph <-
-  graph \%>\%
+  graph |>
   add_graph_action(
     fcn = "rescale_node_attrs",
     node_attr_from = "pagerank",
     node_attr_to = "width",
-    action_name = "pgrnk_to_width") \%>\%
+    action_name = "pgrnk_to_width") |>
   add_graph_action(
     fcn = "set_node_attr_w_fcn",
     node_attr_fcn = "get_pagerank",
     column_name = "pagerank",
-    action_name = "get_pagerank") \%>\%
+    action_name = "get_pagerank") |>
   add_graph_action(
     fcn = "colorize_node_attrs",
     node_attr_from = "width",
@@ -55,7 +55,7 @@ graph <-
 # View the graph actions for the graph
 # object by using the function called
 # `get_graph_actions()`
-graph \%>\% get_graph_actions()
+graph |> get_graph_actions()
 
 # We note that the order isn't
 # correct and that the `get_pagerank`
@@ -66,13 +66,13 @@ graph \%>\% get_graph_actions()
 # and specify the reordering with a
 # numeric vector
 graph <-
-  graph \%>\%
+  graph |>
   reorder_graph_actions(
     indices = c(2, 1, 3))
 
 # View the graph actions for the graph
 # object once again to verify that
 # we have the desired order of actions
-graph \%>\% get_graph_actions()
+graph |> get_graph_actions()
 
 }

--- a/man/rescale_edge_attrs.Rd
+++ b/man/rescale_edge_attrs.Rd
@@ -48,28 +48,28 @@ same edge attribute or to a new edge attribute column.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 7,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_edge_attrs(
     edge_attr = weight,
     values = rnorm(
-      n = count_edges(.),
+      n = 7,
       mean = 5,
       sd = 1))
 
 # Get the graph's internal edf
 # to show which edge attributes
 # are available
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Rescale the `weight` edge
 # attribute, so that its values
 # are rescaled between 0 and 1
 graph <-
-  graph \%>\%
+  graph |>
   rescale_edge_attrs(
     edge_attr_from = weight,
     to_lower_bound = 0,
@@ -78,7 +78,7 @@ graph <-
 # Get the graph's internal edf
 # to show that the edge attribute
 # values had been rescaled
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Scale the values in the `weight`
 # edge attribute to different
@@ -87,12 +87,12 @@ graph \%>\% get_edge_df()
 # numerical values for the
 # `penwidth` attribute
 graph <-
-  graph \%>\%
+  graph |>
   rescale_edge_attrs(
     edge_attr_from = weight,
     to_lower_bound = "gray80",
     to_upper_bound = "gray20",
-    edge_attr_to = color) \%>\%
+    edge_attr_to = color) |>
   rescale_edge_attrs(
     edge_attr_from = weight,
     to_lower_bound = 0.5,
@@ -105,7 +105,7 @@ graph <-
 # in `color` and scaled numerical
 # values are in the `penwidth`
 # edge attribute
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/rescale_node_attrs.Rd
+++ b/man/rescale_node_attrs.Rd
@@ -48,28 +48,28 @@ same node attribute or to a new node attribute column.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 10,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 5,
       mean = 5,
-      sd = 1) \%>\% round(1))
+      sd = 1) |> round(1))
 
 # Get the graph's internal ndf
 # to show which node attributes
 # are available
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Rescale the `value` node
 # attribute, so that its values
 # are rescaled between 0 and 1
 graph <-
-  graph \%>\%
+  graph |>
   rescale_node_attrs(
     node_attr_from = value,
     to_lower_bound = 0,
@@ -78,19 +78,19 @@ graph <-
 # Get the graph's internal ndf
 # to show that the node attribute
 # values had been rescaled
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Scale the values in the `value`
 # node attribute to different
 # shades of gray for the `fillcolor`
 # and `fontcolor` node attributes
 graph <-
-  graph \%>\%
+  graph |>
   rescale_node_attrs(
     node_attr_from = value,
     to_lower_bound = "gray80",
     to_upper_bound = "gray20",
-    node_attr_to = fillcolor) \%>\%
+    node_attr_to = fillcolor) |>
   rescale_node_attrs(
     node_attr_from = value,
     to_lower_bound = "gray5",
@@ -102,7 +102,7 @@ graph <-
 # grayscale colors are now available
 # in the `fillcolor` and `fontcolor`
 # node attributes
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/rev_edge_dir.Rd
+++ b/man/rev_edge_dir.Rd
@@ -20,23 +20,23 @@ graph.
 # Create a graph with a
 # directed tree
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
     k = 2, h = 2)
 
 # Inspect the graph's edges
-graph \%>\% get_edges()
+graph |> get_edges()
 
 # Reverse the edge directions
 # such that edges are directed
 # toward the root of the tree
 graph <-
-  graph \%>\%
+  graph |>
   rev_edge_dir()
 
 # Inspect the graph's edges
 # after their reversal
-graph \%>\% get_edges()
+graph |> get_edges()
 
 }
 \seealso{

--- a/man/rev_edge_dir_ws.Rd
+++ b/man/rev_edge_dir_ws.Rd
@@ -31,17 +31,17 @@ Selections of edges can also be performed using the following traversal
 # Create a graph with a
 # directed tree
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
     k = 2, h = 2)
 
 # Inspect the graph's edges
-graph \%>\% get_edges()
+graph |> get_edges()
 
 # Select all edges associated
 # with nodes `1` and `2`
 graph <-
-  graph \%>\%
+  graph |>
   select_edges_by_node_id(
     nodes = 1:2)
 
@@ -49,12 +49,12 @@ graph <-
 # of the edges associated with
 # nodes `1` and `2`
 graph <-
-  graph \%>\%
+  graph |>
   rev_edge_dir_ws()
 
 # Inspect the graph's edges
 # after their reversal
-graph \%>\% get_edges()
+graph |> get_edges()
 
 }
 \seealso{

--- a/man/save_graph.Rd
+++ b/man/save_graph.Rd
@@ -22,7 +22,7 @@ Save a graph or a graph series object to disk.
 # a probability value of 0.05
 gnp_graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_gnp_graph(
     n = 100,
     p = 0.05)

--- a/man/select_edges.Rd
+++ b/man/select_edges.Rd
@@ -64,40 +64,40 @@ graph <-
 
 # Explicitly select the edge `1`->`4`
 graph <-
-  graph \%>\%
+  graph |>
   select_edges(
     from = 1,
     to = 4)
 
 # Verify that an edge selection has been made
 # using the `get_selection()` function
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Select edges based on the relationship label
 # being `z`
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
+  graph |>
+  clear_selection() |>
   select_edges(
     conditions = rel == "z")
 
 # Verify that an edge selection has been made, and
 # recall that the `2`->`3` edge uniquely has the
 # `z` relationship label
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Select edges based on the edge value attribute
 # being greater than 3.0 (first clearing the current
 # selection of edges)
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
+  graph |>
+  clear_selection() |>
   select_edges(
     conditions = value > 3.0)
 
 # Verify that the correct edge selection has been
 # made; in this case, edges `1`->`4` and
 # `3`->`1` have values for `value` > 3.0
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/select_edges_by_edge_id.Rd
+++ b/man/select_edges_by_edge_id.Rd
@@ -26,38 +26,38 @@ Select edges in a graph object of class \code{dgr_graph} using edge ID values.
 \examples{
 # Create a graph with 5 nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 5)
 
 # Create a graph selection by selecting
 # edges with edge IDs `1` and `2`
 graph <-
-  graph \%>\%
+  graph |>
   select_edges_by_edge_id(
     edges = 1:2)
 
 # Get the selection of edges
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Perform another selection of edges,
 # with edge IDs `1`, `2`, and `4`
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
+  graph |>
+  clear_selection() |>
   select_edges_by_edge_id(
     edges = c(1, 2, 4))
 
 # Get the selection of edges
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Get the fraction of edges selected
 # over all the edges in the graph
-graph \%>\%
-  {
-    l <- get_selection(.) \%>\%
-      length(.)
-    e <- count_edges(.)
-    l/e
-  }
+l <- graph |>
+  get_selection() |>
+  length()
+
+e <- graph |> count_edges()
+
+l/e
 
 }

--- a/man/select_edges_by_node_id.Rd
+++ b/man/select_edges_by_node_id.Rd
@@ -27,38 +27,38 @@ edges associated with the provided nodes will be included in the selection.
 \examples{
 # Create a graph with 5 nodes
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 5)
 
 # Create a graph selection by selecting edges
 # associated with nodes `1` and `2`
 graph <-
-  graph \%>\%
+  graph |>
   select_edges_by_node_id(
     nodes = 1:2)
 
 # Get the selection of edges
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Perform another selection of edges, with nodes
 # `1`, `2`, and `4`
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
+  graph |>
+  clear_selection() |>
   select_edges_by_node_id(
     nodes = c(1, 2, 4))
 
 # Get the selection of edges
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Get a fraction of the edges selected over all
 # the edges in the graph
-graph \%>\%
-  {
-    l <- get_selection(.) \%>\%
-      length(.)
-    e <- count_edges(.)
-    l/e
-  }
+l <- graph |>
+  get_selection() |>
+  length()
+
+e <- graph |> count_edges()
+
+l/e
 
 }

--- a/man/select_last_edges_created.Rd
+++ b/man/select_last_edges_created.Rd
@@ -21,10 +21,10 @@ edges to be selected.
 # Create a graph and add a cycle and then
 # a tree in 2 separate function calls
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(
     n = 3,
-    rel = "a") \%>\%
+    rel = "a") |>
   add_balanced_tree(
     k = 2, h = 2,
     rel = "b")
@@ -33,15 +33,15 @@ graph <-
 # from the tree) and then set their edge
 # color to be `red`
 graph <-
-  graph \%>\%
-  select_last_edges_created() \%>\%
+  graph |>
+  select_last_edges_created() |>
   set_edge_attrs_ws(
     edge_attr = color,
-    value = "red") \%>\%
+    value = "red") |>
   clear_selection()
 
 # Display the graph's internal edge
 # data frame to verify the change
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }

--- a/man/select_last_nodes_created.Rd
+++ b/man/select_last_nodes_created.Rd
@@ -21,11 +21,11 @@ nodes to be selected.
 # Create a graph and add 4 nodes
 # in 2 separate function calls
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("a_1", "a_2")) \%>\%
+    label = c("a_1", "a_2")) |>
   add_n_nodes(
     n = 2,
     type = "b",
@@ -35,15 +35,15 @@ graph <-
 # from the last function call) and then
 # set their color to be `red`
 graph <-
-  graph \%>\%
-  select_last_nodes_created() \%>\%
+  graph |>
+  select_last_nodes_created() |>
   set_node_attrs_ws(
     node_attr = color,
-    value = "red") \%>\%
+    value = "red") |>
   clear_selection()
 
 # Display the graph's internal node
 # data frame to verify the change
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/select_nodes.Rd
+++ b/man/select_nodes.Rd
@@ -50,38 +50,38 @@ graph <-
 
 # Explicitly select nodes `1` and `3`
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes(nodes = c(1, 3))
 
 # Verify that the node selection has been made
 # using the `get_selection()` function
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Select nodes based on the node `type`
 # being `z`
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
+  graph |>
+  clear_selection() |>
   select_nodes(
     conditions = type == "z")
 
 # Verify that an node selection has been made, and
 # recall that the `3` and `4` nodes are of the
 # `z` type
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Select edges based on the node value attribute
 # being greater than 3.0 (first clearing the current
 # selection of nodes)
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
+  graph |>
+  clear_selection() |>
   select_nodes(
     conditions = value > 3.0)
 
 # Verify that the correct node selection has been
 # made; in this case, nodes `1` and `3` have values
 # for `value` greater than 3.0
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/select_nodes_by_degree.Rd
+++ b/man/select_nodes_by_degree.Rd
@@ -31,7 +31,7 @@ have certain degree values.
 # Create a random graph using
 # the `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 35, m = 125,
     set_seed = 23)
@@ -39,17 +39,17 @@ graph <-
 # Report which nodes have a
 # total degree (in-degree +
 # out-degree) of exactly 9
-graph \%>\%
+graph |>
   select_nodes_by_degree(
-    expressions = "deg == 9") \%>\%
+    expressions = "deg == 9") |>
   get_selection()
 
 # Report which nodes have a
 # total degree greater than or
 # equal to 9
-graph \%>\%
+graph |>
   select_nodes_by_degree(
-    expressions = "deg >= 9") \%>\%
+    expressions = "deg >= 9") |>
   get_selection()
 
 # Combine two calls of
@@ -60,11 +60,11 @@ graph \%>\%
 # default, those `select...()`
 # functions will `union` the
 # sets of nodes selected)
-graph \%>\%
+graph |>
   select_nodes_by_degree(
-    expressions = "deg < 3") \%>\%
+    expressions = "deg < 3") |>
   select_nodes_by_degree(
-    expressions = "deg > 10") \%>\%
+    expressions = "deg > 10") |>
   get_selection()
 
 # Combine two calls of
@@ -75,12 +75,12 @@ graph \%>\%
 # to 10 (the key here is to
 # `intersect` the sets of nodes
 # selected in the second call)
-graph \%>\%
+graph |>
   select_nodes_by_degree(
-    expressions = "deg >= 3") \%>\%
+    expressions = "deg >= 3") |>
   select_nodes_by_degree(
     expressions = "deg <= 10",
-    set_op = "intersect") \%>\%
+    set_op = "intersect") |>
   get_selection()
 
 # Select all nodes with an
@@ -89,14 +89,14 @@ graph \%>\%
 # selected nodes (coloring the
 # selected nodes red)
 graph_2 <-
-  graph \%>\%
+  graph |>
   select_nodes_by_degree(
-    expressions = "indeg > 5") \%>\%
+    expressions = "indeg > 5") |>
   set_node_attrs_ws(
     node_attr = color,
     value = "red")
 
 # Get the selection of nodes
-graph_2 \%>\% get_selection()
+graph_2 |> get_selection()
 
 }

--- a/man/select_nodes_by_id.Rd
+++ b/man/select_nodes_by_id.Rd
@@ -36,8 +36,8 @@ graph <-
 
 # Select nodes `1` to `5` and show that
 # selection of nodes with `get_selection()`
-graph \%>\%
-  select_nodes_by_id(nodes = 1:5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 1:5) |>
   get_selection()
 
 }

--- a/man/select_nodes_in_neighborhood.Rd
+++ b/man/select_nodes_in_neighborhood.Rd
@@ -30,7 +30,7 @@ distance from an initial node.
 # Create a graph containing
 # a balanced tree
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
     k = 2, h = 2)
 
@@ -41,26 +41,26 @@ graph <-
 # nodes that are 1 connection
 # away from node `1`
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_in_neighborhood(
     node = 1,
     distance = 1)
 
 # Get the selection of nodes
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Perform another selection
 # of nodes, this time with a
 # neighborhood spanning 2 nodes
 # from node `1`
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
+  graph |>
+  clear_selection() |>
   select_nodes_in_neighborhood(
     node = 1,
     distance = 2)
 
 # Get the selection of nodes
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/set_cache.Rd
+++ b/man/set_cache.Rd
@@ -28,7 +28,7 @@ Place any vector in the cache of a graph object of class \code{dgr_graph}.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 22,
@@ -39,15 +39,15 @@ graph <-
 # all nodes from `1` to `10` and
 # store in the graph's cache
 graph <-
-  graph \%>\%
+  graph |>
   set_cache(
     name = "closeness_vector",
-    to_cache = get_closeness(.),
+    to_cache = get_closeness(graph),
     col = "closeness"
   )
 
 # Get the graph's cache
-graph \%>\%
+graph |>
   get_cache(name = "closeness_vector")
 
 # Get the difference of betweenness
@@ -55,16 +55,16 @@ graph \%>\%
 # the graph and store the vector in
 # the graph's cache
 graph <-
-  graph \%>\%
+  graph |>
   set_cache(
     name = "difference",
     to_cache =
-      get_betweenness(.)$betweenness -
-        get_closeness(.)$closeness
+      get_betweenness(graph)$betweenness -
+        get_closeness(graph)$closeness
   )
 
 # Get the graph's cache
-graph \%>\%
+graph |>
   get_cache(name = "difference")
 
 }

--- a/man/set_edge_attr_to_display.Rd
+++ b/man/set_edge_attr_to_display.Rd
@@ -39,11 +39,11 @@ default value (\code{default}) for all remaining edges.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 4,
     m = 4,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_edge_attrs(
     edge_attr = value,
     values = c(2.5, 8.2, 4.2, 2.4))
@@ -53,7 +53,7 @@ graph <-
 # the edge `value` attribute (for
 # the other edges, display nothing)
 graph <-
-  graph \%>\%
+  graph |>
   set_edge_attr_to_display(
     edges = 1:3,
     attr = value,
@@ -63,20 +63,20 @@ graph <-
 # `display` edge attribute will show, for
 # each row, which edge attribute value to
 # display when the graph is rendered
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # This function can be called multiple
 # times on a graph; after the first time
 # (i.e., creation of the `display`
 # attribute), the `default` value won't
 # be used
-graph \%>\%
+graph |>
   set_edge_attr_to_display(
     edges = 4,
-    attr = to) \%>\%
+    attr = to) |>
   set_edge_attr_to_display(
     edges = c(1, 3),
-    attr = id) \%>\%
+    attr = id) |>
   get_edge_df()
 
 }

--- a/man/set_edge_attrs.Rd
+++ b/man/set_edge_attrs.Rd
@@ -51,7 +51,7 @@ graph <-
 # for edges `1`->`4` and `3`->`1`
 # in the graph
 graph <-
-  graph \%>\%
+  graph |>
   set_edge_attrs(
     edge_attr = color,
     values = "green",
@@ -61,7 +61,7 @@ graph <-
 # Set attribute `color = "blue"`
 # for all edges in the graph
 graph <-
-  graph \%>\%
+  graph |>
   set_edge_attrs(
     edge_attr = color,
     values = "blue")
@@ -70,7 +70,7 @@ graph <-
 # for all edges in graph outbound
 # from node with ID value `1`
 graph <-
-  graph \%>\%
+  graph |>
   set_edge_attrs(
     edge_attr = color,
     values = "pink",
@@ -80,7 +80,7 @@ graph <-
 # for all edges in graph inbound
 # to node with ID `1`
 graph <-
-  graph \%>\%
+  graph |>
   set_edge_attrs(
     edge_attr = color,
     values = "black",

--- a/man/set_edge_attrs_ws.Rd
+++ b/man/set_edge_attrs_ws.Rd
@@ -35,7 +35,7 @@ Selections of edges can also be performed using the following traversal
 \examples{
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 6)
 
 # Select specific edges from
@@ -43,9 +43,9 @@ graph <-
 # attribute `color = blue` to
 # those selected edges
 graph <-
-  graph \%>\%
-  select_nodes_by_id(nodes = 2:4) \%>\%
-  trav_out_edge() \%>\%
+  graph |>
+  select_nodes_by_id(nodes = 2:4) |>
+  trav_out_edge() |>
   set_edge_attrs_ws(
     edge_attr = color,
     value = "blue")
@@ -54,7 +54,7 @@ graph <-
 # frame to verify that the
 # edge attribute has been set
 # for specific edges
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }
 \seealso{

--- a/man/set_graph_directed.Rd
+++ b/man/set_graph_directed.Rd
@@ -20,18 +20,18 @@ Take a graph which is undirected and convert it to a directed graph.
 # undirected tree
 graph <-
   create_graph(
-    directed = FALSE) \%>\%
+    directed = FALSE) |>
   add_balanced_tree(
     k = 2, h = 2)
 
 # Convert this graph from
 # undirected to directed
 graph <-
-  graph \%>\%
+  graph |>
   set_graph_directed()
 
 # Perform a check on whether
 # graph is directed
-graph \%>\% is_graph_directed()
+graph |> is_graph_directed()
 
 }

--- a/man/set_graph_name.Rd
+++ b/man/set_graph_name.Rd
@@ -23,7 +23,7 @@ graph <- create_graph()
 
 # Provide the new graph with a name
 graph <-
-  graph \%>\%
+  graph |>
   set_graph_name(
     name = "example_name")
 

--- a/man/set_graph_time.Rd
+++ b/man/set_graph_time.Rd
@@ -26,20 +26,20 @@ graph <- create_graph()
 # Provide the new graph with a timestamp (if `tz`
 # is not supplied, `GMT` is used as the time zone)
 graph_1 <-
-  graph \%>\%
+  graph |>
   set_graph_time(time = "2015-10-25 15:23:00")
 
 # Provide the new graph with a timestamp that is
 # the current time; the time zone is inferred from
 # the user's locale
 graph_2 <-
-  graph \%>\%
+  graph |>
   set_graph_time()
 
 # The time zone can be updated when a timestamp
 # is present
 graph_2 <-
-  graph_2 \%>\%
+  graph_2 |>
   set_graph_time(tz = "America/Los_Angeles")
 
 }

--- a/man/set_graph_undirected.Rd
+++ b/man/set_graph_undirected.Rd
@@ -19,18 +19,18 @@ Take a graph which is directed and convert it to an undirected graph.
 # Create a graph with a
 # directed tree
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_balanced_tree(
     k = 2, h = 2)
 
 # Convert this graph from
 # directed to undirected
 graph <-
-  graph \%>\%
+  graph |>
   set_graph_undirected()
 
 # Perform a check on whether
 # graph is directed
-graph \%>\% is_graph_directed()
+graph |> is_graph_directed()
 
 }

--- a/man/set_node_attr_to_display.Rd
+++ b/man/set_node_attr_to_display.Rd
@@ -39,11 +39,11 @@ specified in \code{nodes} and a default value (\code{default}) for all remaining
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 4,
     m = 4,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = value,
     values = c(2.5, 8.2, 4.2, 2.4))
@@ -53,7 +53,7 @@ graph <-
 # the node `value` attribute (for
 # the other nodes, display nothing)
 graph <-
-  graph \%>\%
+  graph |>
   set_node_attr_to_display(
     nodes = 1:3,
     attr = value,
@@ -63,20 +63,20 @@ graph <-
 # `display` node attribute will show for
 # each row, which node attribute value to
 # display when the graph is rendered
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # This function can be called multiple
 # times on a graph; after the first time
 # (i.e., creation of the `display`
 # attribute), the `default` value won't
 # be used
-graph \%>\%
+graph |>
   set_node_attr_to_display(
     nodes = 4,
-    attr = label) \%>\%
+    attr = label) |>
   set_node_attr_to_display(
     nodes = c(1, 3),
-    attr = id) \%>\%
+    attr = id) |>
   get_node_df()
 
 }

--- a/man/set_node_attr_w_fcn.Rd
+++ b/man/set_node_attr_w_fcn.Rd
@@ -37,34 +37,34 @@ whole-graph functions.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 22,
-    set_seed = 23) \%>\%
+    set_seed = 23) |>
   set_node_attrs(
     node_attr = value,
     values = rnorm(
-      n = count_nodes(.),
+      n = 10,
       mean = 5,
-      sd = 1) \%>\% round(1))
+      sd = 1) |> round(1))
 
 # Get the betweenness values for
 # each of the graph's nodes as a
 # node attribute
 graph_1 <-
-  graph \%>\%
+  graph |>
   set_node_attr_w_fcn(
     node_attr_fcn = "get_betweenness")
 
 # Inspect the graph's internal
 # node data frame
-graph_1 \%>\% get_node_df()
+graph_1 |> get_node_df()
 
 # If a specified function takes argument
 # values, these can be supplied as well
 graph_2 <-
-  graph \%>\%
+  graph |>
   set_node_attr_w_fcn(
     node_attr_fcn = "get_alpha_centrality",
     alpha = 2,
@@ -72,18 +72,18 @@ graph_2 <-
 
 # Inspect the graph's internal
 # node data frame
-graph_2 \%>\% get_node_df()
+graph_2 |> get_node_df()
 
 # The new column name can be provided
 graph_3 <-
-  graph \%>\%
+  graph |>
   set_node_attr_w_fcn(
     node_attr_fcn = "get_pagerank",
     column_name = "pagerank")
 
 # Inspect the graph's internal
 # node data frame
-graph_3 \%>\% get_node_df()
+graph_3 |> get_node_df()
 
 # If `graph_3` is modified by
 # adding a new node then the column
@@ -92,17 +92,17 @@ graph_3 \%>\% get_node_df()
 # the existing column name to provide
 # updated values
 graph_3 <-
-  graph_3 \%>\%
+  graph_3 |>
   add_node(
     from = 1,
-    to = 3) \%>\%
+    to = 3) |>
   set_node_attr_w_fcn(
     node_attr_fcn = "get_pagerank",
     column_name = "pagerank")
 
 # Inspect the graph's internal
 # node data frame
-graph_3 \%>\% get_node_df()
+graph_3 |> get_node_df()
 
 }
 \seealso{

--- a/man/set_node_attrs.Rd
+++ b/man/set_node_attrs.Rd
@@ -49,25 +49,25 @@ graph <-
 # Set attribute `color = "green"` for
 # nodes `1` and `3` using the graph object
 graph <-
-  graph \%>\%
+  graph |>
   set_node_attrs(
     node_attr = color,
     values = "green",
     nodes = c(1, 3))
 
 # View the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Set attribute `color = "blue"` for
 # all nodes in the graph
 graph <-
-  graph \%>\%
+  graph |>
   set_node_attrs(
     node_attr = color,
     values = "blue")
 
 # Display the graph's ndf
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/set_node_attrs_ws.Rd
+++ b/man/set_node_attrs_ws.Rd
@@ -37,17 +37,17 @@ Selections of nodes can also be performed using the following traversal
 \examples{
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(n = 6)
 
 # Select specific nodes from the graph and
 # apply the node attribute `color = blue` to
 # those selected nodes
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes_by_id(
-    nodes = 1:4) \%>\%
-  trav_out() \%>\%
+    nodes = 1:4) |>
+  trav_out() |>
   set_node_attrs_ws(
     node_attr = color,
     value = "blue")
@@ -55,7 +55,7 @@ graph <-
 # Show the internal node data frame to verify
 # that the node attribute has been set for
 # specific node
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/set_node_position.Rd
+++ b/man/set_node_position.Rd
@@ -33,25 +33,25 @@ fixed to those positions on the graph canvas.
 \examples{
 # Create a simple graph with 4 nodes
 graph <-
-  create_graph() \%>\%
-  add_node(label = "one") \%>\%
-  add_node(label = "two") \%>\%
-  add_node(label = "three") \%>\%
+  create_graph() |>
+  add_node(label = "one") |>
+  add_node(label = "two") |>
+  add_node(label = "three") |>
   add_node(label = "four")
 
 # Add position information to each of
 # the graph's nodes
 graph <-
-  graph \%>\%
+  graph |>
   set_node_position(
     node = 1,
-    x = 1, y = 1) \%>\%
+    x = 1, y = 1) |>
   set_node_position(
     node = 2,
-    x = 2, y = 2) \%>\%
+    x = 2, y = 2) |>
   set_node_position(
     node = 3,
-    x = 3, y = 3) \%>\%
+    x = 3, y = 3) |>
   set_node_position(
     node = 4,
     x = 4, y = 4)
@@ -60,27 +60,27 @@ graph <-
 # verify that the `x` and `y` node
 # attributes are available and set to
 # the values provided
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # The same function can modify the data
 # in the `x` and `y` attributes
 graph <-
-  graph \%>\%
+  graph |>
   set_node_position(
     node = 1,
-    x = 1, y = 4) \%>\%
+    x = 1, y = 4) |>
   set_node_position(
     node = 2,
-    x = 3, y = 3) \%>\%
+    x = 3, y = 3) |>
   set_node_position(
     node = 3,
-    x = 3, y = 2) \%>\%
+    x = 3, y = 2) |>
   set_node_position(
     node = 4,
     x = 4, y = 1)
 
 # View the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Position changes can also be made by
 # supplying a node `label` value (and setting
@@ -88,18 +88,18 @@ graph \%>\% get_node_df()
 # all `label` values in the graph's ndf must
 # be unique and non-NA
 graph <-
-  graph \%>\%
+  graph |>
   set_node_position(
     node = "one",
     x = 1, y = 1,
-    use_labels = TRUE) \%>\%
+    use_labels = TRUE) |>
   set_node_position(
     node = "two",
     x = 2, y = 2,
     use_labels = TRUE)
 
 # View the graph's node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }
 \seealso{

--- a/man/to_igraph.Rd
+++ b/man/to_igraph.Rd
@@ -19,7 +19,7 @@ Convert a DiagrammeR graph to an igraph graph object.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 36,
     m = 50,

--- a/man/transform_to_complement_graph.Rd
+++ b/man/transform_to_complement_graph.Rd
@@ -25,21 +25,21 @@ affected by this transformation.
 # Create a simple graph
 # with a single cycle
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(n = 4)
 
 # Get the graph's edge
 # data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Create the complement
 # of the graph
 graph_c <-
-  graph \%>\%
+  graph |>
     transform_to_complement_graph()
 
 # Get the edge data frame
 # for the complement graph
-graph_c \%>\% get_edge_df()
+graph_c |> get_edge_df()
 
 }

--- a/man/transform_to_min_spanning_tree.Rd
+++ b/man/transform_to_min_spanning_tree.Rd
@@ -20,7 +20,7 @@ Get a minimum spanning tree subgraph for a connected graph of class
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 10,
     m = 15,
@@ -30,7 +30,7 @@ graph <-
 # values for each pair of
 # nodes as a square matrix
 j_sim_matrix <-
-  graph \%>\%
+  graph |>
     get_jaccard_similarity()
 
 # Create a weighted, undirected
@@ -38,7 +38,7 @@ j_sim_matrix <-
 # (effectively treating that
 # matrix as an adjacency matrix)
 graph <-
-  j_sim_matrix \%>\%
+  j_sim_matrix |>
   from_adj_matrix(weighted = TRUE)
 
 # The graph in this case is a fully connected graph
@@ -48,17 +48,17 @@ graph <-
 # connected subgraph where the edges retained have
 # the lowest similarity values possible
 min_spanning_tree_graph <-
-  graph \%>\%
-  transform_to_min_spanning_tree() \%>\%
+  graph |>
+  transform_to_min_spanning_tree() |>
   copy_edge_attrs(
     edge_attr_from = weight,
-    edge_attr_to = label) \%>\%
+    edge_attr_to = label) |>
   set_edge_attrs(
     edge_attr = fontname,
-    values = "Helvetica") \%>\%
+    values = "Helvetica") |>
   set_edge_attrs(
     edge_attr = color,
-    values = "gray85") \%>\%
+    values = "gray85") |>
   rescale_edge_attrs(
     edge_attr_from = weight,
     to_lower_bound = 0.5,

--- a/man/transform_to_subgraph_ws.Rd
+++ b/man/transform_to_subgraph_ws.Rd
@@ -58,38 +58,38 @@ graph <-
 # Create a selection of nodes, this selects
 # nodes `1`, `3`, and `5`
 graph <-
-  graph \%>\%
+  graph |>
   select_nodes(
     conditions = value > 3)
 
 # Create a subgraph based on the selection
 subgraph <-
-  graph \%>\%
+  graph |>
   transform_to_subgraph_ws()
 
 # Display the graph's node data frame
-subgraph \%>\% get_node_df()
+subgraph |> get_node_df()
 
 # Display the graph's edge data frame
-subgraph \%>\% get_edge_df()
+subgraph |> get_edge_df()
 
 # Create a selection of edges, this selects
 # edges `1`, `2`
 graph <-
-  graph \%>\%
-  clear_selection() \%>\%
+  graph |>
+  clear_selection() |>
   select_edges(
   edges = c(1,2))
 
 # Create a subgraph based on the selection
 subgraph <-
-  graph \%>\%
+  graph |>
   transform_to_subgraph_ws()
 
 # Display the graph's node data frame
-subgraph \%>\% get_node_df()
+subgraph |> get_node_df()
 
 # Display the graph's edge data frame
-subgraph \%>\% get_edge_df()
+subgraph |> get_edge_df()
 
 }

--- a/man/trav_both.Rd
+++ b/man/trav_both.Rd
@@ -68,15 +68,15 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("asd", "iekd")) \%>\%
+    label = c("asd", "iekd")) |>
   add_n_nodes(
     n = 3,
     type = "b",
-    label = c("idj", "edl", "ohd")) \%>\%
+    label = c("idj", "edl", "ohd")) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5",
     rel = c(NA, "A", "B", "C", "D"))
@@ -101,89 +101,89 @@ df_nodes <-
 # Join the data frame to the graph's internal
 # edge data frame (edf)
 graph <-
-  graph \%>\%
-  join_edge_attrs(df = df_edges) \%>\%
+  graph |>
+  join_edge_attrs(df = df_edges) |>
   join_node_attrs(df = df_nodes)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a simple traversal from node `3`
 # to adjacent nodes with no conditions on
 # the nodes traversed to
-graph \%>\%
-  select_nodes_by_id(nodes = 3) \%>\%
-  trav_both() \%>\%
+graph |>
+  select_nodes_by_id(nodes = 3) |>
+  trav_both() |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # nodes, filtering to those nodes that have
 # numeric values less than `8.0` for
 # the `values` node attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both(
-    conditions = values < 8.0) \%>\%
+    conditions = values < 8.0) |>
   get_selection()
 
 # Traverse from node `5` to any adjacent
 # nodes, filtering to those nodes that
 # have a `type` attribute of `b`
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_both(
-    conditions = type == "b") \%>\%
+    conditions = type == "b") |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # nodes, and use multiple conditions for the
 # traversal
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both(
     conditions =
       type == "a" &
-      values > 8.0) \%>\%
+      values > 8.0) |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # nodes, and use multiple conditions with
 # a single-length vector
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both(
     conditions =
-      type == "a" | values > 8.0) \%>\%
+      type == "a" | values > 8.0) |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # nodes, and use a regular expression as
 # a filtering condition
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both(
-    conditions = grepl("..d", label)) \%>\%
+    conditions = grepl("..d", label)) |>
   get_selection()
 
 # Create another simple graph to demonstrate
 # copying of node attribute values to traversed
 # nodes
 graph <-
-  create_graph() \%>\%
-  add_path(n = 5) \%>\%
-  select_nodes_by_id(nodes = c(2, 4)) \%>\%
+  create_graph() |>
+  add_path(n = 5) |>
+  select_nodes_by_id(nodes = c(2, 4)) |>
   set_node_attrs_ws(
     node_attr = value,
     value = 5)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a traversal from the inner nodes
 # (`2` and `4`) to their adjacent nodes (`1`,
@@ -193,13 +193,13 @@ graph \%>\% get_edge_df()
 # to `3` will occur from `2` and `4` (and
 # multiple values passed will be summed)
 graph <-
-  graph \%>\%
+  graph |>
   trav_both(
     copy_attrs_from = value,
     agg = "sum")
 
 # Show the graph's internal node data frame
 # after this change
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/trav_both_edge.Rd
+++ b/man/trav_both_edge.Rd
@@ -64,15 +64,15 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("asd", "iekd")) \%>\%
+    label = c("asd", "iekd")) |>
   add_n_nodes(
     n = 3,
     type = "b",
-    label = c("idj", "edl", "ohd")) \%>\%
+    label = c("idj", "edl", "ohd")) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5",
     rel = c(NA, "A", "B", "C", "D"))
@@ -89,106 +89,106 @@ df <-
 # Join the data frame to the graph's internal
 # edge data frame (edf)
 graph <-
-  graph \%>\%
+  graph |>
   join_edge_attrs(df = df)
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a simple traversal from nodes to
 # adjacent edges with no conditions on the
 # nodes traversed to
-graph \%>\%
-  select_nodes_by_id(nodes = 3) \%>\%
-  trav_both_edge() \%>\%
+graph |>
+  select_nodes_by_id(nodes = 3) |>
+  trav_both_edge() |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # edges, filtering to those edges that have
 # NA values for the `rel` edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both_edge(
-    conditions = is.na(rel)) \%>\%
+    conditions = is.na(rel)) |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # edges, filtering to those edges that have
 # numeric values greater than `6.5` for
 # the `rel` edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both_edge(
-    conditions = values > 6.5) \%>\%
+    conditions = values > 6.5) |>
   get_selection()
 
 # Traverse from node `5` to any adjacent
 # edges, filtering to those edges that
 # have values equal to `C` for the `rel`
 # edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_both_edge(
-    conditions = rel == "C") \%>\%
+    conditions = rel == "C") |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # edges, filtering to those edges that
 # have values in the set `B` and `C` for
 # the `rel` edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both_edge(
-    conditions = rel \%in\% c("B", "C")) \%>\%
+    conditions = rel \%in\% c("B", "C")) |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # edges, and use multiple conditions for the
 # traversal
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both_edge(
     conditions =
       rel \%in\% c("B", "C") &
-      values > 4.0) \%>\%
+      values > 4.0) |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # edges, and use multiple conditions with
 # a single-length vector
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both_edge(
     conditions =
       rel \%in\% c("B", "C") |
-      values > 4.0) \%>\%
+      values > 4.0) |>
   get_selection()
 
 # Traverse from node `2` to any adjacent
 # edges, and use a regular expression as
 # a filtering condition
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_both_edge(
-    conditions = grepl("B|C", rel)) \%>\%
+    conditions = grepl("B|C", rel)) |>
   get_selection()
 
 # Create another simple graph to demonstrate
 # copying of node attribute values to traversed
 # edges
 graph <-
-  create_graph() \%>\%
-  add_path(n = 4) \%>\%
-  select_nodes_by_id(nodes = 2:3) \%>\%
+  create_graph() |>
+  add_path(n = 4) |>
+  select_nodes_by_id(nodes = 2:3) |>
   set_node_attrs_ws(
     node_attr = value,
     value = 5)
 
 # Show the graph's internal edge data frame
-graph \%>\%get_edge_df()
+graph |>get_edge_df()
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Perform a traversal from the nodes to
 # the adjacent edges while also applying
@@ -197,13 +197,13 @@ graph \%>\% get_node_df()
 # all contributing nodes adding as an edge
 # attribute)
 graph <-
-  graph \%>\%
+  graph |>
   trav_both_edge(
     copy_attrs_from = value,
     agg = "sum")
 
 # Show the graph's internal edge data frame
 # after this change
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }

--- a/man/trav_in.Rd
+++ b/man/trav_in.Rd
@@ -68,15 +68,15 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("asd", "iekd")) \%>\%
+    label = c("asd", "iekd")) |>
   add_n_nodes(
     n = 3,
     type = "b",
-    label = c("idj", "edl", "ohd")) \%>\%
+    label = c("idj", "edl", "ohd")) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5",
     rel = c(NA, "A", "B", "C", "D"))
@@ -101,109 +101,110 @@ df_nodes <-
 # Join the data frame to the graph's internal
 # edge data frame (edf)
 graph <-
-  graph \%>\%
-  join_edge_attrs(df = df_edges) \%>\%
+  graph |>
+  join_edge_attrs(df = df_edges) |>
   join_node_attrs(df = df_nodes)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a simple traversal from node `4` to
 # inward adjacent edges with no conditions
 # on the nodes traversed to
-graph \%>\%
-  select_nodes_by_id(nodes = 4) \%>\%
-  trav_in() \%>\%
+graph |>
+  select_nodes_by_id(nodes = 4) |>
+  trav_in() |>
   get_selection()
 
 # Traverse from node `5` to inbound-facing
 # nodes, filtering to those nodes that have
 # numeric values greater than `5.0` for
 # the `values` node attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 4) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 4) |>
   trav_in(
-    conditions = values > 5.0) \%>\%
+    conditions = values > 5.0) |>
   get_selection()
 
 # Traverse from node `5` to any inbound
 # nodes, filtering to those nodes that
 # have a `type` attribute of `b`
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in(
-    conditions = type == "b") \%>\%
+    conditions = type == "b") |>
   get_selection()
 
 # Traverse from node `5` to any inbound
 # nodes, filtering to those nodes that
 # have a degree of `2`
-graph \%>\%
-  {
-  node_degrees <-
-    get_node_info(.) \%>\%
-    dplyr::select(id, deg)
-  join_node_attrs(., node_degrees)
-  } \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+node_degrees <- graph |>
+  get_node_info() |>
+  dplyr::select(id, deg)
+
+graph <- graph |>
+  join_node_attrs(df = node_degrees)
+
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in(
-    conditions = deg == 2) \%>\%
+    conditions = deg == 2) |>
   get_selection()
 
 # Traverse from node `5` to any inbound
 # nodes, and use multiple conditions for the
 # traversal
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in(
     conditions =
       type == "a" &
-      values > 6.0) \%>\%
+      values > 6.0) |>
   get_selection()
 
 # Traverse from node `5` to any inbound
 # nodes, and use multiple conditions with
 # a single-length vector
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in(
     conditions =
-      type == "b" | values > 6.0) \%>\%
+      type == "b" | values > 6.0) |>
   get_selection()
 
 # Traverse from node `5` to any inbound
 # nodes, and use a regular expression as
 # a filtering condition
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_in(
-    conditions = grepl("^i.*", label)) \%>\%
+    conditions = grepl("^i.*", label)) |>
   get_selection()
 
 # Create another simple graph to demonstrate
 # copying of node attribute values to traversed
 # nodes
 graph <-
-  create_graph() \%>\%
-  add_node() \%>\%
-  select_nodes() \%>\%
+  create_graph() |>
+  add_node() |>
+  select_nodes() |>
   add_n_nodes_ws(
     n = 2,
-    direction = "from") \%>\%
-  clear_selection() \%>\%
-  select_nodes_by_id(nodes = 2:3) \%>\%
+    direction = "from") |>
+  clear_selection() |>
+  select_nodes_by_id(nodes = 2:3) |>
   set_node_attrs_ws(
     node_attr = value,
     value = 5)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a traversal from the outer nodes
 # (`2` and `3`) to the central node (`1`) while
@@ -212,13 +213,13 @@ graph \%>\% get_edge_df()
 # both nodes before applying the value to the
 # target node)
 graph <-
-  graph \%>\%
+  graph |>
   trav_in(
     copy_attrs_from = value,
     agg = "sum")
 
 # Show the graph's internal node data frame
 # after this change
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/trav_in_edge.Rd
+++ b/man/trav_in_edge.Rd
@@ -57,15 +57,15 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("asd", "iekd")) \%>\%
+    label = c("asd", "iekd")) |>
   add_n_nodes(
     n = 3,
     type = "b",
-    label = c("idj", "edl", "ohd")) \%>\%
+    label = c("idj", "edl", "ohd")) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5",
     rel = c(NA, "A", "B", "C", "D"))
@@ -83,29 +83,29 @@ df <-
 # Join the data frame to the graph's
 # internal edge data frame (edf)
 graph <-
-  graph \%>\%
+  graph |>
   join_edge_attrs(df = df)
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a simple traversal from
 # nodes to inbound edges with no
 # conditions on the nodes
 # traversed to
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
-  trav_in_edge() \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
+  trav_in_edge() |>
   get_selection()
 
 # Traverse from node `2` to any
 # inbound edges, filtering to
 # those edges that have NA values
 # for the `rel` edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_in_edge(
-    conditions = is.na(rel)) \%>\%
+    conditions = is.na(rel)) |>
   get_selection()
 
 # Traverse from node `2` to any
@@ -115,10 +115,10 @@ graph \%>\%
 # (since there are no allowed
 # traversals, the selection of node
 # `2` is retained)
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_in_edge(
-    conditions = !is.na(rel)) \%>\%
+    conditions = !is.na(rel)) |>
   get_selection()
 
 # Traverse from node `5` to any
@@ -126,20 +126,20 @@ graph \%>\%
 # edges that have numeric values
 # greater than `5.5` for the `rel`
 # edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in_edge(
-    conditions = values > 5.5) \%>\%
+    conditions = values > 5.5) |>
   get_selection()
 
 # Traverse from node `5` to any
 # inbound edges, filtering to those
 # edges that have values equal to
 # `D` for the `rel` edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in_edge(
-    conditions = rel == "D") \%>\%
+    conditions = rel == "D") |>
   get_selection()
 
 # Traverse from node `5` to any
@@ -147,49 +147,49 @@ graph \%>\%
 # edges that have values in the set
 # `C` and `D` for the `rel` edge
 # attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in_edge(
-    conditions = rel \%in\% c("C", "D")) \%>\%
+    conditions = rel \%in\% c("C", "D")) |>
   get_selection()
 
 # Traverse from node `5` to any
 # inbound edges, and use multiple
 # conditions for the traversal
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in_edge(
     conditions =
       rel \%in\% c("C", "D") &
-      values > 5.5) \%>\%
+      values > 5.5) |>
   get_selection()
 
 # Traverse from node `5` to any
 # inbound edges, and use multiple
 # conditions with a single-length
 # vector
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in_edge(
     conditions =
       rel \%in\% c("D", "E") |
-      values > 5.5) \%>\%
+      values > 5.5) |>
   get_selection()
 
 # Traverse from node `5` to any
 # inbound edges, and use a regular
 # expression as a filtering condition
-graph \%>\%
-  select_nodes_by_id(nodes = 5) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 5) |>
   trav_in_edge(
-    conditions = grepl("C|D", rel)) \%>\%
+    conditions = grepl("C|D", rel)) |>
   get_selection()
 
 # Show the graph's internal ndf
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edf
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a traversal from all
 # nodes to their incoming edges and,
@@ -197,13 +197,13 @@ graph \%>\% get_edge_df()
 # node attribute to any of the nodes'
 # incoming edges
 graph <-
-  graph \%>\%
-  select_nodes() \%>\%
+  graph |>
+  select_nodes() |>
   trav_in_edge(
     copy_attrs_from = label)
 
 # Show the graph's internal edge
 # data frame after this change
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }

--- a/man/trav_in_node.Rd
+++ b/man/trav_in_node.Rd
@@ -62,15 +62,15 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("asd", "iekd")) \%>\%
+    label = c("asd", "iekd")) |>
   add_n_nodes(
     n = 3,
     type = "b",
-    label = c("idj", "edl", "ohd")) \%>\%
+    label = c("idj", "edl", "ohd")) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5",
     rel = c(NA, "A", "B", "C", "D"))
@@ -95,40 +95,40 @@ df_nodes <-
 # Join the data frame to the graph's internal
 # edge data frame (edf)
 graph <-
-  graph \%>\%
-  join_edge_attrs(df = df_edges) \%>\%
+  graph |>
+  join_edge_attrs(df = df_edges) |>
   join_node_attrs(df = df_nodes)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a simple traversal from the
 # edge `1`->`3` to the attached node
 # in the direction of the edge; here, no
 # conditions are placed on the nodes
 # traversed to
-graph \%>\%
+graph |>
   select_edges(
     from = 1,
-    to = 3) \%>\%
-  trav_in_node() \%>\%
+    to = 3) |>
+  trav_in_node() |>
   get_selection()
 
 # Traverse from edges `2`->`5` and
 # `3`->`5` to the attached node along
 # the direction of the edge; both
 # traversals lead to the same node
-graph \%>\%
+graph |>
   select_edges(
     from = 2,
-    to = 5) \%>\%
+    to = 5) |>
   select_edges(
     from = 3,
-    to = 5) \%>\%
-  trav_in_node() \%>\%
+    to = 5) |>
+  trav_in_node() |>
   get_selection()
 
 # Traverse from the edge `1`->`3`
@@ -136,12 +136,12 @@ graph \%>\%
 # is incoming, this time filtering
 # numeric values greater than `5.0` for
 # the `values` node attribute
-graph \%>\%
+graph |>
   select_edges(
     from = 1,
-    to = 3) \%>\%
+    to = 3) |>
   trav_in_node(
-    conditions = values > 5.0) \%>\%
+    conditions = values > 5.0) |>
   get_selection()
 
 # Traverse from the edge `1`->`3`
@@ -151,60 +151,60 @@ graph \%>\%
 # the `values` node attribute (the
 # condition is not met so the original
 # selection of edge `1` -> `3` remains)
-graph \%>\%
+graph |>
   select_edges(
     from = 1,
-    to = 3) \%>\%
+    to = 3) |>
   trav_in_node(
-    conditions = values < 5.0) \%>\%
+    conditions = values < 5.0) |>
   get_selection()
 
 # Traverse from the edge `1`->`2` to
 # the node `2` using multiple conditions
 # with a single-length vector
-graph \%>\%
+graph |>
   select_edges(
     from = 1,
-    to = 2) \%>\%
+    to = 2) |>
   trav_in_node(
     conditions =
       grepl(".*d$", label) |
-      values < 6.0) \%>\%
+      values < 6.0) |>
   get_selection()
 
 # Create another simple graph to demonstrate
 # copying of edge attribute values to traversed
 # nodes
 graph <-
-  create_graph() \%>\%
-  add_node() \%>\%
-  select_nodes() \%>\%
+  create_graph() |>
+  add_node() |>
+  select_nodes() |>
   add_n_nodes_ws(
     n = 2,
-    direction = "to") \%>\%
-  clear_selection() \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+    direction = "to") |>
+  clear_selection() |>
+  select_nodes_by_id(nodes = 2) |>
   set_node_attrs_ws(
     node_attr = value,
-    value = 8) \%>\%
-  clear_selection() \%>\%
-  select_edges_by_edge_id(edges = 1) \%>\%
+    value = 8) |>
+  clear_selection() |>
+  select_edges_by_edge_id(edges = 1) |>
   set_edge_attrs_ws(
     edge_attr = value,
-    value = 5) \%>\%
-  clear_selection() \%>\%
-  select_edges_by_edge_id(edges = 2) \%>\%
+    value = 5) |>
+  clear_selection() |>
+  select_edges_by_edge_id(edges = 2) |>
   set_edge_attrs_ws(
     edge_attr = value,
-    value = 5) \%>\%
-  clear_selection() \%>\%
+    value = 5) |>
+  clear_selection() |>
   select_edges()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Perform a traversal from the edges to
 # the central node (`1`) while also applying
@@ -212,13 +212,13 @@ graph \%>\% get_node_df()
 # this case summing the `value` of 5 from
 # both edges before adding as a node attribute)
 graph <-
-  graph \%>\%
+  graph |>
   trav_in_node(
     copy_attrs_from = value,
     agg = "sum")
 
 # Show the graph's internal node data frame
 # after this change
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/trav_in_until.Rd
+++ b/man/trav_in_until.Rd
@@ -61,11 +61,11 @@ Selections of nodes can also be performed using the following traversal
 # nodes from beginning to end;
 # select the last path node
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 10,
     node_data = node_data(
-      value = 1:10)) \%>\%
+      value = 1:10)) |>
   select_nodes_by_id(
     nodes = 10)
 
@@ -73,13 +73,13 @@ graph <-
 # until stopping at a node where
 # the `value` attribute is 1
 graph <-
-  graph \%>\%
+  graph |>
   trav_in_until(
     conditions =
       value == 1)
 
 # Get the graph's node selection
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Create two cycles in a graph and
 # add values of 1 to 6 to the
@@ -87,15 +87,15 @@ graph \%>\% get_selection()
 # 12 in the second; select nodes
 # `6` and `12`
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(
     n = 6,
     node_data = node_data(
-      value = 1:6)) \%>\%
+      value = 1:6)) |>
   add_cycle(
     n = 6,
     node_data = node_data(
-      value = 7:12)) \%>\%
+      value = 7:12)) |>
   select_nodes_by_id(
     nodes = c(6, 12))
 
@@ -107,13 +107,13 @@ graph <-
 # keep the finally traversed to
 # nodes that satisfy the conditions
 graph <-
-  graph \%>\%
+  graph |>
   trav_in_until(
     conditions =
       value \%in\% c(1, 2, 10),
     exclude_unmatched = TRUE)
 
 # Get the graph's node selection
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/trav_out.Rd
+++ b/man/trav_out.Rd
@@ -68,15 +68,15 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("asd", "iekd")) \%>\%
+    label = c("asd", "iekd")) |>
   add_n_nodes(
     n = 3,
     type = "b",
-    label = c("idj", "edl", "ohd")) \%>\%
+    label = c("idj", "edl", "ohd")) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5",
     rel = c(NA, "A", "B", "C", "D"))
@@ -101,112 +101,111 @@ df_nodes <-
 # Join the data frame to the graph's internal
 # edge data frame (edf)
 graph <-
-  graph \%>\%
-  join_edge_attrs(df = df_edges) \%>\%
+  graph |>
+  join_edge_attrs(df = df_edges) |>
   join_node_attrs(df = df_nodes)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a simple traversal from node `3`
 # to outward adjacent nodes with no conditions
 # on the nodes traversed to
-graph \%>\%
-  select_nodes_by_id(nodes = 3) \%>\%
-  trav_out() \%>\%
+graph |>
+  select_nodes_by_id(nodes = 3) |>
+  trav_out() |>
   get_selection()
 
 # Traverse from node `1` to outbound
 # nodes, filtering to those nodes that have
 # numeric values greater than `7.0` for
 # the `values` node attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 1) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 1) |>
   trav_out(
-    conditions = values > 7.0) \%>\%
+    conditions = values > 7.0) |>
   get_selection()
 
 # Traverse from node `1` to any outbound
 # nodes, filtering to those nodes that
 # have a `type` attribute of `b`
-graph \%>\%
-  select_nodes_by_id(nodes = 1) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 1) |>
   trav_out(
-    conditions = type == "b") \%>\%
+    conditions = type == "b") |>
   get_selection()
 
 # Traverse from node `2` to any outbound
 # nodes, filtering to those nodes that
 # have a degree of `1`
-graph \%>\%
-  {
-  node_degrees <-
-    get_node_info(.) \%>\%
-    dplyr::select(id, deg)
-  join_node_attrs(
-    graph = .,
-    df = node_degrees)
-  } \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+node_degrees <- graph |>
+  get_node_info() |>
+  dplyr::select(id, deg)
+
+graph <- graph |>
+  join_node_attrs(df = node_degrees)
+
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_out(
-    conditions = deg == 1) \%>\%
+    conditions = deg == 1) |>
   get_selection()
 
 # Traverse from node `2` to any outbound
 # nodes, and use multiple conditions for
 # the traversal
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_out(
     conditions =
       type == "a" &
-      values > 8.0) \%>\%
+      values > 8.0) |>
   get_selection()
 
 # Traverse from node `2` to any
 # outbound nodes, and use multiple
 # conditions with a single-length vector
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_out(
     conditions =
       type == "b" |
-      values > 8.0) \%>\%
+      values > 8.0) |>
   get_selection()
 
 # Traverse from node `2` to any outbound
 # nodes, and use a regular expression as
 # a filtering condition
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_out(
-    conditions = grepl("..d", label)) \%>\%
+    conditions = grepl("..d", label)) |>
   get_selection()
 
 # Create another simple graph to demonstrate
 # copying of node attribute values to traversed
 # nodes
 graph <-
-  create_graph() \%>\%
-  add_node() \%>\%
-  select_nodes() \%>\%
+  create_graph() |>
+  add_node() |>
+  select_nodes() |>
   add_n_nodes_ws(
     n = 2,
-    direction = "to") \%>\%
-  clear_selection() \%>\%
-  select_nodes_by_id(nodes = 2:3) \%>\%
+    direction = "to") |>
+  clear_selection() |>
+  select_nodes_by_id(nodes = 2:3) |>
   set_node_attrs_ws(
     node_attr = value,
     value = 5)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a traversal from the outer nodes
 # (`2` and `3`) to the central node (`1`) while
@@ -215,13 +214,13 @@ graph \%>\% get_edge_df()
 # both nodes before applying that value to the
 # target node)
 graph <-
-  graph \%>\%
+  graph |>
   trav_out(
     copy_attrs_from = value,
     agg = "sum")
 
 # Show the graph's internal node data
 # frame after this change
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/trav_out_edge.Rd
+++ b/man/trav_out_edge.Rd
@@ -57,18 +57,18 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("asd", "iekd")) \%>\%
+    label = c("asd", "iekd")) |>
   add_n_nodes(
     n = 3,
     type = "b",
-    label = c("idj", "edl", "ohd")) \%>\%
+    label = c("idj", "edl", "ohd")) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5",
-    rel = c(NA, "A", "B", "C", "D")) \%>\%
+    rel = c(NA, "A", "B", "C", "D")) |>
   set_node_attrs(
     node_attr = values,
     values = c(2.3, 4.7, 9.4,
@@ -86,92 +86,92 @@ df <-
 # Join the data frame to the graph's internal
 # edge data frame (edf)
 graph <-
-  graph \%>\%
+  graph |>
   join_edge_attrs(
     df = df)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a simple traversal from nodes to
 # outbound edges with no conditions on the
 # nodes traversed to
-graph \%>\%
-  select_nodes_by_id(nodes = 1) \%>\%
-  trav_out_edge() \%>\%
+graph |>
+  select_nodes_by_id(nodes = 1) |>
+  trav_out_edge() |>
   get_selection()
 
 # Traverse from node `1` to any outbound
 # edges, filtering to those edges that have
 # NA values for the `rel` edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 1) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 1) |>
   trav_out_edge(
-    conditions = is.na(rel)) \%>\%
+    conditions = is.na(rel)) |>
   get_selection()
 
 # Traverse from node `3` to any outbound
 # edges, filtering to those edges that have
 # numeric values greater than `5.0` for
 # the `rel` edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 3) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 3) |>
   trav_out_edge(
-    conditions = values > 5.0) \%>\%
+    conditions = values > 5.0) |>
   get_selection()
 
 # Traverse from node `1` to any outbound
 # edges, filtering to those edges that
 # have values equal to `A` for the `rel`
 # edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 1) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 1) |>
   trav_out_edge(
-    conditions = rel == "A") \%>\%
+    conditions = rel == "A") |>
   get_selection()
 
 # Traverse from node `2` to any outbound
 # edges, filtering to those edges that
 # have values in the set `B` and `C` for
 # the `rel` edge attribute
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_out_edge(
-    conditions = rel \%in\% c("B", "C")) \%>\%
+    conditions = rel \%in\% c("B", "C")) |>
   get_selection()
 
 # Traverse from node `2` to any
 # outbound edges, and use multiple
 # conditions for the traversal
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_out_edge(
     conditions =
       rel \%in\% c("B", "C") &
-      values >= 5.0) \%>\%
+      values >= 5.0) |>
   get_selection()
 
 # Traverse from node `2` to any
 # outbound edges, and use multiple
 # conditions
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_out_edge(
     conditions =
       rel \%in\% c("B", "C") |
-      values > 6.0) \%>\%
+      values > 6.0) |>
   get_selection()
 
 # Traverse from node `2` to any outbound
 # edges, and use a regular expression as
 # a filtering condition
-graph \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+graph |>
+  select_nodes_by_id(nodes = 2) |>
   trav_out_edge(
-    conditions = grepl("B|C", rel)) \%>\%
+    conditions = grepl("B|C", rel)) |>
   get_selection()
 
 # Perform a traversal from all nodes to
@@ -179,13 +179,13 @@ graph \%>\%
 # so, copy the `label` node attribute
 # to any of the nodes' incoming edges
 graph <-
-  graph \%>\%
-  select_nodes() \%>\%
+  graph |>
+  select_nodes() |>
   trav_out_edge(
     copy_attrs_from = label)
 
 # Show the graph's internal edge
 # data frame after this change
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 }

--- a/man/trav_out_node.Rd
+++ b/man/trav_out_node.Rd
@@ -62,15 +62,15 @@ set.seed(23)
 
 # Create a simple graph
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_n_nodes(
     n = 2,
     type = "a",
-    label = c("asd", "iekd")) \%>\%
+    label = c("asd", "iekd")) |>
   add_n_nodes(
     n = 3,
     type = "b",
-    label = c("idj", "edl", "ohd")) \%>\%
+    label = c("idj", "edl", "ohd")) |>
   add_edges_w_string(
     edges = "1->2 1->3 2->4 2->5 3->5",
     rel = c(NA, "A", "B", "C", "D"))
@@ -95,40 +95,40 @@ df_nodes <-
 # Join the data frame to the graph's internal
 # edge data frame (edf)
 graph <-
-  graph \%>\%
-  join_edge_attrs(df = df_edges) \%>\%
+  graph |>
+  join_edge_attrs(df = df_edges) |>
   join_node_attrs(df = df_nodes)
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Perform a simple traversal from the
 # edge `1`->`3` to the attached node
 # in the direction of the edge; here, no
 # conditions are placed on the nodes
 # traversed to
-graph \%>\%
+graph |>
   select_edges(
     from = 1,
-      to = 3) \%>\%
-  trav_out_node() \%>\%
+      to = 3) |>
+  trav_out_node() |>
   get_selection()
 
 # Traverse from edges `2`->`5` and
 # `3`->`5` to the attached node along
 # the direction of the edge; here, the
 # traversals lead to different nodes
-graph \%>\%
+graph |>
   select_edges(
     from = 2,
-      to = 5) \%>\%
+      to = 5) |>
   select_edges(
     from = 3,
-      to = 5) \%>\%
-  trav_out_node() \%>\%
+      to = 5) |>
+  trav_out_node() |>
   get_selection()
 
 # Traverse from the edge `1`->`3`
@@ -136,12 +136,12 @@ graph \%>\%
 # is outgoing, this time filtering
 # numeric values greater than `7.0` for
 # the `values` node attribute
-graph \%>\%
+graph |>
   select_edges(
     from = 1,
-      to = 3) \%>\%
+      to = 3) |>
   trav_out_node(
-    conditions = values > 7.0) \%>\%
+    conditions = values > 7.0) |>
   get_selection()
 
 # Traverse from the edge `1`->`3`
@@ -151,59 +151,59 @@ graph \%>\%
 # the `values` node attribute (the
 # condition is not met so the original
 # selection of edge `1`->`3` remains)
-graph \%>\%
+graph |>
   select_edges(
     from = 1,
-      to = 3) \%>\%
+      to = 3) |>
   trav_out_node(
-    conditions = values < 7.0) \%>\%
+    conditions = values < 7.0) |>
   get_selection()
 
 # Traverse from the edge `1`->`2`
 # to node `2`, using multiple conditions
-graph \%>\%
+graph |>
   select_edges(
     from = 1,
-      to = 2) \%>\%
+      to = 2) |>
   trav_out_node(
     conditions =
       grepl(".*d$", label) |
-      values < 6.0) \%>\%
+      values < 6.0) |>
   get_selection()
 
 # Create another simple graph to demonstrate
 # copying of edge attribute values to traversed
 # nodes
 graph <-
-  create_graph() \%>\%
-  add_node() \%>\%
-  select_nodes() \%>\%
+  create_graph() |>
+  add_node() |>
+  select_nodes() |>
   add_n_nodes_ws(
     n = 2,
-    direction = "from") \%>\%
-  clear_selection() \%>\%
-  select_nodes_by_id(nodes = 2) \%>\%
+    direction = "from") |>
+  clear_selection() |>
+  select_nodes_by_id(nodes = 2) |>
   set_node_attrs_ws(
     node_attr = value,
-    value = 8) \%>\%
-  clear_selection() \%>\%
-  select_edges_by_edge_id(edges = 1) \%>\%
+    value = 8) |>
+  clear_selection() |>
+  select_edges_by_edge_id(edges = 1) |>
   set_edge_attrs_ws(
     edge_attr = value,
-    value = 5) \%>\%
-  clear_selection() \%>\%
-  select_edges_by_edge_id(edges = 2) \%>\%
+    value = 5) |>
+  clear_selection() |>
+  select_edges_by_edge_id(edges = 2) |>
   set_edge_attrs_ws(
     edge_attr = value,
-    value = 5) \%>\%
-  clear_selection() \%>\%
+    value = 5) |>
+  clear_selection() |>
   select_edges()
 
 # Show the graph's internal edge data frame
-graph \%>\% get_edge_df()
+graph |> get_edge_df()
 
 # Show the graph's internal node data frame
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 # Perform a traversal from the edges to
 # the central node (`1`) while also applying
@@ -211,13 +211,13 @@ graph \%>\% get_node_df()
 # this case summing the `value` of 5 from
 # both edges before adding as a node attribute)
 graph <-
-  graph \%>\%
+  graph |>
   trav_out_node(
     copy_attrs_from = value,
     agg = "sum")
 
 # Show the graph's internal node data frame
 # after this change
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }

--- a/man/trav_out_until.Rd
+++ b/man/trav_out_until.Rd
@@ -61,11 +61,11 @@ Selections of nodes can also be performed using the following traversal
 # nodes from beginning to end;
 # select the first path node
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_path(
     n = 10,
     node_data = node_data(
-      value = 1:10)) \%>\%
+      value = 1:10)) |>
   select_nodes_by_id(
     nodes = 1)
 
@@ -73,13 +73,13 @@ graph <-
 # until stopping at a node where
 # the `value` attribute is 8
 graph <-
-  graph \%>\%
+  graph |>
   trav_out_until(
     conditions =
       value == 8)
 
 # Get the graph's node selection
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Create two cycles in graph and
 # add values of 1 to 6 to the
@@ -87,15 +87,15 @@ graph \%>\% get_selection()
 # 12 in the second; select nodes
 # `1` and `7`
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_cycle(
     n = 6,
     node_data = node_data(
-      value = 1:6)) \%>\%
+      value = 1:6)) |>
   add_cycle(
     n = 6,
     node_data = node_data(
-      value = 7:12)) \%>\%
+      value = 7:12)) |>
   select_nodes_by_id(
     nodes = c(1, 7))
 
@@ -107,13 +107,13 @@ graph <-
 # keep the finally traversed to
 # nodes that satisfy the conditions
 graph <-
-  graph \%>\%
+  graph |>
   trav_out_until(
     conditions =
       value \%in\% c(5, 6, 9),
     exclude_unmatched = TRUE)
 
 # Get the graph's node selection
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/trav_reverse_edge.Rd
+++ b/man/trav_reverse_edge.Rd
@@ -60,25 +60,25 @@ graph <-
 # Explicitly select the edges
 # `1`->`4` and `2`->`3`
 graph <-
-  graph \%>\%
+  graph |>
   select_edges(
     from = 1,
-      to = 4) \%>\%
+      to = 4) |>
   select_edges(
     from = 2,
       to = 3)
 
 # Get the inital edge selection
-graph \%>\% get_selection()
+graph |> get_selection()
 
 # Traverse to the reverse edges
 # (edges `2`: `4`->`1` and
 # `4`:`3`->`2`)
 graph <-
-  graph \%>\%
+  graph |>
   trav_reverse_edge()
 
 # Get the current selection of edges
-graph \%>\% get_selection()
+graph |> get_selection()
 
 }

--- a/man/trigger_graph_actions.Rd
+++ b/man/trigger_graph_actions.Rd
@@ -24,7 +24,7 @@ graph actions after setting them, for example.
 # Create a random graph using the
 # `add_gnm_graph()` function
 graph <-
-  create_graph() \%>\%
+  create_graph() |>
   add_gnm_graph(
     n = 5,
     m = 10,
@@ -36,7 +36,7 @@ graph <-
 # to provide PageRank values in the
 # `pagerank` column
 graph <-
-  graph \%>\%
+  graph |>
   add_graph_action(
     fcn = "set_node_attr_w_fcn",
     node_attr_fcn = "get_pagerank",
@@ -49,7 +49,7 @@ graph <-
 # column between 0 and 1, and, puts
 # these values in the `width` column
 graph <-
-  graph \%>\%
+  graph |>
   add_graph_action(
     fcn = "rescale_node_attrs",
     node_attr_from = "pagerank",
@@ -62,7 +62,7 @@ graph <-
 # based on the numeric values from the
 # `width` column
 graph <-
-  graph \%>\%
+  graph |>
   add_graph_action(
     fcn = "colorize_node_attrs",
     node_attr_from = "width",
@@ -72,19 +72,19 @@ graph <-
 # View the graph actions for the graph
 # object by using the `get_graph_actions()`
 # function
-graph \%>\% get_graph_actions()
+graph |> get_graph_actions()
 
 # Manually trigger to invocation of
 # the graph actions using the
 # `trigger_graph_actions()` function
 graph <-
-  graph \%>\%
+  graph |>
   trigger_graph_actions()
 
 # Examine the graph's internal node
 # data frame (ndf) to verify that
 # the `pagerank`, `width`, and
 # `fillcolor` columns are present
-graph \%>\% get_node_df()
+graph |> get_node_df()
 
 }


### PR DESCRIPTION
This PR updates all documentation examples to use the native pipe operator (`|>`) instead of `%>%`.
