### PR TITLE
fix: better handle igraph v2+ authority API to address `get_authority_centrality()` warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     glue (>= 1.5.0),
     htmltools (>= 0.5.2),
     htmlwidgets (>= 1.5),
-    igraph (>= 1.4.0),
+    igraph (>= 2.0.0),
     magrittr (>= 1.5),
     purrr (>= 0.3.4),
     RColorBrewer (>= 1.1-2),

--- a/R/get_authority_centrality.R
+++ b/R/get_authority_centrality.R
@@ -71,16 +71,27 @@ get_authority_centrality <- function(
 
   # Get the authority centrality values for
   # each of the graph's nodes
-  authority_centrality_values <-
-    igraph::authority_score(
-      graph = ig_graph,
-      weights = weights_attr)
+  if (igraph::igraph_version() >= "2.1.0") {
+    authority_centrality_values <-
+      igraph::hits_scores(
+        graph = ig_graph,
+        weights = weights_attr)
+
+    authority_vector <- authority_centrality_values$authority
+  } else {
+    authority_centrality_values <-
+      igraph::authority_score(
+        graph = ig_graph,
+        weights = weights_attr)
+
+    authority_vector <- authority_centrality_values$vector
+  }
 
   # Create df with authority centrality values
   data.frame(
-    id = authority_centrality_values$vector |>
+    id = authority_vector |>
       names() |>
       as.integer(),
-    authority_centrality = unname(authority_centrality_values$vector),
+    authority_centrality = unname(authority_vector),
     stringsAsFactors = FALSE)
 }


### PR DESCRIPTION
This PR updates the minimum required version of the `igraph` package and adds compatibility for newer versions in the `get_authority_centrality()` function. The main focus is ensuring that authority centrality scores are calculated correctly across different `igraph` versions.

Fixes: https://github.com/rich-iannone/DiagrammeR/issues/537