### PR TITLE
fix: update neighbor indexing in `get_leverage_centrality()`

### DIFF
--- a/R/get_leverage_centrality.R
+++ b/R/get_leverage_centrality.R
@@ -60,8 +60,8 @@ get_leverage_centrality <- function(graph) {
       seq_along(degree_vals),
       function(x) {
         mean(
-          (degree_vals[x] - degree_vals[igraph::neighbors(ig_graph, degree_vals)]) /
-            (degree_vals[x] + degree_vals[igraph::neighbors(ig_graph, degree_vals)]))
+          (degree_vals[x] - degree_vals[igraph::neighbors(ig_graph, x)]) /
+            (degree_vals[x] + degree_vals[igraph::neighbors(ig_graph, x)]))
       }) |>
     unlist()
 


### PR DESCRIPTION
This PR fixes a bug in the calculation of leverage centrality in the `get_leverage_centrality()` function by correcting the neighbor indexing.

Fixes: https://github.com/rich-iannone/DiagrammeR/issues/538